### PR TITLE
feat(studio): add step-by-step rendering mode

### DIFF
--- a/src/ai-sdk/examples/ralph-talking-studio.tsx
+++ b/src/ai-sdk/examples/ralph-talking-studio.tsx
@@ -1,0 +1,61 @@
+import { elevenlabs } from "../elevenlabs-provider";
+import { fal } from "../fal-provider";
+import {
+  Animate,
+  Clip,
+  Image,
+  Render,
+  Speech,
+  Title,
+} from "../react";
+
+const TalkingHead = ({
+  character,
+  voice,
+  children,
+}: {
+  character: string;
+  voice: string;
+  children: string;
+}) => (
+  <>
+    <Animate
+      image={Image({
+        prompt: character,
+        model: fal.imageModel("flux-schnell"),
+      })}
+      model={fal.videoModel("wan-2.5")}
+      motion="subtle head movements, blinking, mouth moving"
+    />
+    <Speech voice={voice} model={elevenlabs.speechModel("turbo")}>
+      {children}
+    </Speech>
+  </>
+);
+
+const script = `Hi, I'm Ralph! My cat's breath smells like cat food. 
+Also I invested my lunch money in dogecoin. 
+Now I live in a box. But it's a nice box! 
+It has a window. The window is a hole.`;
+
+export default (
+  <Render width={1080} height={1920}>
+    <Clip duration={10}>
+      <TalkingHead
+        character="ralph wiggum, simpsons style, innocent smile, slightly confused"
+        voice="adam"
+      >
+        {script}
+      </TalkingHead>
+    </Clip>
+
+    <Clip duration={2} transition={{ name: "fade", duration: 0.5 }}>
+      <Image
+        prompt="ralph wiggum in cardboard box, happy, simpsons style"
+        model={fal.imageModel("flux-schnell")}
+        zoom="in"
+      />
+      <Title position="bottom">@RalphInvests</Title>
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/studio/stages.ts
+++ b/src/ai-sdk/studio/stages.ts
@@ -1,0 +1,251 @@
+import type { VargElement, VargNode } from "../react/types";
+
+export type StageType = "image" | "video" | "animate" | "speech" | "music";
+
+export interface RenderStage {
+  id: string;
+  type: StageType;
+  label: string;
+  element: VargElement;
+  path: string[]; // path in the tree for identification
+  dependsOn: string[]; // stage ids this depends on
+  status: "pending" | "running" | "complete" | "error";
+  result?: StageResult;
+}
+
+export interface StageResult {
+  type: "image" | "video" | "audio";
+  path: string;
+  previewUrl?: string;
+  mimeType: string;
+}
+
+export interface ExtractedStages {
+  stages: RenderStage[];
+  order: string[]; // topologically sorted stage ids
+}
+
+/**
+ * Extracts all renderable stages from a JSX tree in dependency order.
+ * Images come before videos that use them, etc.
+ */
+export function extractStages(element: VargElement): ExtractedStages {
+  const stages: RenderStage[] = [];
+  let stageCounter = 0;
+
+  function generateId(): string {
+    return `stage-${stageCounter++}`;
+  }
+
+  function getLabel(type: StageType, element: VargElement): string {
+    const props = element.props as Record<string, unknown>;
+
+    if (type === "image") {
+      const prompt = props.prompt;
+      if (typeof prompt === "string") {
+        return `image: ${prompt.slice(0, 30)}${prompt.length > 30 ? "..." : ""}`;
+      }
+      if (prompt && typeof prompt === "object" && "text" in prompt) {
+        const text = (prompt as { text?: string }).text ?? "";
+        return `image: ${text.slice(0, 30)}${text.length > 30 ? "..." : ""}`;
+      }
+      if (props.src) {
+        return `image: ${String(props.src).split("/").pop()}`;
+      }
+      return "image";
+    }
+
+    if (type === "video") {
+      const prompt = props.prompt;
+      if (typeof prompt === "string") {
+        return `video: ${prompt.slice(0, 30)}${prompt.length > 30 ? "..." : ""}`;
+      }
+      if (prompt && typeof prompt === "object" && "text" in prompt) {
+        const text = (prompt as { text?: string }).text ?? "";
+        return `video: ${text.slice(0, 30)}${text.length > 30 ? "..." : ""}`;
+      }
+      if (props.src) {
+        return `video: ${String(props.src).split("/").pop()}`;
+      }
+      return "video";
+    }
+
+    if (type === "animate") {
+      const motion = props.motion;
+      return motion ? `animate: ${motion}` : "animate";
+    }
+
+    if (type === "speech") {
+      const text = getTextContent(element.children);
+      return `speech: ${text.slice(0, 30)}${text.length > 30 ? "..." : ""}`;
+    }
+
+    if (type === "music") {
+      const prompt = props.prompt;
+      if (typeof prompt === "string") {
+        return `music: ${prompt.slice(0, 30)}${prompt.length > 30 ? "..." : ""}`;
+      }
+      if (props.src) {
+        return `music: ${String(props.src).split("/").pop()}`;
+      }
+      return "music";
+    }
+
+    return type;
+  }
+
+  function getTextContent(children: VargNode[]): string {
+    const texts: string[] = [];
+    for (const child of children) {
+      if (typeof child === "string") {
+        texts.push(child);
+      } else if (typeof child === "number") {
+        texts.push(String(child));
+      }
+    }
+    return texts.join(" ");
+  }
+
+  function walkTree(
+    node: VargNode,
+    path: string[],
+    parentDeps: string[],
+  ): string[] {
+    if (!node || typeof node !== "object" || !("type" in node)) {
+      return [];
+    }
+
+    const element = node as VargElement;
+    const currentPath = [...path, element.type];
+    const collectedDeps: string[] = [...parentDeps];
+
+    // Check if this is a renderable stage
+    const stageTypes: StageType[] = [
+      "image",
+      "video",
+      "animate",
+      "speech",
+      "music",
+    ];
+
+    if (stageTypes.includes(element.type as StageType)) {
+      const stageType = element.type as StageType;
+      const props = element.props as Record<string, unknown>;
+
+      // Skip if it's just a src reference (no generation needed)
+      if (props.src && !props.prompt) {
+        return [];
+      }
+
+      // For video/animate with image inputs, we need to find dependent images first
+      const imageDeps: string[] = [];
+
+      if (stageType === "video" || stageType === "animate") {
+        // Check prompt.images for nested Image elements
+        const prompt = props.prompt as { images?: VargNode[] } | undefined;
+        if (prompt?.images) {
+          for (const imgInput of prompt.images) {
+            if (
+              imgInput &&
+              typeof imgInput === "object" &&
+              "type" in imgInput
+            ) {
+              const imgElement = imgInput as VargElement;
+              if (imgElement.type === "image") {
+                const deps = walkTree(imgElement, currentPath, collectedDeps);
+                imageDeps.push(...deps);
+              }
+            }
+          }
+        }
+
+        // Check for image prop in animate
+        if (stageType === "animate" && props.image) {
+          const imgElement = props.image as VargElement;
+          if (imgElement.type === "image") {
+            const deps = walkTree(imgElement, currentPath, collectedDeps);
+            imageDeps.push(...deps);
+          }
+        }
+      }
+
+      const id = generateId();
+      const stage: RenderStage = {
+        id,
+        type: stageType,
+        label: getLabel(stageType, element),
+        element,
+        path: currentPath,
+        dependsOn: [...new Set([...collectedDeps, ...imageDeps])],
+        status: "pending",
+      };
+
+      stages.push(stage);
+      return [id];
+    }
+
+    // For container elements (render, clip, overlay), recurse into children
+    const childDeps: string[] = [];
+    for (const child of element.children) {
+      const deps = walkTree(child, currentPath, collectedDeps);
+      childDeps.push(...deps);
+    }
+
+    return childDeps;
+  }
+
+  // Start walking from root
+  if (element.type === "render") {
+    walkTree(element, [], []);
+  }
+
+  // Topological sort based on dependencies
+  const order = topologicalSort(stages);
+
+  return { stages, order };
+}
+
+function topologicalSort(stages: RenderStage[]): string[] {
+  const result: string[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  const stageMap = new Map(stages.map((s) => [s.id, s]));
+
+  function visit(id: string) {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) {
+      throw new Error(`Circular dependency detected at stage ${id}`);
+    }
+
+    visiting.add(id);
+    const stage = stageMap.get(id);
+    if (stage) {
+      for (const depId of stage.dependsOn) {
+        visit(depId);
+      }
+    }
+    visiting.delete(id);
+    visited.add(id);
+    result.push(id);
+  }
+
+  for (const stage of stages) {
+    visit(stage.id);
+  }
+
+  return result;
+}
+
+/**
+ * Serializes stages for API response (strips non-serializable element)
+ */
+export function serializeStages(extracted: ExtractedStages): {
+  stages: Omit<RenderStage, "element">[];
+  order: string[];
+} {
+  return {
+    stages: extracted.stages.map(({ element, ...rest }) => rest),
+    order: extracted.order,
+  };
+}

--- a/src/ai-sdk/studio/step-renderer.ts
+++ b/src/ai-sdk/studio/step-renderer.ts
@@ -1,0 +1,255 @@
+import { generateImage } from "ai";
+import { withCache } from "../cache";
+import { File } from "../file";
+import { fileCache } from "../file-cache";
+import { generateVideo } from "../generate-video";
+import { renderAnimate } from "../react/renderers/animate";
+import type { RenderContext } from "../react/renderers/context";
+import { renderImage } from "../react/renderers/image";
+import { renderMusic } from "../react/renderers/music";
+import { createProgressTracker } from "../react/renderers/progress";
+import { renderSpeech } from "../react/renderers/speech";
+import { renderVideo } from "../react/renderers/video";
+import type { RenderProps, VargElement } from "../react/types";
+import type { ExtractedStages, RenderStage, StageResult } from "./stages";
+import { extractStages } from "./stages";
+
+export interface StepSession {
+  id: string;
+  code: string;
+  rootElement: VargElement;
+  extracted: ExtractedStages;
+  ctx: RenderContext;
+  results: Map<string, StageResult>;
+  currentStageIndex: number;
+}
+
+const sessions = new Map<string, StepSession>();
+
+export function createStepSession(
+  code: string,
+  rootElement: VargElement,
+  cacheDir?: string,
+): StepSession {
+  const props = rootElement.props as RenderProps;
+  const cache = cacheDir ? fileCache({ dir: cacheDir }) : undefined;
+
+  const ctx: RenderContext = {
+    width: props.width ?? 1920,
+    height: props.height ?? 1080,
+    fps: props.fps ?? 30,
+    cache,
+    generateImage: cache
+      ? withCache(generateImage, { storage: cache })
+      : generateImage,
+    generateVideo: cache
+      ? withCache(generateVideo, { storage: cache })
+      : generateVideo,
+    tempFiles: [],
+    progress: createProgressTracker(false),
+    pending: new Map(),
+  };
+
+  const extracted = extractStages(rootElement);
+  const sessionId = `step-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const session: StepSession = {
+    id: sessionId,
+    code,
+    rootElement,
+    extracted,
+    ctx,
+    results: new Map(),
+    currentStageIndex: 0,
+  };
+
+  sessions.set(sessionId, session);
+  return session;
+}
+
+export function getSession(sessionId: string): StepSession | undefined {
+  return sessions.get(sessionId);
+}
+
+export function deleteSession(sessionId: string): void {
+  sessions.delete(sessionId);
+}
+
+export async function executeStage(
+  session: StepSession,
+  stageId: string,
+): Promise<StageResult> {
+  const stage = session.extracted.stages.find((s) => s.id === stageId);
+  if (!stage) {
+    throw new Error(`Stage ${stageId} not found`);
+  }
+
+  for (const depId of stage.dependsOn) {
+    if (!session.results.has(depId)) {
+      throw new Error(`Dependency ${depId} not yet executed`);
+    }
+  }
+
+  stage.status = "running";
+  console.log(`[step] executing stage ${stageId}: ${stage.label}`);
+
+  try {
+    let result: StageResult;
+
+    switch (stage.type) {
+      case "image": {
+        const path = await renderImage(
+          stage.element as VargElement<"image">,
+          session.ctx,
+        );
+        result = {
+          type: "image",
+          path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "image/png",
+        };
+        break;
+      }
+
+      case "video": {
+        const path = await renderVideo(
+          stage.element as VargElement<"video">,
+          session.ctx,
+        );
+        result = {
+          type: "video",
+          path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "video/mp4",
+        };
+        break;
+      }
+
+      case "animate": {
+        const path = await renderAnimate(
+          stage.element as VargElement<"animate">,
+          session.ctx,
+        );
+        result = {
+          type: "video",
+          path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "video/mp4",
+        };
+        break;
+      }
+
+      case "speech": {
+        const speechResult = await renderSpeech(
+          stage.element as VargElement<"speech">,
+          session.ctx,
+        );
+        result = {
+          type: "audio",
+          path: speechResult.path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "audio/mp3",
+        };
+        break;
+      }
+
+      case "music": {
+        const musicResult = await renderMusic(
+          stage.element as VargElement<"music">,
+          session.ctx,
+        );
+        result = {
+          type: "audio",
+          path: musicResult.path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "audio/mp3",
+        };
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown stage type: ${stage.type}`);
+    }
+
+    stage.status = "complete";
+    stage.result = result;
+    session.results.set(stageId, result);
+    console.log(`[step] stage ${stageId} complete: ${result.path}`);
+
+    return result;
+  } catch (error) {
+    stage.status = "error";
+    console.error(`[step] stage ${stageId} failed:`, error);
+    throw error;
+  }
+}
+
+export async function executeNextStage(session: StepSession): Promise<{
+  stage: RenderStage;
+  result: StageResult;
+  isLast: boolean;
+} | null> {
+  const { order } = session.extracted;
+
+  if (session.currentStageIndex >= order.length) {
+    return null;
+  }
+
+  const stageId = order[session.currentStageIndex];
+  if (!stageId) {
+    return null;
+  }
+
+  const stage = session.extracted.stages.find((s) => s.id === stageId);
+  if (!stage) {
+    return null;
+  }
+
+  const result = await executeStage(session, stageId);
+  session.currentStageIndex++;
+
+  return {
+    stage,
+    result,
+    isLast: session.currentStageIndex >= order.length,
+  };
+}
+
+export function getStagePreviewPath(
+  session: StepSession,
+  stageId: string,
+): string | null {
+  const result = session.results.get(stageId);
+  return result?.path ?? null;
+}
+
+export function getSessionStatus(session: StepSession): {
+  sessionId: string;
+  totalStages: number;
+  completedStages: number;
+  currentStageIndex: number;
+  stages: Array<{
+    id: string;
+    type: string;
+    label: string;
+    status: string;
+    hasResult: boolean;
+  }>;
+} {
+  return {
+    sessionId: session.id,
+    totalStages: session.extracted.stages.length,
+    completedStages: session.results.size,
+    currentStageIndex: session.currentStageIndex,
+    stages: session.extracted.order.map((id) => {
+      const stage = session.extracted.stages.find((s) => s.id === id)!;
+      return {
+        id: stage.id,
+        type: stage.type,
+        label: stage.label,
+        status: stage.status,
+        hasResult: session.results.has(id),
+      };
+    }),
+  };
+}

