### PR TITLE
feat(scripts): add studio script for ai-sdk development

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "biome format --write .",
     "type-check": "tsc --noEmit",
     "prepare": "husky || true",
-    "size": "size-limit"
+    "size": "size-limit",
+    "studio": "bun run src/ai-sdk/studio .cache/ai"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [


### PR DESCRIPTION
## Summary
- Adds `studio` npm script to run the ai-sdk studio with `.cache/ai` directory
- Enables quick development workflow via `bun run studio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)