--- a/src/ai-sdk/studio/ui/index.html
+++ b/src/ai-sdk/studio/ui/index.html
@@ -106,7 +106,7 @@
       background: #000;
       position: relative;
       overflow: hidden;
-      min-height: 0;
+      min-height: 200px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -243,6 +243,234 @@
       animation: spin 0.8s linear infinite;
     }
     @keyframes spin { to { transform: rotate(360deg); } }
+    
+    /* Step mode timeline */
+    .stage-timeline {
+      padding: 1rem;
+      border-top: 1px solid var(--border);
+      flex-shrink: 0;
+      display: none;
+    }
+    .stage-timeline.active {
+      display: block;
+    }
+    .stage-timeline-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 0.75rem;
+    }
+    .stage-timeline-title {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .stage-timeline-hint {
+      font-size: 0.625rem;
+      color: var(--text-muted);
+      opacity: 0.7;
+    }
+    .stage-timeline-hint kbd {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      padding: 0.125rem 0.375rem;
+      font-family: inherit;
+      font-size: 0.625rem;
+    }
+    .stage-track {
+      display: flex;
+      gap: 0.5rem;
+      overflow-x: auto;
+      padding-bottom: 0.5rem;
+      scrollbar-width: thin;
+      scrollbar-color: var(--border) transparent;
+    }
+    .stage-track::-webkit-scrollbar {
+      height: 4px;
+    }
+    .stage-track::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    .stage-track::-webkit-scrollbar-thumb {
+      background: var(--border);
+      border-radius: 2px;
+    }
+    .stage-item {
+      flex-shrink: 0;
+      width: 100px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 0.5rem;
+      padding: 0.625rem;
+      cursor: default;
+      transition: all 0.2s ease;
+      position: relative;
+      overflow: hidden;
+    }
+    .stage-item::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: transparent;
+      transition: background 0.2s ease;
+    }
+    .stage-item.pending {
+      opacity: 0.5;
+    }
+    .stage-item.running {
+      border-color: var(--accent);
+      box-shadow: 0 0 12px rgba(59, 130, 246, 0.25);
+    }
+    .stage-item.running::before {
+      background: var(--accent);
+      animation: stage-pulse 1.5s ease-in-out infinite;
+    }
+    @keyframes stage-pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+    .stage-item.complete {
+      cursor: pointer;
+      border-color: var(--success);
+    }
+    .stage-item.complete::before {
+      background: var(--success);
+    }
+    .stage-item.complete:hover {
+      border-color: var(--success);
+      background: rgba(34, 197, 94, 0.1);
+    }
+    .stage-item.error {
+      border-color: var(--error);
+    }
+    .stage-item.error::before {
+      background: var(--error);
+    }
+    .stage-item.selected {
+      border-color: var(--accent);
+      background: rgba(59, 130, 246, 0.1);
+    }
+    .stage-icon {
+      font-size: 1.25rem;
+      margin-bottom: 0.375rem;
+    }
+    .stage-label {
+      font-size: 0.7rem;
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: 0.25rem;
+    }
+    .stage-status {
+      font-size: 0.625rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+    .stage-item.running .stage-status {
+      color: var(--accent);
+    }
+    .stage-item.complete .stage-status {
+      color: var(--success);
+    }
+    .stage-item.error .stage-status {
+      color: var(--error);
+    }
+    .stage-connector {
+      flex-shrink: 0;
+      width: 24px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .stage-connector-line {
+      width: 100%;
+      height: 2px;
+      background: var(--border);
+      position: relative;
+    }
+    .stage-connector-line.complete {
+      background: var(--success);
+    }
+    .stage-connector-line::after {
+      content: '';
+      position: absolute;
+      right: -4px;
+      top: -3px;
+      border: 4px solid transparent;
+      border-left-color: var(--border);
+    }
+    .stage-connector-line.complete::after {
+      border-left-color: var(--success);
+    }
+    
+    /* Mode toggle */
+    .mode-toggle {
+      display: flex;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 0.375rem;
+      overflow: hidden;
+    }
+    .mode-toggle-btn {
+      padding: 0.375rem 0.625rem;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 0.7rem;
+      cursor: pointer;
+      transition: all 0.15s;
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .mode-toggle-btn:hover {
+      color: var(--text);
+    }
+    .mode-toggle-btn.active {
+      background: var(--accent);
+      color: var(--text);
+    }
+    .mode-toggle-btn:first-child {
+      border-right: 1px solid var(--border);
+    }
+    
+    /* Next step button */
+    .btn-next {
+      background: linear-gradient(135deg, var(--accent), #6366f1);
+      border-color: transparent;
+      position: relative;
+      overflow: hidden;
+    }
+    .btn-next::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -100%;
+      width: 100%;
+      height: 100%;
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
+      transition: left 0.5s;
+    }
+    .btn-next:hover::before {
+      left: 100%;
+    }
+    .btn-next:hover {
+      background: linear-gradient(135deg, var(--accent-hover), #4f46e5);
+    }
+    .btn-next:disabled {
+      background: var(--bg-secondary);
+      border-color: var(--border);
+    }
+    .btn-next:disabled::before {
+      display: none;
+    }
     .error-banner {
       background: rgba(239, 68, 68, 0.1);
       border: 1px solid var(--error);
@@ -293,8 +521,19 @@
       </div>
       
       <div class="controls">
+        <div class="mode-toggle">
+          <button class="mode-toggle-btn active" id="mode-all-btn" title="Run all stages at once">
+            <span>⚡</span> all
+          </button>
+          <button class="mode-toggle-btn" id="mode-step-btn" title="Run stages one by one">
+            <span>👣</span> step
+          </button>
+        </div>
         <button class="btn btn-primary" id="run-btn">
           <span>▶</span> run
+        </button>
+        <button class="btn btn-next" id="next-btn" style="display: none;">
+          <span>→</span> next
         </button>
         <button class="btn btn-toggle" id="auto-btn">
           <span>⟳</span> auto
@@ -305,6 +544,14 @@
         <button class="btn" id="share-btn" style="margin-left: auto;">
           <span>🔗</span> share
         </button>
+      </div>
+      
+      <div class="stage-timeline" id="stage-timeline">
+        <div class="stage-timeline-header">
+          <div class="stage-timeline-title">stages</div>
+          <div class="stage-timeline-hint"><kbd>Space</kbd> next step</div>
+        </div>
+        <div class="stage-track" id="stage-track"></div>
       </div>
       
       <div class="history-section">
@@ -346,6 +593,13 @@ export default (
     let currentRenderId = null;
     let debounceTimer = null;
     let history = JSON.parse(localStorage.getItem('varg-history') || '[]');
+    
+    // Step mode state
+    let stepMode = false;
+    let stepSession = null;
+    let stages = [];
+    let currentStageIndex = -1;
+    let selectedStageId = null;
 
     require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs' } });
 
@@ -418,7 +672,23 @@ export default (
       e.target.value = '';
     });
 
-    document.getElementById('run-btn').addEventListener('click', startRender);
+    document.getElementById('run-btn').addEventListener('click', () => {
+      if (stepMode) {
+        startStepSession();
+      } else {
+        startRender();
+      }
+    });
+    
+    document.getElementById('next-btn').addEventListener('click', executeNextStep);
+    
+    document.getElementById('mode-all-btn').addEventListener('click', () => {
+      setStepMode(false);
+    });
+    
+    document.getElementById('mode-step-btn').addEventListener('click', () => {
+      setStepMode(true);
+    });
     
     document.getElementById('auto-btn').addEventListener('click', () => {
       autoMode = !autoMode;
@@ -430,12 +700,260 @@ export default (
     document.addEventListener('keydown', (e) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
         e.preventDefault();
-        startRender();
+        if (stepMode) {
+          startStepSession();
+        } else {
+          startRender();
+        }
       }
       if (e.key === 'Escape' && isRendering) {
         stopRender();
       }
+      // Space to execute next step in step mode
+      if (e.code === 'Space' && stepMode && stepSession && !isRendering) {
+        // Don't trigger if focused on editor or input
+        if (document.activeElement.tagName !== 'INPUT' && 
+            document.activeElement.tagName !== 'TEXTAREA' &&
+            !document.activeElement.closest('#editor-container')) {
+          e.preventDefault();
+          executeNextStep();
+        }
+      }
     });
+    
+    function setStepMode(enabled) {
+      stepMode = enabled;
+      document.getElementById('mode-all-btn').classList.toggle('active', !enabled);
+      document.getElementById('mode-step-btn').classList.toggle('active', enabled);
+      document.getElementById('stage-timeline').classList.toggle('active', enabled && stages.length > 0);
+      document.getElementById('next-btn').style.display = enabled && stepSession ? 'flex' : 'none';
+      document.getElementById('auto-btn').style.display = enabled ? 'none' : 'flex';
+      
+      if (!enabled) {
+        // Reset step state when switching to run-all mode
+        stepSession = null;
+        stages = [];
+        currentStageIndex = -1;
+        selectedStageId = null;
+        renderStageTimeline();
+      }
+    }
+    
+    function getStageIcon(type) {
+      const icons = {
+        image: '🖼️',
+        video: '🎬',
+        animate: '🎬',
+        speech: '🎤',
+        music: '🎵',
+        default: '⚙️'
+      };
+      return icons[type] || icons.default;
+    }
+    
+    function renderStageTimeline() {
+      const track = document.getElementById('stage-track');
+      const timeline = document.getElementById('stage-timeline');
+      
+      if (stages.length === 0) {
+        timeline.classList.remove('active');
+        track.innerHTML = '';
+        return;
+      }
+      
+      if (stepMode) {
+        timeline.classList.add('active');
+      }
+      
+      let html = '';
+      stages.forEach((stage, index) => {
+        const isSelected = stage.id === selectedStageId;
+        const statusClass = stage.status + (isSelected ? ' selected' : '');
+        
+        // Add connector before each stage except the first
+        if (index > 0) {
+          const prevComplete = stages[index - 1].status === 'complete';
+          html += `
+            <div class="stage-connector">
+              <div class="stage-connector-line ${prevComplete ? 'complete' : ''}"></div>
+            </div>
+          `;
+        }
+        
+        html += `
+          <div class="stage-item ${statusClass}" 
+               data-stage-id="${stage.id}" 
+               data-stage-index="${index}"
+               onclick="selectStage('${stage.id}')">
+            <div class="stage-icon">${getStageIcon(stage.type)}</div>
+            <div class="stage-label" title="${stage.label}">${stage.label}</div>
+            <div class="stage-status">${stage.status}</div>
+          </div>
+        `;
+      });
+      
+      track.innerHTML = html;
+    }
+    
+    async function selectStage(stageId) {
+      const stage = stages.find(s => s.id === stageId);
+      if (!stage || stage.status !== 'complete') return;
+      
+      selectedStageId = stageId;
+      renderStageTimeline();
+      
+      // Show stored result directly (preview URL already available)
+      if (stage.result) {
+        showStagePreview({ result: stage.result });
+      }
+    }
+    
+    function showStagePreview(data) {
+      const container = document.getElementById('preview-content');
+      console.log('[preview] showStagePreview called with:', data);
+      
+      if (!data || !data.result) {
+        container.innerHTML = `<div class="preview-placeholder">
+          <div class="preview-placeholder-icon">📭</div>
+          <div>no preview available</div>
+        </div>`;
+        return;
+      }
+      
+      const { type, previewUrl, mimeType } = data.result;
+      console.log('[preview] type:', type, 'previewUrl:', previewUrl, 'mimeType:', mimeType);
+      
+      if (mimeType?.startsWith('video/') || type === 'video' || type === 'animate') {
+        container.innerHTML = `<video class="preview-video" src="${previewUrl}" controls autoplay loop></video>`;
+      } else if (mimeType?.startsWith('image/') || type === 'image') {
+        container.innerHTML = `<img class="preview-video" src="${previewUrl}" alt="Stage preview" style="object-fit: contain; max-width: 100%; max-height: 100%;">`;
+      } else if (mimeType?.startsWith('audio/') || type === 'speech' || type === 'music') {
+        container.innerHTML = `
+          <div style="display: flex; flex-direction: column; align-items: center; gap: 1rem;">
+            <div style="font-size: 3rem;">${type === 'music' ? '🎵' : '🎤'}</div>
+            <audio controls src="${previewUrl}" style="width: 80%;"></audio>
+          </div>
+        `;
+      } else {
+        container.innerHTML = `<div class="preview-placeholder">
+          <div class="preview-placeholder-icon">✓</div>
+          <div>stage complete</div>
+        </div>`;
+      }
+    }
+    
+    async function startStepSession() {
+      if (isRendering) return;
+      
+      isRendering = true;
+      updateUI('rendering');
+      
+      const code = editor.getValue();
+      
+      try {
+        const res = await fetch('/api/step/session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+        
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.message || 'Failed to create step session');
+        }
+        
+        const data = await res.json();
+        stepSession = data;
+        stages = data.stages.map(s => ({ ...s, status: 'pending' }));
+        currentStageIndex = -1;
+        selectedStageId = null;
+        
+        renderStageTimeline();
+        document.getElementById('next-btn').style.display = 'flex';
+        document.getElementById('next-btn').disabled = false;
+        
+        updateProgress(0, 'session ready — click next to start');
+        updateUI('idle');
+        
+        // Show placeholder for step mode
+        const container = document.getElementById('preview-content');
+        container.innerHTML = `<div class="preview-placeholder">
+          <div class="preview-placeholder-icon">👣</div>
+          <div>step through ${stages.length} stage${stages.length > 1 ? 's' : ''}</div>
+        </div>`;
+        
+      } catch (err) {
+        showError(err.message);
+        updateUI('error');
+      }
+      
+      isRendering = false;
+    }
+    
+    async function executeNextStep() {
+      if (!stepSession || isRendering) return;
+      
+      const nextIndex = currentStageIndex + 1;
+      if (nextIndex >= stages.length) {
+        // All stages complete
+        document.getElementById('next-btn').disabled = true;
+        return;
+      }
+      
+      isRendering = true;
+      currentStageIndex = nextIndex;
+      stages[nextIndex].status = 'running';
+      renderStageTimeline();
+      
+      document.getElementById('next-btn').disabled = true;
+      updateProgress((nextIndex / stages.length), `executing: ${stages[nextIndex].label}`);
+      document.getElementById('progress-section').style.display = 'block';
+      
+      try {
+        const res = await fetch('/api/step/next', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: stepSession.sessionId }),
+        });
+        
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.message || 'Step execution failed');
+        }
+        
+        const data = await res.json();
+        stages[nextIndex].status = 'complete';
+        stages[nextIndex].result = data.result;
+        
+        // Auto-select and show the completed stage
+        selectedStageId = stages[nextIndex].id;
+        renderStageTimeline();
+        showStagePreview(data);
+        
+        const progress = (nextIndex + 1) / stages.length;
+        if (nextIndex + 1 >= stages.length) {
+          updateProgress(1, 'all stages complete');
+          document.getElementById('progress-bar').className = 'progress-bar complete';
+          document.getElementById('next-btn').disabled = true;
+          
+          // Add to history if final result is a video
+          if (data.result?.type === 'video' && data.result?.previewUrl) {
+            addToHistory(editor.getValue(), data.result.previewUrl);
+          }
+        } else {
+          updateProgress(progress, `${nextIndex + 1}/${stages.length} complete — ready for next`);
+          document.getElementById('next-btn').disabled = false;
+        }
+        
+      } catch (err) {
+        stages[nextIndex].status = 'error';
+        renderStageTimeline();
+        showError(err.message);
+        updateUI('error');
+      }
+      
+      isRendering = false;
+    }
 
     async function startRender() {
       if (isRendering) return;
@@ -507,12 +1025,16 @@ export default (
     function updateUI(state) {
       const runBtn = document.getElementById('run-btn');
       const stopBtn = document.getElementById('stop-btn');
+      const nextBtn = document.getElementById('next-btn');
       const progressSection = document.getElementById('progress-section');
       const progressBar = document.getElementById('progress-bar');
 
       if (state === 'rendering') {
         runBtn.disabled = true;
         stopBtn.disabled = false;
+        if (stepMode) {
+          nextBtn.disabled = true;
+        }
         progressSection.style.display = 'block';
         progressBar.className = 'progress-bar';
       } else if (state === 'complete') {
@@ -526,7 +1048,9 @@ export default (
       } else {
         runBtn.disabled = false;
         stopBtn.disabled = true;
-        progressSection.style.display = 'none';
+        if (!stepMode) {
+          progressSection.style.display = 'none';
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds step-by-step rendering mode to varg studio for debugging and iterating on video generation
- Extracts stages from JSX tree with dependency ordering (images before videos that use them)
- Execute stages one at a time with live preview of each result

## Changes

**New files:**
- `src/ai-sdk/studio/stages.ts` - Stage extraction with topological sort
- `src/ai-sdk/studio/step-renderer.ts` - Session management and single-stage execution
- `src/ai-sdk/examples/ralph-talking-studio.tsx` - Studio-compatible template

**Modified:**
- `src/ai-sdk/studio/server.ts` - New API endpoints for step mode
- `src/ai-sdk/studio/ui/index.html` - Step mode UI with timeline

## New API Endpoints

- `POST /api/step/session` - Create step session from code
- `POST /api/step/next` - Execute next stage
- `GET /api/step/preview/:sessionId/:stageId` - Get stage result media

## UI Features

- Toggle between "all" and "step" modes
- Horizontal stage timeline with status indicators
- Space bar shortcut to step through
- Click completed stages to view their preview