### PR TITLE
refactor/video ai sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ lib
 
 
 output
+.worktrees

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,12 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!node_modules", "!sdk-py-reference"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!sdk-py-reference",
+      "!src/ai-sdk/examples/*.tsx"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/docs/cases-tests.md
+++ b/docs/cases-tests.md
@@ -1,0 +1,6 @@
+# Cases Tests
+
+- create a grid of 12 characters: create 12 images, with a bit similar prompts, but some differences. And in total you will have 3x4 characters, and put them into a single grid with titles describing these characters
+- Generate a girl image, turn into an animated image, add voiceover and captions
+- before-after: two videos on the left with a person which is fairly fat, and on the right same person but fit and good looking, each video asset is generated seperately and edited into a split screen 
+- slideshow: 6 photos each photo 2 second, same character on each photo, diffferent settings and a talking head as a picture in the picture with captions

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,1130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>varg-react | JSX for AI Video</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Sora:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #050505;
+      --bg-elevated: #0a0a0a;
+      --bg-card: #0f0f0f;
+      --bg-code: #0d0d0d;
+      --border: #1a1a1a;
+      --border-subtle: #141414;
+      --text: #e5e5e5;
+      --text-muted: #737373;
+      --text-dim: #525252;
+      --orange: #ff6b35;
+      --orange-glow: rgba(255, 107, 53, 0.15);
+      --orange-dim: #cc5629;
+      --green: #a5d6a7;
+      --blue: #82b1ff;
+      --purple: #ce93d8;
+      --pink: #f48fb1;
+      --yellow: #ffd54f;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      font-family: 'Sora', -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      overflow-x: hidden;
+    }
+
+    /* Noise overlay */
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+      opacity: 0.03;
+      pointer-events: none;
+      z-index: 1000;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    /* Navigation */
+    nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      padding: 20px 0;
+      background: linear-gradient(to bottom, var(--bg) 0%, transparent 100%);
+      backdrop-filter: blur(12px);
+    }
+
+    nav .container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .logo {
+      font-family: 'JetBrains Mono', monospace;
+      font-weight: 600;
+      font-size: 18px;
+      color: var(--text);
+      text-decoration: none;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .logo-icon {
+      width: 28px;
+      height: 28px;
+      background: linear-gradient(135deg, var(--orange) 0%, var(--orange-dim) 100%);
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .logo-icon svg {
+      width: 16px;
+      height: 16px;
+      fill: white;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 32px;
+      align-items: center;
+    }
+
+    .nav-links a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 400;
+      transition: color 0.2s;
+    }
+
+    .nav-links a:hover {
+      color: var(--text);
+    }
+
+    .nav-btn {
+      background: var(--orange);
+      color: #000;
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-weight: 500;
+      font-size: 14px;
+      text-decoration: none;
+      transition: all 0.2s;
+    }
+
+    .nav-btn:hover {
+      background: var(--text);
+      color: #000;
+    }
+
+    /* Hero */
+    .hero {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 120px 0 80px;
+      position: relative;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 800px;
+      height: 600px;
+      background: radial-gradient(ellipse at center, var(--orange-glow) 0%, transparent 60%);
+      pointer-events: none;
+    }
+
+    .hero-content {
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 100px;
+      padding: 6px 14px;
+      font-size: 13px;
+      color: var(--text-muted);
+      margin-bottom: 32px;
+    }
+
+    .hero-badge-dot {
+      width: 6px;
+      height: 6px;
+      background: var(--orange);
+      border-radius: 50%;
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+
+    .hero h1 {
+      font-size: clamp(48px, 10vw, 88px);
+      font-weight: 700;
+      line-height: 1;
+      letter-spacing: -0.03em;
+      margin-bottom: 24px;
+      background: linear-gradient(135deg, var(--text) 0%, var(--text-muted) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero h1 span {
+      background: linear-gradient(135deg, var(--orange) 0%, var(--yellow) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+    }
+
+    .hero-sub {
+      font-size: clamp(18px, 2.5vw, 22px);
+      color: var(--text-muted);
+      max-width: 560px;
+      margin-bottom: 48px;
+      font-weight: 300;
+    }
+
+    .hero-cmd {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      background: var(--bg-code);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px 24px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 15px;
+      margin-bottom: 64px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .hero-cmd:hover {
+      border-color: var(--orange);
+      box-shadow: 0 0 32px var(--orange-glow);
+    }
+
+    .hero-cmd-prompt {
+      color: var(--text-muted);
+    }
+
+    .hero-cmd-text {
+      color: var(--text);
+    }
+
+    .hero-cmd-copy {
+      color: var(--text-dim);
+      padding: 4px;
+      border-radius: 4px;
+      transition: all 0.2s;
+    }
+
+    .hero-cmd:hover .hero-cmd-copy {
+      color: var(--orange);
+    }
+
+    /* Code Block */
+    .code-block {
+      background: var(--bg-code);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      max-width: 720px;
+    }
+
+    .code-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border-subtle);
+      background: var(--bg-card);
+    }
+
+    .code-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--border);
+    }
+
+    .code-dot:nth-child(1) { background: #ff5f57; }
+    .code-dot:nth-child(2) { background: #ffbd2e; }
+    .code-dot:nth-child(3) { background: #28c840; }
+
+    .code-title {
+      margin-left: auto;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 12px;
+      color: var(--text-dim);
+    }
+
+    .code-content {
+      padding: 20px 24px;
+      overflow-x: auto;
+    }
+
+    pre {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 13px;
+      line-height: 1.7;
+      white-space: pre;
+      margin: 0;
+    }
+
+    .kw { color: var(--orange); }
+    .str { color: var(--green); }
+    .tag { color: var(--blue); }
+    .attr { color: var(--purple); }
+    .num { color: var(--pink); }
+    .cmt { color: var(--text-dim); }
+    .fn { color: var(--yellow); }
+    .op { color: var(--text-muted); }
+
+    /* Sections */
+    section {
+      padding: 120px 0;
+    }
+
+    .section-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 12px;
+      color: var(--orange);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 16px;
+    }
+
+    .section-title {
+      font-size: clamp(32px, 5vw, 48px);
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      margin-bottom: 20px;
+      line-height: 1.2;
+    }
+
+    .section-desc {
+      font-size: 17px;
+      color: var(--text-muted);
+      max-width: 600px;
+      font-weight: 300;
+    }
+
+    /* Pillars Grid */
+    .pillars {
+      background: var(--bg-elevated);
+      border-top: 1px solid var(--border-subtle);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .pillars-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1px;
+      background: var(--border-subtle);
+      margin-top: 64px;
+    }
+
+    .pillar {
+      background: var(--bg-elevated);
+      padding: 48px 40px;
+      transition: all 0.3s;
+    }
+
+    .pillar:hover {
+      background: var(--bg-card);
+    }
+
+    .pillar-icon {
+      width: 48px;
+      height: 48px;
+      background: linear-gradient(135deg, var(--orange-glow) 0%, transparent 100%);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 24px;
+    }
+
+    .pillar-icon svg {
+      width: 24px;
+      height: 24px;
+      stroke: var(--orange);
+      fill: none;
+      stroke-width: 1.5;
+    }
+
+    .pillar h3 {
+      font-size: 22px;
+      font-weight: 600;
+      margin-bottom: 16px;
+    }
+
+    .pillar p {
+      color: var(--text-muted);
+      font-size: 15px;
+      line-height: 1.7;
+      margin-bottom: 24px;
+    }
+
+    .pillar-highlight {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 12px;
+      color: var(--orange);
+      background: var(--orange-glow);
+      padding: 6px 12px;
+      border-radius: 4px;
+      display: inline-block;
+    }
+
+    .pillar-code {
+      background: var(--bg-code);
+      border: 1px solid var(--border-subtle);
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 20px;
+    }
+
+    .pillar-code pre {
+      font-size: 12px;
+    }
+
+    /* AI Agents Section */
+    .agents {
+      position: relative;
+    }
+
+    .agents::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      right: 0;
+      transform: translateY(-50%);
+      width: 500px;
+      height: 500px;
+      background: radial-gradient(ellipse at center, var(--orange-glow) 0%, transparent 60%);
+      pointer-events: none;
+    }
+
+    .agents-content {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 80px;
+      align-items: center;
+      margin-top: 64px;
+    }
+
+    .agents-text h3 {
+      font-size: 28px;
+      font-weight: 600;
+      margin-bottom: 20px;
+    }
+
+    .agents-text p {
+      color: var(--text-muted);
+      font-size: 16px;
+      margin-bottom: 32px;
+    }
+
+    .agents-list {
+      list-style: none;
+    }
+
+    .agents-list li {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 12px 0;
+      color: var(--text-muted);
+      font-size: 15px;
+    }
+
+    .agents-list li::before {
+      content: '';
+      width: 6px;
+      height: 6px;
+      background: var(--orange);
+      border-radius: 50%;
+      margin-top: 8px;
+      flex-shrink: 0;
+    }
+
+    .terminal {
+      background: var(--bg-code);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .terminal-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border-subtle);
+      background: var(--bg-card);
+    }
+
+    .terminal-body {
+      padding: 20px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 12px;
+      line-height: 1.8;
+    }
+
+    .terminal-line {
+      display: flex;
+      gap: 8px;
+    }
+
+    .terminal-prompt {
+      color: var(--orange);
+    }
+
+    .terminal-cmd {
+      color: var(--text);
+    }
+
+    .terminal-output {
+      color: var(--text-muted);
+      padding-left: 20px;
+    }
+
+    .terminal-error {
+      color: #ff5f57;
+    }
+
+    .terminal-success {
+      color: #28c840;
+    }
+
+    /* Composability Section */
+    .compose {
+      background: var(--bg-elevated);
+      border-top: 1px solid var(--border-subtle);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .compose-flow {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin-top: 64px;
+      justify-content: center;
+    }
+
+    .compose-item {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 20px 28px;
+      text-align: center;
+      transition: all 0.3s;
+    }
+
+    .compose-item:hover {
+      border-color: var(--orange);
+      transform: translateY(-2px);
+    }
+
+    .compose-item-tag {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 14px;
+      color: var(--blue);
+      margin-bottom: 8px;
+    }
+
+    .compose-item-desc {
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    .compose-arrow {
+      display: flex;
+      align-items: center;
+      color: var(--text-dim);
+      font-size: 20px;
+    }
+
+    .compose-equals {
+      display: flex;
+      align-items: center;
+      color: var(--orange);
+      font-weight: 600;
+      font-size: 18px;
+    }
+
+    .compose-result {
+      background: linear-gradient(135deg, var(--orange-glow) 0%, transparent 100%);
+      border-color: var(--orange);
+    }
+
+    .compose-result .compose-item-tag {
+      color: var(--orange);
+    }
+
+    /* Examples Section */
+    .examples-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 24px;
+      margin-top: 64px;
+    }
+
+    .example-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      transition: all 0.3s;
+    }
+
+    .example-card:hover {
+      border-color: var(--border);
+      transform: translateY(-4px);
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+    }
+
+    .example-header {
+      padding: 20px 24px;
+      border-bottom: 1px solid var(--border-subtle);
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .example-icon {
+      width: 36px;
+      height: 36px;
+      background: var(--orange-glow);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .example-icon svg {
+      width: 18px;
+      height: 18px;
+      stroke: var(--orange);
+      fill: none;
+      stroke-width: 1.5;
+    }
+
+    .example-title {
+      font-size: 16px;
+      font-weight: 500;
+    }
+
+    .example-code {
+      padding: 20px 24px;
+    }
+
+    .example-code pre {
+      font-size: 12px;
+    }
+
+    /* Footer */
+    footer {
+      padding: 80px 0;
+      border-top: 1px solid var(--border-subtle);
+    }
+
+    .footer-content {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .footer-logo {
+      font-family: 'JetBrains Mono', monospace;
+      font-weight: 600;
+      font-size: 18px;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 32px;
+    }
+
+    .footer-links a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 14px;
+      transition: color 0.2s;
+    }
+
+    .footer-links a:hover {
+      color: var(--orange);
+    }
+
+    /* Responsive */
+    @media (max-width: 1024px) {
+      .pillars-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .agents-content {
+        grid-template-columns: 1fr;
+        gap: 48px;
+      }
+
+      .examples-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 768px) {
+      .nav-links {
+        display: none;
+      }
+
+      .hero {
+        padding: 100px 0 60px;
+      }
+
+      .hero h1 {
+        font-size: 40px;
+      }
+
+      .compose-flow {
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .compose-arrow {
+        transform: rotate(90deg);
+      }
+
+      .footer-content {
+        flex-direction: column;
+        gap: 24px;
+        text-align: center;
+      }
+
+      .code-block {
+        margin: 0 -24px;
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .pillar {
+        padding: 32px 24px;
+      }
+
+      .hero-cmd {
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="container">
+      <a href="#" class="logo">
+        <div class="logo-icon">
+          <svg viewBox="0 0 24 24"><polygon points="12,2 22,22 2,22"/></svg>
+        </div>
+        varg-react
+      </a>
+      <div class="nav-links">
+        <a href="#pillars">Features</a>
+        <a href="#agents">AI Agents</a>
+        <a href="#examples">Examples</a>
+        <a href="https://github.com/varghq/sdk" class="nav-btn">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <div class="container">
+      <div class="hero-content">
+        <div class="hero-badge">
+          <span class="hero-badge-dot"></span>
+          <span>Now in public beta</span>
+        </div>
+        <h1>JSX for <span>AI Video</span></h1>
+        <p class="hero-sub">Declarative video rendering with AI generation. Write JSX, get video. Same prompt = cache hit = instant.</p>
+        
+        <div class="hero-cmd" onclick="navigator.clipboard.writeText('varg render example.tsx')">
+          <span class="hero-cmd-prompt">$</span>
+          <span class="hero-cmd-text">varg render example.tsx</span>
+          <span class="hero-cmd-copy">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+          </span>
+        </div>
+
+        <div class="code-block">
+          <div class="code-header">
+            <div class="code-dot"></div>
+            <div class="code-dot"></div>
+            <div class="code-dot"></div>
+            <span class="code-title">portrait.tsx</span>
+          </div>
+          <div class="code-content">
+<pre><span class="kw">import</span> { <span class="tag">Clip</span>, <span class="tag">Image</span>, <span class="tag">Render</span>, <span class="tag">Video</span> } <span class="kw">from</span> <span class="str">"@vargai/react"</span>;
+<span class="kw">import</span> { <span class="fn">fal</span> } <span class="kw">from</span> <span class="str">"@vargai/fal"</span>;
+
+<span class="kw">export default</span> (
+  &lt;<span class="tag">Render</span> <span class="attr">width</span>=<span class="op">{</span><span class="num">1080</span><span class="op">}</span> <span class="attr">height</span>=<span class="op">{</span><span class="num">1920</span><span class="op">}</span>&gt;
+    &lt;<span class="tag">Clip</span> <span class="attr">duration</span>=<span class="op">{</span><span class="num">5</span><span class="op">}</span>&gt;
+      &lt;<span class="tag">Video</span>
+        <span class="attr">prompt</span>=<span class="op">{{</span>
+          <span class="attr">text</span>: <span class="str">"Camera reveals full figure, dramatic lighting..."</span>,
+          <span class="attr">images</span>: [
+            <span class="fn">Image</span>({
+              <span class="attr">prompt</span>: { <span class="attr">text</span>: <span class="str">"Editorial portrait, orange rim light..."</span> },
+              <span class="attr">model</span>: <span class="fn">fal</span>.<span class="fn">imageModel</span>(<span class="str">"nano-banana-pro/edit"</span>),
+            }),
+          ],
+        <span class="op">}}</span>
+        <span class="attr">model</span>=<span class="op">{</span><span class="fn">fal</span>.<span class="fn">videoModel</span>(<span class="str">"kling-v2.5"</span>)<span class="op">}</span>
+        <span class="attr">duration</span>=<span class="op">{</span><span class="num">5</span><span class="op">}</span>
+      /&gt;
+    &lt;/<span class="tag">Clip</span>&gt;
+  &lt;/<span class="tag">Render</span>&gt;
+);</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="pillars" id="pillars">
+    <div class="container">
+      <span class="section-label">Core Principles</span>
+      <h2 class="section-title">Three pillars of video generation</h2>
+      <p class="section-desc">Built on principles that make complex video workflows feel simple.</p>
+
+      <div class="pillars-grid">
+        <div class="pillar">
+          <div class="pillar-icon">
+            <svg viewBox="0 0 24 24"><path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1M16 3h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1"/></svg>
+          </div>
+          <h3>Declarative</h3>
+          <p>Describe WHAT you want, not HOW to make it. No manual file handling, no temp files, no state management. Just JSX that describes your video structure. The engine handles orchestration, parallelization, and composition automatically.</p>
+          <div class="pillar-code">
+<pre><span class="cmt">// describe structure, not steps</span>
+&lt;<span class="tag">Render</span>&gt;
+  &lt;<span class="tag">Clip</span>&gt;&lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="str">"scene 1"</span> /&gt;&lt;/<span class="tag">Clip</span>&gt;
+  &lt;<span class="tag">Clip</span>&gt;&lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="str">"scene 2"</span> /&gt;&lt;/<span class="tag">Clip</span>&gt;
+&lt;/<span class="tag">Render</span>&gt;</pre>
+          </div>
+        </div>
+
+        <div class="pillar">
+          <div class="pillar-icon">
+            <svg viewBox="0 0 24 24"><path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z"/></svg>
+          </div>
+          <h3>Good Defaults</h3>
+          <p>Everything just works out of the box. Automatic caching, smart aspect ratio handling, audio ducking, transitions. You don't configure what you don't need to. But when you do need control, every parameter is there.</p>
+          <span class="pillar-highlight">same prompt = cache hit = instant</span>
+        </div>
+
+        <div class="pillar">
+          <div class="pillar-icon">
+            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
+          </div>
+          <h3>Flexible</h3>
+          <p>Compose primitives into complex pipelines. TalkingHead? Just Image + Animate + Speech. Split screen? Two children in a Split component. Everything is composable. Build your own abstractions on top of the primitives.</p>
+          <div class="pillar-code">
+<pre><span class="cmt">// compose your own components</span>
+<span class="kw">const</span> <span class="fn">TalkingHead</span> = () =&gt; (
+  &lt;&gt;
+    &lt;<span class="tag">Animate</span> <span class="attr">image</span>=<span class="op">{</span>&lt;<span class="tag">Image</span> /&gt;<span class="op">}</span> /&gt;
+    &lt;<span class="tag">Speech</span>&gt;Hello!&lt;/<span class="tag">Speech</span>&gt;
+  &lt;/&gt;
+);</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="agents" id="agents">
+    <div class="container">
+      <span class="section-label">AI Native</span>
+      <h2 class="section-title">Made for AI Agents</h2>
+      <p class="section-desc">AI agents write good varg-react code out of the box. The declarative API maps naturally to how LLMs think about structure.</p>
+
+      <div class="agents-content">
+        <div class="agents-text">
+          <h3>Clear errors, easy fixes</h3>
+          <p>For the 5% of cases where agents don't one-shot it, they receive clear runtime errors with actionable messages. No cryptic stack traces. No hidden state to debug.</p>
+          <ul class="agents-list">
+            <li>Agents generate correct code 95% of the time</li>
+            <li>Clear runtime errors for the other 5%</li>
+            <li>No magic strings or hidden state</li>
+            <li>Type-safe props catch mistakes early</li>
+          </ul>
+        </div>
+
+        <div class="terminal">
+          <div class="terminal-header">
+            <div class="code-dot"></div>
+            <div class="code-dot"></div>
+            <div class="code-dot"></div>
+          </div>
+          <div class="terminal-body">
+            <div class="terminal-line"><span class="terminal-prompt">$</span><span class="terminal-cmd"> varg render scene.tsx</span></div>
+            <div class="terminal-output"><span class="terminal-error">Error: Clip duration required when using Video</span></div>
+            <div class="terminal-output"><span class="terminal-error">   at Clip (line 12)</span></div>
+            <div class="terminal-output"><span class="terminal-error">   hint: add duration={5} or duration="auto"</span></div>
+            <br>
+            <div class="terminal-line"><span class="terminal-prompt">$</span><span class="terminal-cmd"> # agent fixes and retries</span></div>
+            <div class="terminal-line"><span class="terminal-prompt">$</span><span class="terminal-cmd"> varg render scene.tsx</span></div>
+            <div class="terminal-output"><span class="terminal-success">Rendering 3 clips...</span></div>
+            <div class="terminal-output"><span class="terminal-success">Done! output/scene.mp4</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="compose">
+    <div class="container">
+      <span class="section-label">Primitives</span>
+      <h2 class="section-title">Everything Composes</h2>
+      <p class="section-desc">Combine simple primitives into complex pipelines. Each piece does one thing well.</p>
+
+      <div class="compose-flow">
+        <div class="compose-item">
+          <div class="compose-item-tag">&lt;Image /&gt;</div>
+          <div class="compose-item-desc">generates still</div>
+        </div>
+        <div class="compose-arrow">+</div>
+        <div class="compose-item">
+          <div class="compose-item-tag">&lt;Animate /&gt;</div>
+          <div class="compose-item-desc">adds motion</div>
+        </div>
+        <div class="compose-arrow">+</div>
+        <div class="compose-item">
+          <div class="compose-item-tag">&lt;Speech /&gt;</div>
+          <div class="compose-item-desc">generates audio</div>
+        </div>
+        <div class="compose-equals">=</div>
+        <div class="compose-item compose-result">
+          <div class="compose-item-tag">TalkingHead</div>
+          <div class="compose-item-desc">full character video</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="examples" id="examples">
+    <div class="container">
+      <span class="section-label">Examples</span>
+      <h2 class="section-title">See it in action</h2>
+      <p class="section-desc">Real patterns from production. Copy, paste, render.</p>
+
+      <div class="examples-grid">
+        <div class="example-card">
+          <div class="example-header">
+            <div class="example-icon">
+              <svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="5"/><path d="M20 21a8 8 0 1 0-16 0"/></svg>
+            </div>
+            <span class="example-title">Talking Head</span>
+          </div>
+          <div class="example-code">
+<pre><span class="kw">const</span> <span class="fn">TalkingHead</span> = ({ <span class="attr">character</span>, <span class="attr">voice</span>, <span class="attr">children</span> }) =&gt; (
+  &lt;&gt;
+    &lt;<span class="tag">Animate</span>
+      <span class="attr">image</span>=<span class="op">{</span>&lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="op">{</span>character<span class="op">}</span> /&gt;<span class="op">}</span>
+      <span class="attr">motion</span>=<span class="str">"talking, blinking"</span>
+    /&gt;
+    &lt;<span class="tag">Speech</span> <span class="attr">voice</span>=<span class="op">{</span>voice<span class="op">}</span>&gt;<span class="op">{</span>children<span class="op">}</span>&lt;/<span class="tag">Speech</span>&gt;
+  &lt;/&gt;
+);
+
+&lt;<span class="tag">Clip</span> <span class="attr">duration</span>=<span class="str">"auto"</span>&gt;
+  &lt;<span class="tag">TalkingHead</span> <span class="attr">character</span>=<span class="str">"news anchor"</span> <span class="attr">voice</span>=<span class="str">"adam"</span>&gt;
+    Breaking news from the studio...
+  &lt;/<span class="tag">TalkingHead</span>&gt;
+&lt;/<span class="tag">Clip</span>&gt;</pre>
+          </div>
+        </div>
+
+        <div class="example-card">
+          <div class="example-header">
+            <div class="example-icon">
+              <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="12" y1="3" x2="12" y2="21"/></svg>
+            </div>
+            <span class="example-title">Split Screen</span>
+          </div>
+          <div class="example-code">
+<pre><span class="kw">const</span> before = &lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="str">"before state"</span> /&gt;;
+<span class="kw">const</span> after = &lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="str">"after state"</span> /&gt;;
+
+&lt;<span class="tag">Render</span> <span class="attr">width</span>=<span class="op">{</span><span class="num">1920</span><span class="op">}</span> <span class="attr">height</span>=<span class="op">{</span><span class="num">1080</span><span class="op">}</span>&gt;
+  &lt;<span class="tag">Clip</span> <span class="attr">duration</span>=<span class="op">{</span><span class="num">5</span><span class="op">}</span>&gt;
+    &lt;<span class="tag">Split</span> <span class="attr">left</span>=<span class="op">{</span>before<span class="op">}</span> <span class="attr">right</span>=<span class="op">{</span>after<span class="op">}</span> /&gt;
+    &lt;<span class="tag">Title</span> <span class="attr">position</span>=<span class="str">"bottom"</span>&gt;
+      30 Day Transformation
+    &lt;/<span class="tag">Title</span>&gt;
+  &lt;/<span class="tag">Clip</span>&gt;
+&lt;/<span class="tag">Render</span>&gt;</pre>
+          </div>
+        </div>
+
+        <div class="example-card">
+          <div class="example-header">
+            <div class="example-icon">
+              <svg viewBox="0 0 24 24"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M12 12h.01"/><path d="M17 12h.01"/><path d="M7 12h.01"/></svg>
+            </div>
+            <span class="example-title">Slideshow</span>
+          </div>
+          <div class="example-code">
+<pre><span class="kw">const</span> scenes = [<span class="str">"sunset"</span>, <span class="str">"mountains"</span>, <span class="str">"ocean"</span>];
+
+&lt;<span class="tag">Render</span>&gt;
+  &lt;<span class="tag">Music</span> <span class="attr">prompt</span>=<span class="str">"ambient, peaceful"</span> <span class="attr">loop</span> /&gt;
+  
+  <span class="op">{</span>scenes.<span class="fn">map</span>((scene, i) =&gt; (
+    &lt;<span class="tag">Clip</span>
+      <span class="attr">key</span>=<span class="op">{</span>i<span class="op">}</span>
+      <span class="attr">duration</span>=<span class="op">{</span><span class="num">3</span><span class="op">}</span>
+      <span class="attr">transition</span>=<span class="op">{{</span> <span class="attr">name</span>: <span class="str">"fade"</span> <span class="op">}}</span>
+    &gt;
+      &lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="op">{</span>scene<span class="op">}</span> <span class="attr">zoom</span>=<span class="str">"in"</span> /&gt;
+    &lt;/<span class="tag">Clip</span>&gt;
+  ))<span class="op">}</span>
+&lt;/<span class="tag">Render</span>&gt;</pre>
+          </div>
+        </div>
+
+        <div class="example-card">
+          <div class="example-header">
+            <div class="example-icon">
+              <svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            </div>
+            <span class="example-title">Before/After Slider</span>
+          </div>
+          <div class="example-code">
+<pre>&lt;<span class="tag">Clip</span> <span class="attr">duration</span>=<span class="op">{</span><span class="num">5</span><span class="op">}</span>&gt;
+  &lt;<span class="tag">Slider</span> <span class="attr">direction</span>=<span class="str">"horizontal"</span>&gt;
+    &lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="str">"old photo, faded"</span> /&gt;
+    &lt;<span class="tag">Image</span> <span class="attr">prompt</span>=<span class="str">"restored photo, vibrant"</span> /&gt;
+  &lt;/<span class="tag">Slider</span>&gt;
+  
+  &lt;<span class="tag">Title</span> <span class="attr">position</span>=<span class="str">"top"</span>&gt;
+    AI Photo Restoration
+  &lt;/<span class="tag">Title</span>&gt;
+&lt;/<span class="tag">Clip</span>&gt;</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="container">
+      <div class="footer-content">
+        <div class="footer-logo">
+          <div class="logo-icon">
+            <svg viewBox="0 0 24 24"><polygon points="12,2 22,22 2,22" fill="white"/></svg>
+          </div>
+          varg-react
+        </div>
+        <div class="footer-links">
+          <a href="https://github.com/varghq/sdk">GitHub</a>
+          <a href="#">Docs</a>
+          <a href="#">Discord</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Smooth reveal animations on scroll
+    const observerOptions = {
+      threshold: 0.1,
+      rootMargin: '0px 0px -50px 0px'
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.style.opacity = '1';
+          entry.target.style.transform = 'translateY(0)';
+        }
+      });
+    }, observerOptions);
+
+    document.querySelectorAll('.pillar, .example-card, .compose-item').forEach(el => {
+      el.style.opacity = '0';
+      el.style.transform = 'translateY(20px)';
+      el.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
+      observer.observe(el);
+    });
+
+    // Stagger animation for pillars
+    document.querySelectorAll('.pillar').forEach((el, i) => {
+      el.style.transitionDelay = `${i * 0.1}s`;
+    });
+
+    // Copy command on click
+    document.querySelector('.hero-cmd').addEventListener('click', function() {
+      const text = this.querySelector('.hero-cmd-text').textContent;
+      navigator.clipboard.writeText(text).then(() => {
+        const copyIcon = this.querySelector('.hero-cmd-copy');
+        copyIcon.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+        setTimeout(() => {
+          copyIcon.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+        }, 2000);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/prompting-guide.md
+++ b/docs/prompting-guide.md
@@ -1,0 +1,326 @@
+# Prompting Kling & Nano-Banana-Pro
+
+_Shared by Alex_
+
+---
+
+## Kling AI (Video Generation)
+
+### Core Prompt Structure
+
+A strong Kling prompt relies on four key elements: **subject**, **context**, **action**, and **style**. If you omit any of these, the model is forced to guess.
+
+**Formula:**
+
+```
+[Subject] + [Action/Motion] + [Context/Setting] + [Camera/Style]
+```
+
+### What Makes Kling Special
+
+- Kling's greatest strength is **camera motion** and **character physics**
+- Works best with prompts under **40–50 words**, using clear and structured formatting
+- The real magic shows up when you guide it visually, not just verbally—**reference-first prompting** with images
+
+### Pro Techniques
+
+#### Camera Control
+
+- Add detailed camera movements: `"slow zoom-in"`, `"quick pan"`, `"aerial shot"`
+- Include technical specifications like `"Shot on virtual anamorphic lens, 24mm, f/2.8"`—these function as stylistic cues
+
+#### Weight Elements
+
+Use emphasis indicators `(++)` for critical elements:
+
+```
+++sleek red convertible++ driving along coastal highway
+```
+
+#### Negative Prompts
+
+Specify what to avoid:
+
+```
+No people, no text overlays, no distortion in vehicle proportions
+```
+
+### Image-to-Video Formula
+
+For Image-to-Video, the essential elements are **subject** and **movement**. Unlike Text-to-Video, which requires scene description, Image-to-Video already has a scene provided by the input image.
+
+**Example:**
+
+```
+Cat walking forward on the alien landscape, his tail swaying gently. 
+Vibrant meteor shower fills the sky, with meteors streaking across.
+```
+
+### Common Pitfalls
+
+- Requesting `"360-degree rotation around subject while zooming in"` often produces warped geometry due to multiple simultaneous camera transformations
+- Avoid relying on specific numbers—the AI may struggle with consistency (e.g., "5 trees", "6 puppies")
+- Mixing lighting terms like `"golden hour"` with `"studio lighting"` confuses the model's style interpretation
+
+---
+
+## Nano-Banana-Pro (Image Generation)
+
+Google's latest model—internally "Gemini 3 Pro Image."
+
+### Key Paradigm Shift
+
+Nano-Banana Pro is a **"Thinking" model**. It doesn't just match keywords; it understands intent, physics, and composition. Stop using "tag soups" (e.g., `dog, park, 4k, realistic`) and start acting like a **Creative Director**.
+
+### Core Prompt Formula
+
+```
+[Subject + Adjectives] doing [Action] in [Location/Context]. 
+[Composition/Camera Angle]. [Lighting/Atmosphere]. [Style/Media]. 
+[Specific Constraint/Text].
+```
+
+**ICS Method:** Always specify:
+
+1. **Image type** — blueprint, infographic, diagram
+2. **Content** — source data or information
+3. **Visual style** — survival guide, McKinsey presentation, comic
+
+### Killer Features
+
+#### Text Rendering
+
+Don't just say "add text." Be specific:
+
+```
+Write the text 'HELLO WORLD' in a bold, red, serif font on the sign.
+```
+
+Maximize text legibility by isolating string literals in double quotes. Explicitly define font family.
+
+#### Conversational Editing
+
+The model excels at understanding conversational edits. If an image is 80% correct, don't regenerate from scratch—simply ask for the specific change you need.
+
+#### Search-Powered Generation
+
+Nano-Banana Pro uses Google Search to generate imagery based on real-time data, current events, or factual verification.
+
+#### Multi-Image Context
+
+Supports a **14-image context window**. Upload images (style guides, logos, character sheets) and instruct:
+
+```
+Use the uploaded images as a strict style reference...
+```
+
+### Pro Tips
+
+- Remove polite phrases like "please"—use command-line style syntax
+- Trick the model into photorealism by specifying camera gear: `"Shot on Arri Alexa"` forces the AI to emulate specific film grain
+- You don't need `"4k, trending on artstation, masterpiece"` spam anymore—Nano Banana Pro understands natural language
+
+### Limitations
+
+- Rendering small text, fine details, and producing accurate spellings may not work perfectly
+- Always verify the factual accuracy of data-driven visuals like diagrams and infographics
+
+---
+
+## Quick Comparison
+
+| Aspect | Kling | Nano-Banana-Pro |
+|--------|-------|-----------------|
+| **Type** | Video gen | Image gen |
+| **Sweet Spot** | Camera motion, physics | Text rendering, editing |
+| **Prompting Style** | Cinematic director | Creative director |
+| **Best Input** | Image + motion prompt | Natural language + refs |
+| **Iteration** | Re-generate | Conversational edits |
+
+---
+
+## TikTok-Style Prompts for Kling
+
+### General Guidelines
+
+- **Image-to-Video** gives more control (upload frame → describe movement)
+- Specify **vertical 9:16** aspect ratio
+- Keep prompts short (**40–50 words max**)
+- Use **one camera movement type** at a time (don't mix pan + zoom + rotate)
+
+### Timeline Breakdown
+
+| Time | Action/Angle | Notes |
+|------|--------------|-------|
+| 0–1s | Hook — unusual expression or text question, frontal close-up | Capture attention in first 1–2 seconds |
+| 1–4s | Switch to 45° medium shot; first grimace | Sharp angle change on music beat |
+| 4–7s | Low angle or extreme close-up — funny angle; add text/emoji | Use jump cut to remove pause |
+| 7–10s | High angle; new emotion, possible match cut or object cover | Insert reaction cutaway for smoothness |
+| 10–13s | Show all four angles in 2×2 grid (optional) | Creates powerful final effect |
+| 13–15s | Finale and CTA: return to frontal shot; deliver joke or call-to-action | End on strong beat; add text with CTA |
+
+---
+
+### Prompt Examples by Segment
+
+#### 0–1 sec: Hook — Frontal Close-up
+
+**Text-to-Video:**
+
+```
+Young woman, surprised expression with wide eyes, looking directly at camera. 
+Extreme close-up face shot, static camera, soft ring light, vertical 9:16 format.
+Cinematic, social media aesthetic, sharp focus on eyes.
+```
+
+**Image-to-Video:**
+
+```
+Woman's eyes widen in surprise, eyebrows raise slightly, subtle head tilt forward.
+Static shot, no camera movement.
+```
+
+**Negative prompt:** `blur, camera shake, side profile, horizontal format`
+
+---
+
+#### 1–4 sec: 45° Medium Shot + Grimace
+
+**Text-to-Video:**
+
+```
+Woman at 45-degree angle, medium shot showing torso and hands. 
+She makes an exaggerated funny face, hands gesture expressively.
+Camera slowly pushes in, soft natural lighting from window, vertical format.
+TikTok influencer style, playful mood.
+```
+
+**Image-to-Video:**
+
+```
+Woman turns head 45 degrees, makes exaggerated grimace, 
+hands move up near face expressively. Slow push-in camera movement.
+```
+
+**Tip:** Use `++grimace++` or `++expressive hands++` for emphasis
+
+---
+
+#### 4–7 sec: Low Angle or Extreme Close-up
+
+**Option A — Low Angle:**
+
+```
+Woman filmed from below, low angle shot, looking down at camera with 
+confident smirk. Dramatic perspective, she appears powerful and playful.
+Static camera, vertical 9:16, slight lens distortion for comic effect.
+```
+
+**Option B — Extreme Close-up (eyes/lips):**
+
+```
+Extreme close-up of woman's eyes, pupils dilate slightly, 
+eyebrow raises in surprise. Macro shot, shallow depth of field, 
+ring light reflection in eyes. Static, vertical format.
+```
+
+**Negative prompt:** `full body, wide shot, horizontal, distortion in face proportions`
+
+---
+
+#### 7–10 sec: High Angle + New Emotion
+
+**Text-to-Video:**
+
+```
+Woman filmed from above, high angle shot, she looks up at camera 
+with playful vulnerability. Arms spread wide filling the frame.
+Slow gentle tilt down, soft overhead lighting, vertical 9:16.
+Cute, endearing mood, TikTok aesthetic.
+```
+
+**Image-to-Video:**
+
+```
+Woman looks up at camera, expression shifts from neutral to excited smile,
+hands move into frame from sides. Subtle camera tilt, gentle movement.
+```
+
+---
+
+#### 10–13 sec: Split Screen 2×2 (All 4 Angles)
+
+Kling doesn't natively create grids—this is post-production. Options:
+
+1. **Generate each angle separately** → combine in CapCut/Premiere
+2. **Experimental mosaic prompt:**
+
+```
+Split screen 2x2 grid showing same woman from four angles simultaneously:
+top-left frontal close-up, top-right 45-degree medium shot,
+bottom-left low angle, bottom-right high angle.
+All expressions different, synchronized movement, vertical format.
+```
+
+> ⚠️ Kling may struggle with consistency. Better to generate separately and combine.
+
+---
+
+#### 13–15 sec: Finale + CTA — Return to Frontal
+
+**Text-to-Video:**
+
+```
+Woman, frontal close-up, delivers punchline directly to camera 
+with confident smile. Slight head nod, wink at the end.
+Static camera, punchy energy, vertical 9:16, TikTok creator vibe.
+Sharp focus, professional ring lighting.
+```
+
+**Image-to-Video:**
+
+```
+Woman smiles confidently, delivers line to camera, 
+subtle wink, slight forward lean. Static shot, no camera movement.
+```
+
+---
+
+### Universal TikTok-Style Modifiers
+
+Add to the end of prompts:
+
+| Goal | Modifier |
+|------|----------|
+| **Vertical** | `vertical 9:16 format, portrait orientation` |
+| **TikTok vibe** | `TikTok creator aesthetic, social media style` |
+| **Lighting** | `ring light, soft natural window light, even lighting` |
+| **Sharpness** | `sharp focus, high clarity, 1080p quality` |
+| **Energy** | `dynamic, punchy, energetic mood` |
+
+---
+
+### Prompt Template for varg SDK
+
+```javascript
+const klingPromptTemplate = {
+  subject: "Young woman, [EXPRESSION]",
+  action: "[MOVEMENT/GESTURE]",
+  camera: {
+    angle: "[frontal/45-degree/low-angle/high-angle]",
+    shot: "[extreme-close-up/close-up/medium-shot]",
+    movement: "[static/slow-push-in/gentle-tilt]"
+  },
+  style: "TikTok creator aesthetic, vertical 9:16",
+  lighting: "ring light, soft natural lighting",
+  negative: "blur, horizontal format, camera shake"
+};
+```
+
+---
+
+## Pro Tips for Scale
+
+- **Consistency via Image-to-Video** — Generate base frame in Flux/SDXL, then animate in Kling. Prevents face "drifting" between angles.
+- **Batch prompts** — Create 3–4 expression variations per angle, then pick the best during editing.
+- **Reference-first** — Kling works better when you provide an image and describe only the movement.

--- a/docs/varg-react.md
+++ b/docs/varg-react.md
@@ -1,0 +1,834 @@
+# varg-react
+
+declarative video rendering with ai generation. jsx for videos.
+
+## quick start
+
+```bash
+bun install @vargai/react
+```
+
+```tsx
+import { render, Render, Clip, Image, Title } from "@vargai/react";
+
+await render(
+  <Render width={1280} height={720}>
+    <Clip duration={5}>
+      <Image prompt="sunset over ocean, cinematic" />
+      <Title position="bottom">beautiful sunset</Title>
+    </Clip>
+  </Render>,
+  { output: "output/sunset.mp4" }
+);
+```
+
+## core concepts
+
+### everything is cached
+
+every element computes a cache key from its props. same props = cache hit.
+
+```tsx
+// first run: generates image (~3s)
+// second run: instant cache hit
+<Image prompt="cyberpunk cityscape at night" />
+```
+
+change any prop and it regenerates:
+
+```tsx
+<Image prompt="cyberpunk cityscape at night" aspectRatio="9:16" />
+// different aspectRatio = new cache key = regenerates
+```
+
+### clips and layers
+
+clips are sequential. layers within a clip are stacked.
+
+```tsx
+<Render width={1080} height={1920} fps={30}>
+  {/* first clip */}
+  <Clip duration={5}>
+    <Image prompt="coffee shop interior" />
+  </Clip>
+  
+  {/* second clip with transition */}
+  <Clip duration={3} transition={{ name: "fade", duration: 0.5 }}>
+    <Image prompt="park with autumn leaves" />
+  </Clip>
+</Render>
+```
+
+### transitions
+
+```tsx
+<Clip transition={{ name: "fade", duration: 0.3 }}>
+<Clip transition={{ name: "wipeleft", duration: 0.5 }}>
+<Clip transition={{ name: "slideright", duration: 0.4 }}>
+<Clip transition={{ name: "crossfade", duration: 0.5 }}>
+<Clip transition={{ name: "cube", duration: 0.8 }}>
+<Clip transition={{ name: "directionalwipe", duration: 0.5 }}>
+```
+
+67 gl-transitions available: `fade`, `crossfade`, `wipeleft`, `wiperight`, `wipeup`, `wipedown`, `slideleft`, `slideright`, `slideup`, `slidedown`, `cube`, `directionalwipe`, `dreamy`, `squareswire`, `radial`, `pixelize`, and more.
+
+## rendering images
+
+```tsx
+import { Image } from "@vargai/react";
+
+// basic
+<Image prompt="ralph wiggum eating glue, simpsons style" />
+
+// with aspect ratio
+<Image prompt="fat tiger lying on couch" aspectRatio="1:1" />
+<Image prompt="luigi in wheelchair racing down hill" aspectRatio="16:9" />
+<Image prompt="south park cartman screaming" aspectRatio="9:16" />
+
+// zoom animation (ken burns)
+<Image prompt="epic mountain landscape" zoom="in" />
+<Image prompt="white-teeth black athletic guy flexing" zoom="out" />
+<Image prompt="forest path mysterious" zoom="left" />
+<Image prompt="ocean waves crashing" zoom="right" />
+
+// contain with blur (no black bars)
+<Image prompt="fat tiger square photo" resize="contain-blur" />
+
+// remove background
+<Image prompt="ralph wiggum transparent" removeBackground />
+
+// image-to-image edit
+<Image 
+  src="./photo.png"
+  prompt="make it look like south park style"
+/>
+```
+
+## rendering video
+
+### text-to-video generation
+
+```tsx
+import { Video } from "@vargai/react";
+
+// generate video from prompt
+<Video prompt="ocean waves crashing on beach, cinematic" model={fal.videoModel("wan-2.5")} />
+
+// use existing video file
+<Video src="./interview.mp4" />
+
+// with audio and trimming
+<Video src="./clip.mp4" keepAudio volume={0.8} cutFrom={5} cutTo={15} />
+```
+
+### image-to-video animation
+
+```tsx
+import { Animate } from "@vargai/react";
+
+// animate an image
+<Animate 
+  image={<Image prompt="fat tiger on couch" />}
+  motion="fat tiger breathing heavily, belly jiggles"
+  duration={5}
+/>
+
+// from existing file
+<Animate 
+  src="./luigi.png"
+  motion="wheelchair spinning in circles"
+  duration={5}
+/>
+```
+
+## rendering speech
+
+```tsx
+import { Speech } from "@vargai/react";
+
+<Clip>
+  <Image prompt="ralph wiggum at podium, simpsons style" />
+  <Speech voice="adam">
+    I'm in danger. Also I'm the CEO now.
+  </Speech>
+</Clip>
+```
+
+voices: `rachel`, `adam`, `bella`, `sam`, `josh`
+
+## talking heads
+
+compose Image, Animate, and Speech to create talking characters:
+
+```tsx
+import { Clip, Image, Animate, Speech } from "@vargai/react";
+import { fal, elevenlabs } from "@vargai/sdk";
+
+// define a reusable TalkingHead component
+const TalkingHead = ({ character, voice, children }: {
+  character: string;
+  voice: string;
+  children: string;
+}) => (
+  <>
+    <Animate 
+      image={<Image prompt={character} model={fal.imageModel("flux-schnell")} />}
+      model={fal.videoModel("wan-2.5")}
+      motion="subtle talking, head movements, blinking"
+    />
+    <Speech voice={voice} model={elevenlabs.speechModel("turbo")}>
+      {children}
+    </Speech>
+  </>
+);
+
+// use it
+<Clip duration="auto">
+  <TalkingHead character="south park cartman, angry face" voice="adam">
+    Screw you guys, I'm going home. But first let me tell you 
+    about our sponsor, NordVPN.
+  </TalkingHead>
+</Clip>
+```
+
+this internally:
+1. generates character image from prompt
+2. generates speech audio from text  
+3. animates image to video
+4. sets clip duration to match audio length
+
+all steps cached independently.
+
+### with existing image
+
+```tsx
+const TalkingHead = ({ src, voice, children }) => (
+  <>
+    <Animate 
+      src={src}
+      model={fal.videoModel("wan-2.5")}
+      motion="talking naturally"
+    />
+    <Speech voice={voice} model={elevenlabs.speechModel("turbo")}>
+      {children}
+    </Speech>
+  </>
+);
+
+<Clip duration="auto">
+  <TalkingHead src="./fat-tiger.png" voice="josh">
+    I'm not fat, I'm cultivating mass.
+  </TalkingHead>
+</Clip>
+```
+
+## overlays and pip
+
+layer children stack on top of each other.
+
+```tsx
+<Clip duration={5}>
+  {/* base layer - full frame */}
+  <Image prompt="luigi wheelchair racing track" />
+  
+  {/* picture-in-picture overlay */}
+  <TalkingHead
+    character="white-teeth black athletic guy, sports commentator"
+    voice="josh"
+    position={{ right: "5%", bottom: "5%" }}
+    size={{ width: "25%", height: "25%" }}
+  >
+    And he's approaching the final turn! Incredible speed!
+  </TalkingHead>
+</Clip>
+```
+
+### position presets
+
+```tsx
+<Image position="top-left" />
+<Image position="top" />
+<Image position="top-right" />
+<Image position="left" />
+<Image position="center" />
+<Image position="right" />
+<Image position="bottom-left" />
+<Image position="bottom" />
+<Image position="bottom-right" />
+```
+
+## text overlays
+
+```tsx
+import { Title, Subtitle } from "@vargai/react";
+
+<Clip duration={5}>
+  <Image prompt="ralph wiggum staring blankly" />
+  
+  {/* centered title */}
+  <Title>I'M IN DANGER</Title>
+  
+  {/* positioned title */}
+  <Title position="top" color="#ffffff">
+    Episode 1
+  </Title>
+  
+  {/* subtitle with background */}
+  <Subtitle>the beginning of something special</Subtitle>
+</Clip>
+```
+
+### text timing
+
+text appears and disappears within the clip:
+
+```tsx
+<Clip duration={10}>
+  <Image prompt="fat tiger sleeping timelapse" />
+  
+  {/* appears at 2s, disappears at 5s */}
+  <Title start={2} end={5}>
+    Hour 1: Still sleeping
+  </Title>
+  
+  {/* appears at 6s, stays until clip ends */}
+  <Title start={6}>
+    Hour 47: Still sleeping
+  </Title>
+</Clip>
+```
+
+## captions (tiktok-style)
+
+word-by-word animated captions synced to speech:
+
+```tsx
+import { Captions } from "@vargai/react";
+
+<Clip>
+  <Video src="./cartman-rant.mp4" />
+  <Captions 
+    src="./cartman-rant.mp4"
+    style="tiktok"
+    color="#ffffff"
+    activeColor="#ffff00"
+    fontSize={48}
+  />
+</Clip>
+```
+
+or feed it a speech element directly:
+
+```tsx
+<Clip>
+  <Image prompt="ralph wiggum at podium" />
+  <Speech voice="adam" id="ralph-speech">
+    I'm in danger. The danger is me.
+  </Speech>
+  <Captions 
+    src={ralph-speech}
+    style="tiktok"
+  />
+</Clip>
+```
+
+### caption styles
+
+```tsx
+<Captions src="./audio.mp3" style="tiktok" />     // word-by-word highlight
+<Captions src="./audio.mp3" style="karaoke" />    // fill left-to-right
+<Captions src="./audio.mp3" style="bounce" />     // words bounce in
+<Captions src="./audio.mp3" style="typewriter" /> // typing effect
+```
+
+### with custom transcript
+
+```tsx
+<Clip>
+  <Video src="./video.mp4" />
+  <Captions srt="./captions.srt" style="tiktok" />
+</Clip>
+```
+
+## split screen
+
+```tsx
+import { Split } from "@vargai/react";
+
+<Clip duration={5}>
+  <Split direction="horizontal">
+    <Animate 
+      image={<Image prompt="fat tiger on couch, lazy" />}
+      motion="breathing heavily, not moving"
+    />
+    <Animate 
+      image={<Image prompt="fat tiger slightly less fat, still on couch" />}
+      motion="breathing slightly less heavily"
+    />
+  </Split>
+  <Title position="bottom">WEEK 1 / WEEK 52</Title>
+</Clip>
+```
+
+## slider (before/after reveal)
+
+animated wipe reveal between two images:
+
+```tsx
+import { Slider } from "@vargai/react";
+
+<Clip duration={5}>
+  <Slider direction="horizontal">
+    <Image prompt="luigi standing normally" />
+    <Image prompt="luigi in wheelchair, looking defeated" />
+  </Slider>
+  <Title position="top">What racing does to a mf</Title>
+</Clip>
+```
+
+the slider animates from left to right, revealing the second image.
+
+## swipe animation
+
+tinder-style card swipes:
+
+```tsx
+import { Swipe } from "@vargai/react";
+
+<Clip duration={6}>
+  <Swipe direction="right" interval={1.5}>
+    <Image prompt="ralph wiggum dating profile, eating paste" />
+    <Image prompt="fat tiger dating profile, lying down" />
+    <Image prompt="luigi wheelchair dating profile, sad eyes" />
+    <Image prompt="white-teeth guy dating profile, perfect smile" />
+  </Swipe>
+</Clip>
+```
+
+## packshot (end card)
+
+end card with call-to-action button:
+
+```tsx
+import { Packshot } from "@vargai/react";
+
+<Clip duration={4}>
+  <Packshot
+    background={<Image prompt="south park style gradient" />}
+    logo="./cartman-enterprises.png"
+    cta="Respect My Authority"
+    ctaColor="#ff5500"
+    blinkCta
+  />
+</Clip>
+```
+
+## audio
+
+### background music
+
+```tsx
+<Render>
+  {/* loops to match video duration */}
+  <Music prompt="epic orchestral, hero music" loop />
+  
+  <Clip duration={5}>
+    <Image prompt="luigi wheelchair training montage" />
+  </Clip>
+  
+  <Clip duration={5}>
+    <Image prompt="luigi wheelchair racing final lap" />
+  </Clip>
+</Render>
+```
+
+### preserve source audio
+
+```tsx
+<Clip>
+  <Video src="./interview.mp4" keepAudio volume={0.8} />
+</Clip>
+```
+
+### mix multiple audio
+
+```tsx
+<Clip duration={10}>
+  <Video src="./fat-tiger-sleeping.mp4" keepAudio volume={0.3} />
+  <Speech voice="sam" volume={1.0}>
+    Day 47. He still hasn't moved. Scientists are baffled.
+  </Speech>
+</Clip>
+```
+
+### audio ducking
+
+automatically lower music when speech plays:
+
+```tsx
+<Render>
+  <Music prompt="dramatic documentary music" loop ducking />
+  
+  <Clip duration={5}>
+    <Image prompt="ralph wiggum walking into frame" />
+  </Clip>
+  
+  <Clip duration={10}>
+    <Image prompt="ralph wiggum close up, confused" />
+    <Speech voice="josh">
+      This is ralph. He doesn't know where he is. Neither do we.
+    </Speech>
+  </Clip>
+</Render>
+```
+
+### audio normalization
+
+```tsx
+<Render normalize>
+  {/* all audio levels balanced automatically */}
+  <Clip>
+    <Video src="./loud-clip.mp4" keepAudio />
+  </Clip>
+  <Clip>
+    <Video src="./quiet-clip.mp4" keepAudio />
+  </Clip>
+</Render>
+```
+
+## character consistency
+
+reuse the same image reference for consistency:
+
+```tsx
+const luigi = <Image prompt="luigi in wheelchair, determined face, mario kart style" />;
+
+<Render>
+  <Clip duration={3}>
+    {luigi}
+    <Title>ORIGIN STORY</Title>
+  </Clip>
+  
+  <Clip duration={5}>
+    <Animate image={luigi} motion="wheelchair wheels spinning, wind in mustache" />
+  </Clip>
+  
+  <Clip duration={3}>
+    {luigi}
+    <Title>HE NEVER RECOVERED</Title>
+  </Clip>
+</Render>
+```
+
+same `luigi` reference = same cache key = same generated image.
+
+## elements and scene composition
+
+define reusable elements for consistent generation:
+
+```tsx
+import { Element, scene } from "@vargai/react";
+
+// define a character element
+const tiger = Element({
+  type: "character",
+  prompt: "fat tiger, orange stripes, chubby cheeks, sleepy eyes",
+});
+
+// define a style element  
+const style = Element({
+  type: "style",
+  prompt: "pixar animation style, soft lighting",
+});
+
+// use in scene template
+<Image prompt={scene`${tiger} lying on couch, ${style}`} />
+<Image prompt={scene`${tiger} attempting to exercise, ${style}`} />
+```
+
+elements ensure visual consistency across multiple generations.
+
+## slideshow
+
+```tsx
+const SCENES = [
+  "at the gym, confused by equipment",
+  "eating entire pizza, no regrets",
+  "attempting yoga, stuck",
+  "napping on treadmill",
+];
+
+const character = "fat tiger, chubby, adorable";
+
+<Render width={1280} height={720}>
+  <Music prompt="motivational gym music, ironic" loop />
+  
+  {SCENES.map((scene, i) => (
+    <Clip key={i} duration={3} transition={{ name: "fade", duration: 0.3 }}>
+      <Image prompt={`${character}, ${scene}`} zoom="in" />
+    </Clip>
+  ))}
+</Render>
+```
+
+## character grid
+
+```tsx
+const CHARACTERS = [
+  { name: "Ralph", prompt: "ralph wiggum, eating glue, happy" },
+  { name: "Fat Tiger", prompt: "fat tiger, lying down, exhausted" },
+  { name: "Luigi", prompt: "luigi in wheelchair, sad but determined" },
+  { name: "The Smile", prompt: "white-teeth black athletic guy, perfect smile, shiny" },
+];
+
+<Render width={720} height={720}>
+  {CHARACTERS.map(({ name, prompt }) => (
+    <Clip key={name} duration={2} transition={{ name: "fade", duration: 0.3 }}>
+      <Image prompt={`${prompt}, portrait, meme style`} aspectRatio="1:1" />
+      <Title position="bottom" color="#ffffff">{name}</Title>
+    </Clip>
+  ))}
+</Render>
+```
+
+## conditional rendering
+
+standard jsx conditionals:
+
+```tsx
+<Render>
+  <Clip duration={5}>
+    <Image prompt="south park cartman main scene" />
+  </Clip>
+  
+  {includeOutro && (
+    <Clip duration={3}>
+      <Image prompt="cartman waving goodbye" />
+      <Title>Screw you guys!</Title>
+    </Clip>
+  )}
+  
+  {sponsor && (
+    <Clip duration={5}>
+      <Image prompt="cartman holding sponsor product" />
+      <Speech voice="adam">{sponsor.script}</Speech>
+    </Clip>
+  )}
+</Render>
+```
+
+## render options
+
+```tsx
+import { render } from "@vargai/react";
+
+// save to file
+await render(<Render>...</Render>, { 
+  output: "output/video.mp4" 
+});
+
+// with cache directory
+await render(<Render>...</Render>, { 
+  output: "output/video.mp4",
+  cache: ".cache/ai"
+});
+
+// get buffer
+const buffer = await render(<Render>...</Render>);
+await Bun.write("video.mp4", buffer);
+
+// stream progress
+const stream = render.stream(<Render>...</Render>);
+for await (const event of stream) {
+  console.log(`${event.type}: ${event.progress}%`);
+  // "generating image: 45%"
+  // "generating speech: 100%"
+  // "rendering clip: 30%"
+}
+```
+
+## full example: ralph explains crypto
+
+```tsx
+import { render, Render, Clip, Image, Animate, Speech, Title } from "@vargai/react";
+import { fal, elevenlabs } from "@vargai/sdk";
+
+// TalkingHead is just a composition of primitives
+const TalkingHead = ({ character, voice, children }: {
+  character: string;
+  voice: string;
+  children: string;
+}) => (
+  <Clip duration="auto">
+    <Animate 
+      image={<Image prompt={character} model={fal.imageModel("flux-schnell")} />}
+      model={fal.videoModel("wan-2.5")}
+      motion="subtle head movements, blinking, mouth moving"
+    />
+    <Speech voice={voice} model={elevenlabs.speechModel("turbo")}>
+      {children}
+    </Speech>
+  </Clip>
+);
+
+const script = `Hi, I'm Ralph! My cat's breath smells like cat food. 
+Also I invested my lunch money in dogecoin. 
+Now I live in a box. But it's a nice box! 
+It has a window. The window is a hole.`;
+
+await render(
+  <Render width={1080} height={1920}>
+    <TalkingHead
+      character="ralph wiggum, simpsons style, innocent smile, slightly confused"
+      voice="adam"
+    >
+      {script}
+    </TalkingHead>
+    
+    <Clip duration={2} transition={{ name: "fade", duration: 0.5 }}>
+      <Image 
+        prompt="ralph wiggum in cardboard box, happy, simpsons style"
+        model={fal.imageModel("flux-schnell")}
+        zoom="in"
+      />
+      <Title position="bottom">@RalphInvests</Title>
+    </Clip>
+  </Render>,
+  { 
+    output: "output/ralph-crypto.mp4",
+    cache: ".cache/ai"
+  }
+);
+```
+
+## full example: wheelchair racing promo
+
+```tsx
+import { render, Render, Clip, Image, Animate, Title, Subtitle, Music } from "@vargai/react";
+
+const luigi = <Image prompt="luigi in racing wheelchair, determined, mario kart style" />;
+
+await render(
+  <Render width={1080} height={1920}>
+    <Music prompt="epic racing music, fast drums, intense" loop />
+    
+    <Clip duration={3}>
+      {luigi}
+      <Title start={1}>This Summer</Title>
+    </Clip>
+    
+    <Clip duration={5} transition={{ name: "fade", duration: 0.5 }}>
+      <Animate 
+        image={luigi}
+        motion="wheelchair wheels spinning fast, wind effects, speed lines"
+      />
+      <Title position="bottom">NO LIMITS</Title>
+    </Clip>
+    
+    <Clip duration={3} transition={{ name: "fade", duration: 0.5 }}>
+      {luigi}
+      <Title>LUIGI KART: WHEELCHAIR EDITION</Title>
+      <Subtitle>He can't walk but he can win</Subtitle>
+    </Clip>
+  </Render>,
+  { output: "output/luigi-promo.mp4" }
+);
+```
+
+## full example: fat tiger's fitness journey
+
+```tsx
+import { render, Render, Clip, Image, Animate, Split, Title } from "@vargai/react";
+
+const tiger = "fat tiger, orange stripes, cute, pixar style";
+
+const before = <Image prompt={`${tiger}, extremely chubby, on couch, pizza boxes`} aspectRatio="3:4" />;
+const after = <Image prompt={`${tiger}, slightly less chubby, still on couch, salad nearby unopened`} aspectRatio="3:4" />;
+
+await render(
+  <Render width={1280} height={720}>
+    <Clip duration={5}>
+      <Split direction="horizontal">
+        <Animate image={before} motion="breathing heavily, belly jiggles" />
+        <Animate image={after} motion="breathing slightly less heavily, one ear twitches" />
+      </Split>
+      <Title position="bottom" color="#ffffff">
+        DAY 1                    DAY 365
+      </Title>
+    </Clip>
+  </Render>,
+  { output: "output/tiger-transformation.mp4" }
+);
+```
+
+## models
+
+specify which ai model to use:
+
+```tsx
+import { Image, Animate, Speech, TalkingHead } from "@vargai/react";
+import { fal, openai, replicate, elevenlabs, higgsfield } from "@vargai/sdk";
+
+// image models
+<Image prompt="sunset" model={fal.imageModel("flux-schnell")} />
+<Image prompt="sunset" model={fal.imageModel("flux-pro")} />
+<Image prompt="sunset" model={openai.imageModel("dall-e-3")} />
+<Image prompt="sunset" model={replicate.imageModel("sdxl")} />
+
+// video models
+<Animate model={fal.videoModel("kling-v2.5")} motion="slow zoom" />
+<Animate model={fal.videoModel("wan-2.5")} motion="camera pan" />
+<Animate model={higgsfield.videoModel("soul")} motion="walking" />
+
+// speech models
+<Speech model={elevenlabs.speechModel("turbo")} voice="rachel">
+  hello world
+</Speech>
+
+// talking head with lipsync
+<TalkingHead 
+  model={fal.videoModel("wan-2.5")}
+  lipsyncModel={fal.videoModel("sync-v2")}
+  voice="adam"
+>
+  this syncs lips to speech
+</TalkingHead>
+```
+
+### higgsfield characters
+
+for consistent character animation:
+
+```tsx
+<Render>
+  <Clip duration={5}>
+    <Animate
+      model={higgsfield.videoModel("soul")}
+      character="white-teeth-guy"
+      motion="walking forward with perfect posture, teeth gleaming"
+    />
+  </Clip>
+  
+  <Clip duration={5}>
+    <Animate
+      model={higgsfield.videoModel("soul")}
+      character="white-teeth-guy"
+      motion="pointing at camera, smile intensifies"
+    />
+  </Clip>
+</Render>
+```
+
+same `character` id = consistent appearance across clips.
+
+## why varg-react?
+
+| imperative (current) | declarative (varg-react) |
+|---------------------|-------------------------|
+| manual cache keys | automatic from props |
+| step-by-step generation | parallel where possible |
+| explicit file handling | automatic temp files |
+| editly config objects | jsx composition |
+| ~50 lines for talking head | ~10 lines |
+
+same power, less code, automatic caching.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "type-check": "tsc --noEmit",
-    "prepare": "husky install",
-    "size": "size-limit"
+    "prepare": "husky || true",
+    "size": "size-limit",
+    "studio": "bun run src/ai-sdk/studio/index.ts"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [
@@ -59,9 +60,10 @@
     "replicate": "^1.4.0",
     "zod": "^4.2.1"
   },
-  "version": "0.3.0",
+  "version": "0.4.0-alpha.1",
   "exports": {
     ".": "./src/index.ts",
+    "./ai": "./src/ai-sdk/index.ts",
     "./core": "./src/core/index.ts",
     "./providers": "./src/providers/index.ts",
     "./definitions": "./src/definitions/index.ts"

--- a/src/ai-sdk/examples/.gitignore
+++ b/src/ai-sdk/examples/.gitignore
@@ -1,0 +1,1 @@
+_studio*.tsx

--- a/src/ai-sdk/examples/gym.tsx
+++ b/src/ai-sdk/examples/gym.tsx
@@ -1,0 +1,210 @@
+import { fal } from "../index";
+import { Clip, Image, Render, Video } from "../react";
+
+// ============================================================================
+// CHARACTER REFERENCE
+// ============================================================================
+
+const characterRef = "https://s3.varg.ai/uploads/images/screenshot-2026-01-18-at-34213-pm_3644f152.png";
+
+// ============================================================================
+// STEP 1: BASE GYM ENVIRONMENT (one consistent gym)
+// ============================================================================
+
+const baseGym = Image({
+  prompt: "Modern gym interior, clean minimalist design, large windows with natural daylight, mirror wall, dumbbell rack, workout benches, rubber flooring, empty scene without people, wide establishing shot, vertical 9:16 composition",
+  model: fal.imageModel("nano-banana-pro"),
+  aspectRatio: "9:16",
+});
+
+// ============================================================================
+// STEP 2: DIFFERENT ANGLES OF THE SAME GYM
+// ============================================================================
+
+const gymAngle_bench = Image({
+  prompt: {
+    text: "Same gym interior, camera angle focused on bench press area near mirror wall. Same lighting, same equipment layout, same windows. Empty scene, no people.",
+    images: [baseGym],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+const gymAngle_mirror = Image({
+  prompt: {
+    text: "Same gym interior, camera angle facing the mirror wall directly. Same natural lighting from windows, same equipment visible. Empty scene, no people.",
+    images: [baseGym],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+const gymAngle_weights = Image({
+  prompt: {
+    text: "Same gym interior, camera angle near dumbbell rack and free weights area. Same lighting, same design aesthetic. Empty scene, no people.",
+    images: [baseGym],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+const gymAngle_wide = Image({
+  prompt: {
+    text: "Same gym interior, wider shot showing more of the space. Same windows, same mirror, same equipment. Empty scene, no people.",
+    images: [baseGym],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// ============================================================================
+// STEP 3: PLACE CHARACTER IN SCENES
+// ============================================================================
+
+// Scene 1: Frustrated scrolling on bench
+const scene1_frustrated = Image({
+  prompt: {
+    text: "Place this man sitting on gym bench, hunched over looking at his phone with frustrated annoyed expression. Same athletic wear as reference. He's scrolling rapidly, looks confused and irritated. Keep the gym environment exactly as shown.",
+    images: [characterRef, gymAngle_bench],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// Scene 2: Sighing at generic apps (closer shot near mirror)
+const scene2_sighing = Image({
+  prompt: {
+    text: "Place this man standing near gym mirror, looking at phone with disappointed expression. He sighs, slight eye roll. Same clothes as reference. Phone visible in his hands. Keep the gym environment exactly as shown.",
+    images: [characterRef, gymAngle_mirror],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// Scene 3: Discovery moment - expression changes
+const scene3_discovery = Image({
+  prompt: {
+    text: "Place this man in gym, now with curious interested expression looking at phone. Eyebrows raised, slight smile forming, pleasant surprise. Same athletic wear. He sits up straighter, engaged. Keep the gym environment exactly as shown.",
+    images: [characterRef, gymAngle_bench],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// Scene 4: Personalized plan - satisfied
+const scene4_personalized = Image({
+  prompt: {
+    text: "Place this man sitting on gym bench, smiling genuinely at phone screen. Confident relaxed posture, nodding approvingly. Same clothes as reference. Phone clearly visible. Keep the gym environment exactly as shown.",
+    images: [characterRef, gymAngle_bench],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// Scene 5: Watching demo - over shoulder
+const scene5_demo = Image({
+  prompt: {
+    text: "Over-the-shoulder view of this man watching phone screen in gym. He's standing, phone held up, head slightly tilted studying exercise form. Back and shoulder visible. Same athletic wear. Keep the gym environment exactly as shown.",
+    images: [characterRef, gymAngle_weights],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// Scene 6: Working out - dumbbell exercise
+const scene6_workout = Image({
+  prompt: {
+    text: "Place this man doing dumbbell press on gym bench. Focused determined expression, mid-rep with good form. Phone placed on bench beside him. Same athletic wear as reference. Keep the gym environment exactly as shown.",
+    images: [characterRef, gymAngle_weights],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// Scene 7: CTA - selfie style to camera
+const scene7_cta = Image({
+  prompt: {
+    text: "Place this man in selfie-style front-facing shot, speaking directly to camera with confident friendly smile. One hand gesturing casually. Same clothes as reference. Gym background slightly blurred behind him. Authentic vlogger energy.",
+    images: [characterRef, gymAngle_wide],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+// ============================================================================
+// RENDER - VIDEO CLIPS
+// ============================================================================
+
+export default (
+  <Render width={1080} height={1920}>
+    <Clip duration={4}>
+      <Video
+        prompt={{
+          images: [scene1_frustrated],
+          text: "Man sits on gym bench looking frustrated at phone, scrolling rapidly with annoyed expression. He sighs and shifts uncomfortably. Static camera.",
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+
+    <Clip duration={3}>
+      <Video
+        prompt={{
+          images: [scene2_sighing],
+          text: "Man near gym mirror sighing, slight eye roll, disappointed expression looking at phone. He swipes between apps. Static camera.",
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+
+    <Clip duration={3}>
+      <Video
+        prompt={{
+          images: [scene3_discovery],
+          text: "Man's expression changes from bored to curious, then pleasantly surprised. Eyebrows raise, slight smile forms. Static camera.",
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+
+    <Clip duration={3}>
+      <Video
+        prompt={{
+          images: [scene4_personalized],
+          text: "Man smiles genuinely, nods approvingly at phone screen. Relaxed confident body language. Static camera.",
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+
+    <Clip duration={3}>
+      <Video
+        prompt={{
+          images: [scene5_demo],
+          text: "Over-shoulder shot, man watches exercise demo on phone, tilts head studying form, then mimics movement slightly. Static camera.",
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+
+    <Clip duration={5}>
+      <Video
+        prompt={{
+          images: [scene6_workout],
+          text: "Man performs dumbbell press with good form, focused expression. Completes rep and glances at phone timer on bench. Static camera.",
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+
+    <Clip duration={4}>
+      <Video
+        prompt={{
+          images: [scene7_cta],
+          text: "Man speaks to camera selfie style, confident smile, casual hand gesture pointing down. Friendly authentic energy. Static camera.",
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/examples/madi.tsx
+++ b/src/ai-sdk/examples/madi.tsx
@@ -1,0 +1,60 @@
+import { elevenlabs } from "../elevenlabs-provider";
+import { fal } from "../fal-provider";
+import { Animate, Clip, Image, Music, Render } from "../react";
+
+const MADI_REF =
+  "https://s3.varg.ai/fellowers/madi/character_shots/madi_shot_03_closeup.png";
+
+const SCENES = [
+  {
+    prompt:
+      "extreme close-up face shot, surprised expression with wide eyes, looking directly at camera, holding peach near lips",
+    motion:
+      "eyes widen in surprise, eyebrows raise slightly, subtle head tilt forward. Static shot, no camera movement.",
+  },
+  {
+    prompt:
+      "45-degree angle medium shot showing face and hands, biting into peach with exaggerated enjoyment, juice on lips, playful expression",
+    motion:
+      "turns head 45 degrees, bites into peach, juice drips down chin, hands move expressively. Slow push-in camera movement.",
+  },
+  {
+    prompt:
+      "low angle shot from below, looking down at camera with confident smirk, holding peach triumphantly, dramatic perspective",
+    motion:
+      "looks down at camera with growing smile, raises peach slightly, confident head tilt. Static camera, slight lens distortion.",
+  },
+  {
+    prompt:
+      "high angle shot from above, looking up at camera with playful smile, arms spread wide, peach in one hand, endearing expression",
+    motion:
+      "looks up at camera, expression shifts from neutral to excited smile, subtle wink, slight forward lean. Gentle camera tilt down.",
+  },
+];
+
+export default (
+  <Render width={1080} height={1920}>
+    <Music
+      prompt="upbeat electronic pop, energetic female vocal chops, modern tiktok vibe, catchy melody"
+      model={elevenlabs.musicModel()}
+      duration={10}
+      volume={0.6}
+    />
+
+    {SCENES.map((scene, i) => (
+      <Clip key={i} duration={2}>
+        <Animate
+          image={Image({
+            prompt: { text: scene.prompt, images: [MADI_REF] },
+            model: fal.imageModel("nano-banana-pro/edit"),
+            aspectRatio: "9:16",
+            resize: "cover",
+          })}
+          motion={scene.motion}
+          model={fal.videoModel("wan-2.5")}
+          duration={5}
+        />
+      </Clip>
+    ))}
+  </Render>
+);

--- a/src/ai-sdk/examples/multi-clip-branching.tsx
+++ b/src/ai-sdk/examples/multi-clip-branching.tsx
@@ -1,0 +1,61 @@
+import { elevenlabs } from "../elevenlabs-provider";
+import { fal } from "../fal-provider";
+import { Animate, Clip, Image, Render, Speech, Title } from "../react";
+
+// Non-linear tree: multiple clips with independent branches
+// Clip 1: TalkingHead (Image -> Animate + Speech)
+// Clip 2: Split comparison (2 independent Images)
+// Clip 3: Product shot with music
+
+const character = Image({
+  prompt: "friendly tech reviewer, young man with glasses, studio lighting, professional headshot",
+  model: fal.imageModel("flux-schnell"),
+});
+
+const productBefore = Image({
+  prompt: "old smartphone, cracked screen, slow, outdated design, on white background",
+  model: fal.imageModel("flux-schnell"),
+});
+
+const productAfter = Image({
+  prompt: "sleek new smartphone, edge-to-edge display, premium design, on white background",
+  model: fal.imageModel("flux-schnell"),
+});
+
+const packshot = Image({
+  prompt: "smartphone floating with gradient background, product photography, premium feel",
+  model: fal.imageModel("flux-schnell"),
+});
+
+export default (
+  <Render width={1080} height={1920}>
+    {/* Clip 1: Talking head intro */}
+    <Clip duration={5}>
+      <Animate
+        image={character}
+        model={fal.videoModel("wan-2.5")}
+        motion="talking naturally, slight head movements, friendly expression"
+      />
+      <Speech voice="adam" model={elevenlabs.speechModel("turbo")}>
+        Hey everyone! Today we're looking at the biggest smartphone upgrade of the year.
+      </Speech>
+    </Clip>
+
+    {/* Clip 2: Before/after comparison - branches into 2 images */}
+    <Clip duration={4} transition={{ name: "fade", duration: 0.5 }}>
+      <Image
+        prompt="split screen comparison layout"
+        model={fal.imageModel("flux-schnell")}
+      />
+      <Title position="top">Before vs After</Title>
+    </Clip>
+
+    {/* Clip 3: Product packshot */}
+    <Clip duration={3} transition={{ name: "fade", duration: 0.5 }}>
+      {packshot}
+      <Title position="bottom" color="#ffffff">
+        Available Now
+      </Title>
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/examples/onlyfans-1m/workflow.tsx
+++ b/src/ai-sdk/examples/onlyfans-1m/workflow.tsx
@@ -1,0 +1,88 @@
+/**
+ * OnlyFans-style selfie video workflow (React DSL)
+ *
+ * 1. Generate base girl image using Higgsfield Soul
+ * 2. Edit bra color using nano-banana-pro/edit
+ * 3. Generate 5 photos with different angles using nano-banana
+ * 4. Animate all with prompts (step back, turn left/right)
+ * 5. Concatenate into ~10 second video
+ *
+ * Run: bun run src/ai-sdk/react/cli.ts src/ai-sdk/examples/onlyfans-1m/workflow.tsx -o output/onlyfans-1m.mp4
+ *
+ * Required env: HIGGSFIELD_API_KEY, HIGGSFIELD_SECRET, FAL_KEY
+ */
+
+import { fal, higgsfield } from "../../index";
+import { Clip, Image, Render, Video } from "../../react";
+
+// ============================================================================
+// CHARACTER DEFINITION
+// ============================================================================
+
+const NEW_BRA_COLOR = "deep purple";
+
+// Base character prompt for Higgsfield
+const baseCharacter = Image({
+  prompt:
+    "A beautiful Slavic woman in her late 20s with platinum blonde hair, icy blue eyes, and perfect skin. She bends very close to the phone lens, her chest framed by a white sports bra with a bold neckline, and she is wearing high-waisted athletic shorts in pale grey that accentuate her figure. Her expression is confident and slightly teasing. The background shows a modern apartment with soft daylight through large windows, reinforcing the natural homemade vibe",
+  model: higgsfield.imageModel("soul", {
+    quality: "1080p",
+    styleId: higgsfield.styles.CAM_360,
+  }),
+  aspectRatio: "9:16",
+});
+
+// Recolor the bra using nano-banana
+const background = Image({
+  prompt: {
+    text: `Remove character from the image`,
+    images: [baseCharacter],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+const newBraCharacter = Image({
+  prompt: {
+    text: `Change the sports bra colour to ${NEW_BRA_COLOR}. Keep everything else exactly the same - same woman, same pose, same lighting, same background.`,
+    images: [baseCharacter, background],
+  },
+  model: fal.imageModel("seedream-v4.5/edit"),
+  aspectRatio: "9:16",
+});
+
+const newAngleCharacter = Image({
+  prompt: {
+    text: `Slightly change the pose of the character, keeping the same pose, lighting, and background. Put the character two steps aways from the`,
+    images: [newBraCharacter, background],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+  aspectRatio: "9:16",
+});
+
+const motionLeft = `A woman in stylish ${NEW_BRA_COLOR} sportswear takes a selfie. She starts very close to camera showing face and decolletage, then steps back to reveal more of her body. She turns slightly to the LEFT to show her figure in profile. Warm daylight, authentic homemade video feel. Camera static.`;
+
+export default (
+  <Render width={1080} height={1920}>
+    {/* Clip 1: Left angle, turns left */}
+    <Clip duration={3}>
+      <Video
+        prompt={{
+          images: [newBraCharacter],
+          text: motionLeft,
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+
+    <Clip duration={3}>
+      <Video
+        prompt={{
+          images: [newAngleCharacter],
+          text: motionLeft,
+        }}
+        model={fal.videoModel("kling-v2.5")}
+      />
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/examples/orange-portrait-cues.tsx
+++ b/src/ai-sdk/examples/orange-portrait-cues.tsx
@@ -1,0 +1,443 @@
+import { fal } from "../fal-provider";
+import { Clip, Image, Render, Video } from "../react";
+
+type Cue = { readonly _tag: string; readonly tokens: readonly string[] };
+
+const cue = <T extends string>(tag: T, tokens: readonly string[]): Cue & { _tag: T } => ({
+  _tag: tag,
+  tokens,
+});
+
+// =============================================================================
+// IMAGE CUES
+// =============================================================================
+
+const shot = {
+  extremeCloseUp: cue("shot", ["extreme close-up"]),
+  closeUp: cue("shot", ["close-up shot"]),
+  medium: cue("shot", ["medium shot"]),
+  full: cue("shot", ["full body shot"]),
+  wide: cue("shot", ["wide shot"]),
+  
+  eyeLevel: cue("shot", ["eye level angle"]),
+  lowAngle: cue("shot", ["low angle", "looking up"]),
+  highAngle: cue("shot", ["high angle", "looking down"]),
+  dutchAngle: cue("shot", ["dutch angle", "tilted frame"]),
+  birdsEye: cue("shot", ["bird's eye view", "overhead"]),
+  wormEye: cue("shot", ["worm's eye view", "ground level"]),
+  
+  frontView: cue("shot", ["front view", "facing camera"]),
+  threeQuarter: cue("shot", ["three-quarter view"]),
+  profile: cue("shot", ["profile view", "side angle"]),
+  overShoulder: cue("shot", ["over the shoulder"]),
+} as const;
+
+const subject = {
+  text: (description: string) => cue("subject", [description]),
+  fromRef: (refDescription: string) => cue("subject", [`exact likeness from reference: ${refDescription}`]),
+} as const;
+
+const pose = {
+  standing: cue("pose", ["standing"]),
+  sitting: cue("pose", ["sitting"]),
+  leaning: cue("pose", ["leaning"]),
+  walking: cue("pose", ["walking"]),
+  
+  confident: cue("pose", ["confident posture", "shoulders back"]),
+  relaxed: cue("pose", ["relaxed posture", "natural stance"]),
+  tense: cue("pose", ["tense posture", "stiff"]),
+  dynamic: cue("pose", ["dynamic pose", "movement implied"]),
+  
+  directGaze: cue("pose", ["looking directly at camera", "eye contact"]),
+  averted: cue("pose", ["gaze averted", "looking away"]),
+  downcast: cue("pose", ["eyes downcast", "looking down"]),
+  upward: cue("pose", ["looking upward"]),
+  
+  smiling: cue("pose", ["smiling"]),
+  serious: cue("pose", ["serious expression"]),
+  playful: cue("pose", ["playful expression"]),
+  contemplative: cue("pose", ["contemplative expression"]),
+  vulnerable: cue("pose", ["vulnerable expression"]),
+} as const;
+
+const lighting = {
+  soft: cue("lighting", ["soft diffused lighting"]),
+  hard: cue("lighting", ["hard lighting", "sharp shadows"]),
+  rim: cue("lighting", ["rim lighting", "edge highlights"]),
+  backlit: cue("lighting", ["backlit", "silhouette edges"]),
+  butterfly: cue("lighting", ["butterfly lighting", "shadow under nose"]),
+  rembrandt: cue("lighting", ["rembrandt lighting", "triangle on cheek"]),
+  split: cue("lighting", ["split lighting", "half face lit"]),
+  loop: cue("lighting", ["loop lighting", "small nose shadow"]),
+  
+  warmTemp: cue("lighting", ["warm color temperature", "golden tones"]),
+  coolTemp: cue("lighting", ["cool color temperature", "blue tones"]),
+  neutral: cue("lighting", ["neutral color temperature"]),
+  
+  orange: cue("lighting", ["orange light"]),
+  blue: cue("lighting", ["blue light"]),
+  purple: cue("lighting", ["purple light"]),
+  red: cue("lighting", ["red light"]),
+  green: cue("lighting", ["green light"]),
+  
+  highContrast: cue("lighting", ["high contrast", "deep shadows"]),
+  lowContrast: cue("lighting", ["low contrast", "flat lighting"]),
+  
+  fromLeft: cue("lighting", ["light from left"]),
+  fromRight: cue("lighting", ["light from right"]),
+  fromAbove: cue("lighting", ["light from above"]),
+  fromBelow: cue("lighting", ["light from below", "underlighting"]),
+} as const;
+
+const frame = {
+  centered: cue("frame", ["centered framing"]),
+  ruleOfThirds: cue("frame", ["rule of thirds"]),
+  goldenRatio: cue("frame", ["golden ratio composition"]),
+  symmetrical: cue("frame", ["symmetrical framing"]),
+  asymmetrical: cue("frame", ["asymmetrical framing"]),
+  
+  tightCrop: cue("frame", ["tight crop"]),
+  looseCrop: cue("frame", ["loose crop", "breathing room"]),
+  headroom: cue("frame", ["minimal headroom"]),
+  
+  dutchTilt: cue("frame", ["slight dutch tilt"]),
+  straightHorizon: cue("frame", ["level horizon"]),
+} as const;
+
+const lens = {
+  mm85: cue("lens", ["85mm lens", "portrait focal length"]),
+  mm50: cue("lens", ["50mm lens", "natural perspective"]),
+  mm35: cue("lens", ["35mm lens", "slight wide angle"]),
+  mm24: cue("lens", ["24mm lens", "wide angle"]),
+  mm135: cue("lens", ["135mm lens", "telephoto compression"]),
+  
+  f14: cue("lens", ["f/1.4 aperture", "shallow depth of field"]),
+  f18: cue("lens", ["f/1.8 aperture", "shallow depth of field"]),
+  f28: cue("lens", ["f/2.8 aperture", "moderate bokeh"]),
+  f4: cue("lens", ["f/4 aperture"]),
+  f8: cue("lens", ["f/8 aperture", "deep focus"]),
+  
+  shallowDof: cue("lens", ["shallow depth of field", "bokeh background"]),
+  deepDof: cue("lens", ["deep depth of field", "everything sharp"]),
+} as const;
+
+const expression = {
+  confident: cue("expression", ["confident expression", "self-assured"]),
+  playful: cue("expression", ["playful expression", "slight smirk"]),
+  serious: cue("expression", ["serious expression", "intense gaze"]),
+  neutral: cue("expression", ["neutral expression", "composed"]),
+  vulnerable: cue("expression", ["vulnerable expression", "soft gaze"]),
+  surprised: cue("expression", ["surprised expression", "wide eyes"]),
+  joyful: cue("expression", ["joyful expression", "genuine smile"]),
+  contemplative: cue("expression", ["contemplative expression", "thoughtful"]),
+  fierce: cue("expression", ["fierce expression", "intense"]),
+  serene: cue("expression", ["serene expression", "peaceful"]),
+} as const;
+
+const skin = {
+  smooth: cue("skin", ["smooth skin", "soft texture"]),
+  textured: cue("skin", ["visible skin texture", "pores visible"]),
+  dewy: cue("skin", ["dewy skin", "slight sheen"]),
+  matte: cue("skin", ["matte skin", "no shine"]),
+  freckled: cue("skin", ["freckled skin"]),
+  weathered: cue("skin", ["weathered skin", "character lines"]),
+} as const;
+
+const wardrobe = {
+  casual: cue("wardrobe", ["casual clothing"]),
+  formal: cue("wardrobe", ["formal attire"]),
+  streetwear: cue("wardrobe", ["streetwear"]),
+  elegant: cue("wardrobe", ["elegant clothing"]),
+  minimal: cue("wardrobe", ["minimal clothing"]),
+  
+  fitted: cue("wardrobe", ["fitted clothing"]),
+  loose: cue("wardrobe", ["loose clothing"]),
+  oversized: cue("wardrobe", ["oversized fit"]),
+  
+  cotton: cue("wardrobe", ["cotton fabric"]),
+  silk: cue("wardrobe", ["silk fabric", "shiny material"]),
+  leather: cue("wardrobe", ["leather material"]),
+  denim: cue("wardrobe", ["denim fabric"]),
+  knit: cue("wardrobe", ["knit fabric", "textured weave"]),
+  velvet: cue("wardrobe", ["velvet fabric", "soft sheen"]),
+} as const;
+
+const accessories = {
+  earrings: cue("accessories", ["earrings"]),
+  hoops: cue("accessories", ["hoop earrings"]),
+  studs: cue("accessories", ["stud earrings"]),
+  necklace: cue("accessories", ["necklace"]),
+  rings: cue("accessories", ["rings"]),
+  bracelet: cue("accessories", ["bracelet"]),
+  watch: cue("accessories", ["watch"]),
+  glasses: cue("accessories", ["glasses"]),
+  sunglasses: cue("accessories", ["sunglasses"]),
+  hat: cue("accessories", ["hat"]),
+  
+  gold: cue("accessories", ["gold jewelry", "warm metal"]),
+  silver: cue("accessories", ["silver jewelry", "cool metal"]),
+  catching: cue("accessories", ["catching light", "reflective"]),
+} as const;
+
+const environment = {
+  studio: cue("environment", ["studio setting"]),
+  outdoor: cue("environment", ["outdoor setting"]),
+  urban: cue("environment", ["urban environment", "city"]),
+  nature: cue("environment", ["natural environment"]),
+  interior: cue("environment", ["interior setting"]),
+  
+  blackBg: cue("environment", ["black background", "void"]),
+  whiteBg: cue("environment", ["white background", "clean"]),
+  gradientBg: cue("environment", ["gradient background"]),
+  
+  concrete: cue("environment", ["concrete surfaces"]),
+  brick: cue("environment", ["brick walls"]),
+  wood: cue("environment", ["wooden surfaces"]),
+  metal: cue("environment", ["metal surfaces"]),
+  
+  foggy: cue("environment", ["foggy atmosphere", "haze"]),
+  dusty: cue("environment", ["dusty atmosphere", "particles"]),
+  rainy: cue("environment", ["rain", "wet surfaces"]),
+  smoky: cue("environment", ["smoke", "atmospheric"]),
+} as const;
+
+const texture = {
+  filmGrain: cue("texture", ["subtle film grain"]),
+  noiseGrain: cue("texture", ["digital noise"]),
+  clean: cue("texture", ["clean image", "no grain"]),
+  
+  sharpFocus: cue("texture", ["sharp focus", "crisp details"]),
+  softFocus: cue("texture", ["soft focus", "dreamy"]),
+  
+  fabricDetail: cue("texture", ["visible fabric texture"]),
+  skinDetail: cue("texture", ["visible skin detail"]),
+  metalDetail: cue("texture", ["metal reflections", "specular highlights"]),
+  hairDetail: cue("texture", ["individual hair strands visible"]),
+} as const;
+
+const era = {
+  modern: cue("era", ["modern", "contemporary"]),
+  vintage: cue("era", ["vintage aesthetic"]),
+  retro70s: cue("era", ["1970s aesthetic", "retro"]),
+  retro80s: cue("era", ["1980s aesthetic"]),
+  retro90s: cue("era", ["1990s aesthetic"]),
+  y2k: cue("era", ["Y2K aesthetic", "early 2000s"]),
+  
+  digitalCamera: cue("era", ["digital camera"]),
+  filmCamera: cue("era", ["shot on film"]),
+  polaroid: cue("era", ["polaroid style"]),
+  mediumFormat: cue("era", ["medium format film"]),
+  dslr: cue("era", ["DSLR quality"]),
+  cinematic: cue("era", ["cinematic camera", "anamorphic"]),
+} as const;
+
+const style = {
+  editorial: cue("style", ["high-end fashion editorial", "magazine quality"]),
+  cinematic: cue("style", ["cinematic", "movie still"]),
+  documentary: cue("style", ["documentary style", "candid"]),
+  portrait: cue("style", ["professional portrait"]),
+  artistic: cue("style", ["artistic", "creative"]),
+  commercial: cue("style", ["commercial photography"]),
+  streetPhoto: cue("style", ["street photography"]),
+  fineart: cue("style", ["fine art photography"]),
+  noir: cue("style", ["noir aesthetic"]),
+  glamour: cue("style", ["glamour photography"]),
+} as const;
+
+// =============================================================================
+// VIDEO CUES
+// =============================================================================
+
+const motion = {
+  stepsBack: cue("motion", ["steps backward", "reveals more of body"]),
+  stepsForward: cue("motion", ["steps forward", "approaches camera"]),
+  turnsHead: cue("motion", ["turns head", "looks to side"]),
+  turnsSide: cue("motion", ["turns body to side", "shows profile"]),
+  tiltsHead: cue("motion", ["tilts head slightly"]),
+  looksUp: cue("motion", ["looks upward"]),
+  looksDown: cue("motion", ["looks downward"]),
+  blinks: cue("motion", ["blinks naturally"]),
+  smiles: cue("motion", ["smile grows", "expression warms"]),
+  still: cue("motion", ["remains still", "subtle breathing only"]),
+  walks: cue("motion", ["walks", "in motion"]),
+  runs: cue("motion", ["runs", "fast movement"]),
+  gestures: cue("motion", ["hand gestures", "expressive hands"]),
+} as const;
+
+const camera = {
+  static: cue("camera", ["camera static", "locked off", "no movement"]),
+  slowPush: cue("camera", ["slow push in", "dolly forward"]),
+  slowPull: cue("camera", ["slow pull back", "dolly backward"]),
+  pan: cue("camera", ["slow pan", "horizontal movement"]),
+  tilt: cue("camera", ["slow tilt", "vertical movement"]),
+  handheld: cue("camera", ["subtle handheld", "organic movement"]),
+  orbit: cue("camera", ["slow orbit", "circles subject"]),
+  crane: cue("camera", ["crane movement", "vertical sweep"]),
+  tracking: cue("camera", ["tracking shot", "follows subject"]),
+  whip: cue("camera", ["whip pan", "fast movement"]),
+} as const;
+
+const mood = {
+  authentic: cue("mood", ["authentic", "genuine"]),
+  playful: cue("mood", ["playful", "lighthearted"]),
+  intense: cue("mood", ["intense", "dramatic"]),
+  calm: cue("mood", ["calm", "serene"]),
+  energetic: cue("mood", ["energetic", "dynamic"]),
+  mysterious: cue("mood", ["mysterious", "enigmatic"]),
+  romantic: cue("mood", ["romantic", "soft"]),
+  melancholic: cue("mood", ["melancholic", "wistful"]),
+} as const;
+
+// =============================================================================
+// TYPE DEFINITIONS
+// =============================================================================
+
+type ShotCue = (typeof shot)[keyof typeof shot];
+type SubjectCue = ReturnType<typeof subject.text> | ReturnType<typeof subject.fromRef>;
+type PoseCue = (typeof pose)[keyof typeof pose];
+type ExpressionCue = (typeof expression)[keyof typeof expression];
+type LightingCue = (typeof lighting)[keyof typeof lighting];
+type FrameCue = (typeof frame)[keyof typeof frame];
+type LensCue = (typeof lens)[keyof typeof lens];
+type SkinCue = (typeof skin)[keyof typeof skin];
+type WardrobeCue = (typeof wardrobe)[keyof typeof wardrobe];
+type AccessoriesCue = (typeof accessories)[keyof typeof accessories];
+type EnvironmentCue = (typeof environment)[keyof typeof environment];
+type TextureCue = (typeof texture)[keyof typeof texture];
+type EraCue = (typeof era)[keyof typeof era];
+type StyleCue = (typeof style)[keyof typeof style];
+type MotionCue = (typeof motion)[keyof typeof motion];
+type CameraCue = (typeof camera)[keyof typeof camera];
+type MoodCue = (typeof mood)[keyof typeof mood];
+
+type CueInput<T extends Cue> = T | [T, ...(T | string)[]];
+
+type ImageShotConfig = {
+  shot: CueInput<ShotCue>;
+  subject: CueInput<SubjectCue>;
+  pose: CueInput<PoseCue>;
+  expression: CueInput<ExpressionCue>;
+  lighting: CueInput<LightingCue>;
+  frame: CueInput<FrameCue>;
+  lens: CueInput<LensCue>;
+  
+  skin?: CueInput<SkinCue>;
+  wardrobe?: CueInput<WardrobeCue>;
+  accessories?: CueInput<AccessoriesCue>;
+  environment?: CueInput<EnvironmentCue>;
+  texture?: CueInput<TextureCue>;
+  era?: CueInput<EraCue>;
+  style?: CueInput<StyleCue>;
+};
+
+type VideoShotConfig = {
+  motion: CueInput<MotionCue>;
+  camera: CueInput<CameraCue>;
+  lighting?: CueInput<LightingCue>;
+  mood?: CueInput<MoodCue>;
+};
+
+// =============================================================================
+// PROMPT BUILDERS
+// =============================================================================
+
+function normalizeCue(input: Cue | (Cue | string)[]): string[] {
+  if (Array.isArray(input)) {
+    return input.flatMap((item) => (typeof item === "string" ? [item] : [...item.tokens]));
+  }
+  return [...input.tokens];
+}
+
+function imageShot(config: ImageShotConfig): string {
+  const sections: string[][] = [
+    normalizeCue(config.shot),
+    normalizeCue(config.subject),
+    config.skin ? normalizeCue(config.skin) : [],
+    config.wardrobe ? normalizeCue(config.wardrobe) : [],
+    config.accessories ? normalizeCue(config.accessories) : [],
+    normalizeCue(config.pose),
+    normalizeCue(config.expression),
+    config.environment ? normalizeCue(config.environment) : [],
+    normalizeCue(config.lighting),
+    normalizeCue(config.frame),
+    normalizeCue(config.lens),
+    config.texture ? normalizeCue(config.texture) : [],
+    config.era ? normalizeCue(config.era) : [],
+    config.style ? normalizeCue(config.style) : [],
+  ];
+  return sections
+    .filter((s) => s.length > 0)
+    .map((s) => s.join(", "))
+    .join(". ") + ".";
+}
+
+function videoShot(config: VideoShotConfig): string {
+  const sections: string[][] = [
+    normalizeCue(config.motion),
+    normalizeCue(config.camera),
+    config.lighting ? normalizeCue(config.lighting) : [],
+    config.mood ? normalizeCue(config.mood) : [],
+  ];
+  return sections
+    .filter((s) => s.length > 0)
+    .map((s) => s.join(", "))
+    .join(". ") + ".";
+}
+
+// =============================================================================
+// EXAMPLE USAGE
+// =============================================================================
+
+const portraitPrompt = imageShot({
+  shot: [shot.closeUp, shot.threeQuarter, shot.eyeLevel],
+  subject: subject.fromRef("young woman, short dark brown bob, wispy bangs, large dark brown eyes, full lips"),
+  pose: [pose.confident, pose.directGaze, "relaxed shoulders"],
+  lighting: [lighting.rim, "low contrast lighting", "soft lighting", "warm edge highlights"],
+  frame: [frame.centered],
+  lens: [lens.mm85, lens.f14],
+  expression: expression.confident,
+  
+  skin: [skin.smooth, skin.dewy],
+  wardrobe: [wardrobe.knit, wardrobe.fitted, "bright red cropped sweater"],
+  accessories: [accessories.hoops, accessories.silver, accessories.catching],
+  environment: [environment.blackBg, "diagonal orange geometric shapes"],
+  texture: [texture.filmGrain, texture.hairDetail],
+  era: era.modern,
+  style: style.editorial,
+});
+
+const videoPrompt = videoShot({
+  motion: [motion.stepsBack, "revealing full body gradually ", "then turns slightly to show profile"],
+  camera: camera.static,
+  lighting: [lighting.rim, lighting.orange],
+  mood: [mood.authentic, mood.playful],
+});
+
+console.log("Image prompt:", portraitPrompt);
+console.log("Video prompt:", videoPrompt);
+
+const character = Image({
+  prompt: {
+    text: portraitPrompt,
+    images: [
+      "https://s3.varg.ai/uploads/images/1_0475e227.png",
+      "https://s3.varg.ai/uploads/images/xyearp51qvve-zi3nrcve-zbno2hfgt5gergjrof_995f553d.png",
+    ],
+  },
+  model: fal.imageModel("nano-banana-pro/edit"),
+});
+
+export default (
+  <Render width={1080} height={1920}>
+    <Clip duration={5}>
+      <Video
+        prompt={{
+          images: [character],
+          text: videoPrompt,
+        }}
+        model={fal.videoModel("kling-v2.5")}
+        duration={5}
+      />
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/examples/orange-portrait-new-syntax.tsx
+++ b/src/ai-sdk/examples/orange-portrait-new-syntax.tsx
@@ -1,0 +1,142 @@
+import { openai } from "@ai-sdk/openai";
+import type { ImageModelV3 } from "@ai-sdk/provider";
+import { generateText } from "ai";
+import { fal } from "../fal-provider";
+import { Clip, Image, Render, Video, type VargElement } from "../react";
+import type { VideoModelV3 } from "../video-model";
+
+// character: young woman, short dark brown bob with wispy bangs, oval face, fair skin,
+// large dark brown eyes, full lips, silver hoop earrings
+// style: deep black bg, dramatic orange rim lighting, noir/premium aesthetic
+const setting = async (params: {
+  model: any;
+  position: string;
+  motion: string;
+  lighting: string;
+}) => {
+  const result = await generateText({
+    model: params.model,
+    prompt: `${params.position} ${params.motion} ${params.lighting}`,
+  });
+  return result.text;
+};
+
+const optimize = async (
+  text: string,
+  options: {
+    model: VideoModelV3 | ImageModelV3;
+    params: Record<string, string>;
+  },
+) => {
+  const paramsString = Object.entries(options.params)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(", ");
+
+  const optimized = await generateText({
+    model: openai("gpt-5-nano"),
+    prompt: `optimize prompt: ${text} for ${options.model.provider} ${options.model.modelId}, add the following parameters: ${paramsString}`,
+  });
+
+  return optimized.text;
+};
+
+function combine(strings: TemplateStringsArray, ...values: string[]) {
+  return strings.reduce((acc, str, i) => acc + str + (values[i] || ""), "");
+}
+
+const LIGHTING = {
+  STUDIO: "studio",
+  ORANGE_RIM: "orange rim lighting",
+  OUTDOORS: "outdoors",
+  NOIR: "noir",
+  PREMIUM: "premium aesthetic",
+} as const;
+
+const POSITION = {
+  THREE_QUARTER: "three-quarter angle",
+  PROFILE: "profile view",
+  FRONT: "front view",
+  CLOSE_UP: "close-up",
+  SIDE_PROFILE: "side profile",
+  WIDE_SHOT: "wide shot",
+  THREE_QUARTER_FRONT: "three-quarter front view",
+} as const;
+
+const CAMERA_MOVEMENT = {
+  BACK_SLOWLY: "camera moves back slowly",
+  DOLLY_IN: "camera dollys in",
+  STATIC: "camera static",
+} as const;
+
+const MOTION = {
+  STEPS_BACK: "She steps back",
+  LOOKS_AT_CAMERA: "She looks at camera",
+  TURNS_SLIGHTLY: "She turns slightly to the side",
+} as const;
+
+const context = await setting({
+  model: fal.imageModel("nano-banana-pro/edit"),
+  lighting: LIGHTING.STUDIO,
+  position: POSITION.THREE_QUARTER,
+  motion: MOTION.STEPS_BACK,
+});
+
+console.log("DEBUG MOTION", context);
+
+const Optimize = ({
+  text,
+  for: model,
+  params,
+}: {
+  text: string;
+  for: VideoModelV3 | ImageModelV3;
+  params: Record<string, string>;
+}): VargElement => {
+  const optimized = optimize(text, { model, params });
+  return <>{optimized}</>;
+};
+
+export default (
+  <Render width={1080} height={1920}>
+    <Clip duration={5}>
+      <Video
+        prompt={{
+          images: [
+            Image({
+              prompt: {
+                text: `Using the attached reference images, generate a photorealistic Three-quarter editorial portrait of the exact same character — maintain identical face, hairstyle, and proportions from Image 1.
+
+                Framing: Head and shoulders, cropped at upper chest. Direct eye contact with camera.
+
+                Natural confident expression, relaxed shoulders.
+                Preserve the outfit neckline and visible clothing details from reference.
+
+                Background: Deep black with two contrasting orange gradient accents matching Reference 2. Soft gradient bleed, no hard edges.
+
+                Shot on 85mm f/1.4 lens, shallow depth of field. Clean studio lighting — soft key light on face, subtle rim light on hair and shoulders for separation. High-end fashion editorial aesthetic.`,
+                images: [
+                  "https://s3.varg.ai/uploads/images/1_0475e227.png",
+                  "https://s3.varg.ai/uploads/images/xyearp51qvve-zi3nrcve-zbno2hfgt5gergjrof_995f553d.png",
+                ],
+              },
+              model: fal.imageModel("nano-banana-pro/edit"),
+            }),
+          ],
+          text: String(
+            <Optimize
+              text={`girl with a bob`}
+              params={{
+                lighting: "dramatic orange",
+                position: POSITION.THREE_QUARTER,
+                motion: MOTION.STEPS_BACK,
+              }}
+              for={fal.videoModel("kling-v2.5")}
+            />,
+          ),
+        }}
+        model={fal.videoModel("kling-v2.5")}
+        duration={5}
+      />
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/examples/orange-portrait.tsx
+++ b/src/ai-sdk/examples/orange-portrait.tsx
@@ -1,0 +1,41 @@
+import { fal } from "../fal-provider";
+import { Clip, Image, Render, Video } from "../react";
+
+// character: young woman, short dark brown bob with wispy bangs, oval face, fair skin,
+// large dark brown eyes, full lips, silver hoop earrings
+// style: deep black bg, dramatic orange rim lighting, noir/premium aesthetic
+
+export default (
+  <Render width={1080} height={1920}>
+    <Clip duration={5}>
+      <Video
+        prompt={{
+          text: "She steps back, camera reveals more of her body until she appears fully in frame. Studio lighting, authentic confident slightly playful atmosphere. Camera static. She poses naturally, first looking straight at camera, then turning slightly to the side to show her figure in profile. Intense orange lighting.",
+          images: [
+            Image({
+              prompt: {
+                text: `Using the attached reference images, generate a photorealistic Three-quarter editorial portrait of the exact same character — maintain identical face, hairstyle, and proportions from Image 1.
+
+                Framing: Head and shoulders, cropped at upper chest. Direct eye contact with camera.
+
+                Natural confident expression, relaxed shoulders.
+                Preserve the outfit neckline and visible clothing details from reference.
+
+                Background: Deep black with two contrasting orange gradient accents matching Reference 2. Soft gradient bleed, no hard edges.
+
+                Shot on 85mm f/1.4 lens, shallow depth of field. Clean studio lighting — soft key light on face, subtle rim light on hair and shoulders for separation. High-end fashion editorial aesthetic.`,
+                images: [
+                  "https://s3.varg.ai/uploads/images/1_0475e227.png",
+                  "https://s3.varg.ai/uploads/images/xyearp51qvve-zi3nrcve-zbno2hfgt5gergjrof_995f553d.png",
+                ],
+              },
+              model: fal.imageModel("nano-banana-pro/edit"),
+            }),
+          ],
+        }}
+        model={fal.videoModel("kling-v2.5")}
+        duration={5}
+      />
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/examples/ralph-crypto.tsx
+++ b/src/ai-sdk/examples/ralph-crypto.tsx
@@ -1,0 +1,61 @@
+import { fal } from "../fal-provider";
+import { Clip, Image, Render, render, Title } from "../react";
+
+const script = `Hi, I'm Ralph! My cat's breath smells like cat food. 
+Also I invested my lunch money in dogecoin. 
+Now I live in a box. But it's a nice box! 
+It has a window. The window is a hole.`;
+
+async function main() {
+  console.log("rendering ralph crypto video...\n");
+
+  const video = (
+    <Render width={1080} height={1920}>
+      <Clip duration={4}>
+        <Image
+          prompt="ralph wiggum, simpsons style, innocent smile, slightly confused, holding phone showing crypto chart going down"
+          model={fal.imageModel("flux-schnell")}
+          zoom="in"
+        />
+        <Title position="bottom" color="#ffff00">
+          FINANCIAL ADVICE
+        </Title>
+      </Clip>
+
+      <Clip duration={3} transition={{ name: "fade", duration: 0.5 }}>
+        <Image
+          prompt="ralph wiggum looking at empty wallet, simpsons style, confused but happy"
+          model={fal.imageModel("flux-schnell")}
+          zoom="out"
+        />
+        <Title position="bottom" color="#ffffff">
+          IM IN DANGER
+        </Title>
+      </Clip>
+
+      <Clip duration={3} transition={{ name: "fade", duration: 0.5 }}>
+        <Image
+          prompt="ralph wiggum in cardboard box, happy, simpsons style, box has 'CEO' written on it"
+          model={fal.imageModel("flux-schnell")}
+          zoom="in"
+        />
+        <Title position="bottom" color="#ffffff">
+          @RalphInvests
+        </Title>
+      </Clip>
+    </Render>
+  );
+
+  console.log("script:", script);
+  console.log("\nvideo tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/ralph-crypto.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/ralph-crypto.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/examples/ralph-talking-studio.tsx
+++ b/src/ai-sdk/examples/ralph-talking-studio.tsx
@@ -1,0 +1,61 @@
+import { elevenlabs } from "../elevenlabs-provider";
+import { fal } from "../fal-provider";
+import {
+  Animate,
+  Clip,
+  Image,
+  Render,
+  Speech,
+  Title,
+} from "../react";
+
+const TalkingHead = ({
+  character,
+  voice,
+  children,
+}: {
+  character: string;
+  voice: string;
+  children: string;
+}) => (
+  <>
+    <Animate
+      image={Image({
+        prompt: character,
+        model: fal.imageModel("flux-schnell"),
+      })}
+      model={fal.videoModel("wan-2.5")}
+      motion="subtle head movements, blinking, mouth moving"
+    />
+    <Speech voice={voice} model={elevenlabs.speechModel("turbo")}>
+      {children}
+    </Speech>
+  </>
+);
+
+const script = `Hi, I'm Ralph! My cat's breath smells like cat food. 
+Also I invested my lunch money in dogecoin. 
+Now I live in a box. But it's a nice box! 
+It has a window. The window is a hole.`;
+
+export default (
+  <Render width={1080} height={1920}>
+    <Clip duration={10}>
+      <TalkingHead
+        character="ralph wiggum, simpsons style, innocent smile, slightly confused"
+        voice="adam"
+      >
+        {script}
+      </TalkingHead>
+    </Clip>
+
+    <Clip duration={2} transition={{ name: "fade", duration: 0.5 }}>
+      <Image
+        prompt="ralph wiggum in cardboard box, happy, simpsons style"
+        model={fal.imageModel("flux-schnell")}
+        zoom="in"
+      />
+      <Title position="bottom">@RalphInvests</Title>
+    </Clip>
+  </Render>
+);

--- a/src/ai-sdk/examples/ralph-talking.tsx
+++ b/src/ai-sdk/examples/ralph-talking.tsx
@@ -1,0 +1,81 @@
+import { elevenlabs } from "../elevenlabs-provider";
+import { fal } from "../fal-provider";
+import {
+  Animate,
+  Clip,
+  Image,
+  Render,
+  render,
+  Speech,
+  Title,
+  type VargElement,
+} from "../react";
+
+// TalkingHead is just a composition of primitives
+const TalkingHead = ({
+  character,
+  voice,
+  children,
+}: {
+  character: string;
+  voice: string;
+  children: string;
+}) => (
+  <>
+    <Animate
+      image={Image({
+        prompt: character,
+        model: fal.imageModel("flux-schnell"),
+      })}
+      model={fal.videoModel("wan-2.5")}
+      motion="subtle head movements, blinking, mouth moving"
+    />
+    <Speech voice={voice} model={elevenlabs.speechModel("turbo")}>
+      {children}
+    </Speech>
+  </>
+);
+
+const script = `Hi, I'm Ralph! My cat's breath smells like cat food. 
+Also I invested my lunch money in dogecoin. 
+Now I live in a box. But it's a nice box! 
+It has a window. The window is a hole.`;
+
+async function main() {
+  console.log("rendering ralph talking head...\n");
+  console.log("script:", script);
+
+  const video = (
+    <Render width={1080} height={1920}>
+      <Clip duration={10}>
+        <TalkingHead
+          character="ralph wiggum, simpsons style, innocent smile, slightly confused"
+          voice="adam"
+        >
+          {script}
+        </TalkingHead>
+      </Clip>
+
+      <Clip duration={2} transition={{ name: "fade", duration: 0.5 }}>
+        <Image
+          prompt="ralph wiggum in cardboard box, happy, simpsons style"
+          model={fal.imageModel("flux-schnell")}
+          zoom="in"
+        />
+        <Title position="bottom">@RalphInvests</Title>
+      </Clip>
+    </Render>
+  );
+
+  console.log("\nvideo tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/ralph-talking.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/ralph-talking.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/examples/ralph.tsx
+++ b/src/ai-sdk/examples/ralph.tsx
@@ -1,0 +1,39 @@
+import { fal } from "../fal-provider";
+import { Clip, Image, Render, Subtitle, Title, Video } from "../react";
+
+export const Ralph = (
+  <Render width={1080} height={1920}>
+    <Clip duration={5}>
+      <Video
+        prompt={{
+          text: "ralph says 'I'm in danger'",
+          images: [
+            Image({
+              prompt: {
+                text: "ralph staring blankly",
+                images: ["./media/ralph.jpg"],
+              },
+              model: fal.imageModel("nano-banana-pro/edit"),
+            }),
+          ],
+        }}
+        model={fal.videoModel("wan-2.5")}
+        duration={5}
+        keepAudio
+      />
+
+      {/* centered title */}
+      <Title>I'M IN DANGER</Title>
+
+      {/* positioned title */}
+      <Title position="top" color="#ffffff">
+        Episode 1
+      </Title>
+
+      {/* subtitle with background */}
+      <Subtitle>the beginning of something special</Subtitle>
+    </Clip>
+  </Render>
+);
+
+export default Ralph;

--- a/src/ai-sdk/examples/react-grid.tsx
+++ b/src/ai-sdk/examples/react-grid.tsx
@@ -1,0 +1,53 @@
+import { fal } from "../fal-provider";
+import { Clip, Grid, Image, Render, render, Title } from "../react";
+
+const CHARACTER_PROMPTS = [
+  { name: "Warrior", prompt: "fierce warrior with sword, armor" },
+  { name: "Mage", prompt: "mystical mage with glowing staff, robes" },
+  { name: "Rogue", prompt: "stealthy rogue with daggers, hooded" },
+  { name: "Healer", prompt: "gentle healer with staff, white robes" },
+  { name: "Archer", prompt: "skilled archer with bow, leather armor" },
+  { name: "Knight", prompt: "noble knight with shield, heavy armor" },
+  { name: "Necro", prompt: "dark necromancer with skull staff" },
+  { name: "Paladin", prompt: "holy paladin with hammer, golden armor" },
+  { name: "Bard", prompt: "charismatic bard with lute, colorful" },
+  { name: "Druid", prompt: "nature druid with wooden staff, leaves" },
+  { name: "Monk", prompt: "disciplined monk with wrapped fists" },
+  { name: "Assassin", prompt: "deadly assassin with hidden blades" },
+];
+
+async function main() {
+  console.log("creating 3x4 character grid...\n");
+
+  const baseStyle = "fantasy portrait, stylized art, vibrant colors";
+
+  const images = CHARACTER_PROMPTS.map(({ prompt }) =>
+    Image({
+      prompt: `${prompt}, ${baseStyle}`,
+      model: fal.imageModel("flux-schnell"),
+    })
+  );
+
+  const video = (
+    <Render width={1080} height={1440}>
+      <Clip duration={5}>
+        <Grid columns={3} children={images} />
+        <Title position="bottom" color="#ffffff">
+          Fantasy Characters
+        </Title>
+      </Clip>
+    </Render>
+  );
+
+  console.log("video tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/react-grid.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/react-grid.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/examples/react-madi.tsx
+++ b/src/ai-sdk/examples/react-madi.tsx
@@ -1,0 +1,84 @@
+import { elevenlabs } from "../elevenlabs-provider";
+import { fal } from "../fal-provider";
+import { Animate, Clip, Image, Music, Render, render } from "../react";
+
+const MADI_REF =
+  "https://s3.varg.ai/fellowers/madi/character_shots/madi_shot_03_closeup.png";
+
+// TikTok timeline structure:
+// 0-2s: HOOK - frontal close-up, grab attention
+// 2-4s: 45° medium shot + expression change
+// 4-6s: low angle or extreme close-up
+// 6-8s: high angle + new emotion
+const SCENES = [
+  {
+    // 0-2s: HOOK - frontal extreme close-up, surprised/curious expression
+    prompt:
+      "extreme close-up face shot, surprised expression with wide eyes, looking directly at camera, holding peach near lips",
+    motion:
+      "eyes widen in surprise, eyebrows raise slightly, subtle head tilt forward. Static shot, no camera movement.",
+  },
+  {
+    // 2-4s: 45° medium shot, playful grimace while eating
+    prompt:
+      "45-degree angle medium shot showing face and hands, biting into peach with exaggerated enjoyment, juice on lips, playful expression",
+    motion:
+      "turns head 45 degrees, bites into peach, juice drips down chin, hands move expressively. Slow push-in camera movement.",
+  },
+  {
+    // 4-6s: low angle (up shot), confident/powerful vibe
+    prompt:
+      "low angle shot from below, looking down at camera with confident smirk, holding peach triumphantly, dramatic perspective",
+    motion:
+      "looks down at camera with growing smile, raises peach slightly, confident head tilt. Static camera, slight lens distortion.",
+  },
+  {
+    // 6-8s: high angle (down shot), playful vulnerability + CTA energy
+    prompt:
+      "high angle shot from above, looking up at camera with playful smile, arms spread wide, peach in one hand, endearing expression",
+    motion:
+      "looks up at camera, expression shifts from neutral to excited smile, subtle wink, slight forward lean. Gentle camera tilt down.",
+  },
+];
+
+async function main() {
+  console.log("creating madi peach video (animated)...\n");
+
+  const video = (
+    <Render width={1080} height={1920}>
+      <Music
+        prompt="upbeat electronic pop, energetic female vocal chops, modern tiktok vibe, catchy melody"
+        model={elevenlabs.musicModel()}
+        duration={8}
+      />
+
+      {SCENES.map((scene, i) => (
+        <Clip key={i} duration={2}>
+          <Animate
+            image={Image({
+              prompt: { text: scene.prompt, images: [MADI_REF] },
+              model: fal.imageModel("nano-banana-pro/edit"),
+              aspectRatio: "9:16",
+              resize: "cover",
+            })}
+            motion={scene.motion}
+            model={fal.videoModel("wan-2.5")}
+            duration={5}
+          />
+        </Clip>
+      ))}
+    </Render>
+  );
+
+  console.log("rendering", SCENES.length, "animated clips in parallel...");
+
+  const buffer = await render(video, {
+    output: "output/react-madi.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/react-madi.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/examples/react-overlay-test.tsx
+++ b/src/ai-sdk/examples/react-overlay-test.tsx
@@ -1,0 +1,53 @@
+import { fal } from "../fal-provider";
+import { Clip, Image, Overlay, Render, render, Title, Video } from "../react";
+
+async function main() {
+  console.log("testing continuous overlay...\n");
+
+  const video = (
+    <Render width={1280} height={720} fps={30}>
+      <Overlay left="73%" top="73%" width="25%" height="25%" keepAudio>
+        <Video src="./output/workflow-talking-synced.mp4" keepAudio />
+      </Overlay>
+
+      <Clip duration={2}>
+        <Image
+          prompt="modern coffee shop interior, warm lighting"
+          model={fal.imageModel("flux-schnell")}
+          zoom="in"
+        />
+        <Title position="bottom">Scene 1: Coffee Shop</Title>
+      </Clip>
+
+      <Clip duration={2} transition={{ name: "fade", duration: 0.3 }}>
+        <Image
+          prompt="beautiful park with autumn leaves, golden hour"
+          model={fal.imageModel("flux-schnell")}
+          zoom="out"
+        />
+        <Title position="bottom">Scene 2: Park Walk</Title>
+      </Clip>
+
+      <Clip duration={2} transition={{ name: "fade", duration: 0.3 }}>
+        <Image
+          prompt="cozy home office with big window, modern desk"
+          model={fal.imageModel("flux-schnell")}
+          zoom="in"
+        />
+        <Title position="bottom">Scene 3: Home Office</Title>
+      </Clip>
+    </Render>
+  );
+
+  console.log("video tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/react-overlay-test.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/react-overlay-test.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/examples/react-split.tsx
+++ b/src/ai-sdk/examples/react-split.tsx
@@ -1,0 +1,39 @@
+import { fal } from "../fal-provider";
+import { Clip, Image, Render, render, SplitLayout as Split, Title } from "../react";
+
+async function main() {
+  console.log("creating before/after split screen...\n");
+
+  const before = Image({
+    prompt: "overweight man sitting on couch, tired expression, pale skin, messy hair, wearing stained t-shirt",
+    model: fal.imageModel("flux-schnell"),
+  });
+
+  const after = Image({
+    prompt: "fit muscular man standing confidently, tanned skin, bright smile, wearing fitted athletic shirt",
+    model: fal.imageModel("flux-schnell"),
+  });
+
+  const video = (
+    <Render width={1920} height={1080}>
+      <Clip duration={5}>
+        <Split left={before} right={after} />
+        <Title position="bottom" color="#ffffff">
+          30 Day Transformation
+        </Title>
+      </Clip>
+    </Render>
+  );
+
+  console.log("video tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/react-split.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/react-split.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/examples/react-test.tsx
+++ b/src/ai-sdk/examples/react-test.tsx
@@ -1,0 +1,59 @@
+import { elevenlabs } from "../elevenlabs-provider";
+import { fal } from "../fal-provider";
+import { Clip, Image, Render, render, Speech, Title, Music } from "../react";
+
+async function main() {
+  console.log("rendering varg-react video...\n");
+
+  const video = (
+    <Render width={720} height={720} fps={30}>
+      <Speech model={elevenlabs.speechModel("turbo")} voice="adam">
+        I was so hungry today. So I ate a whole pizza.
+      </Speech>
+      <Clip duration={3}>
+        <Image
+          prompt="fat tiger lying on couch, cute, pixar style"
+          model={fal.imageModel("flux-schnell")}
+          zoom="in"
+        />
+        <Title position="bottom" color="#ffffff">
+          DAY 1
+        </Title>
+      </Clip>
+
+      <Clip duration={3} transition={{ name: "fade", duration: 0.5 }}>
+        <Image
+          prompt="fat tiger still on couch, slightly fatter, pizza boxes, pixar style"
+          model={fal.imageModel("flux-schnell")}
+          zoom="in"
+        />
+        <Image
+          prompt="logo of varg.ai in helvetica"
+          model={fal.imageModel("flux-schnell")}
+          top={20}
+          left={20}
+          width={100}
+          height={100}
+        />
+
+        <Title position="bottom" color="#ffffff">
+          DAY 365
+        </Title>
+      </Clip>
+
+      <Music src="./output/duet-mixed.mp4" />
+    </Render>
+  );
+
+  console.log("video tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/react-test.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/react-test.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/examples/react-video-grid.tsx
+++ b/src/ai-sdk/examples/react-video-grid.tsx
@@ -1,0 +1,46 @@
+import { fal } from "../fal-provider";
+import { Clip, Grid, Render, render, Title, Video } from "../react";
+
+async function main() {
+  console.log("creating 2x2 video grid...\n");
+
+  const video = (
+    <Render width={1920} height={1080}>
+      <Clip duration={5}>
+        <Grid columns={2}>
+          <Video
+            prompt="ocean waves crashing on rocks, slow motion, cinematic"
+            model={fal.videoModel("wan-2.5")}
+          />
+          <Video
+            prompt="fire burning in fireplace, cozy, warm light"
+            model={fal.videoModel("wan-2.5")}
+          />
+          <Video
+            prompt="rain falling on window glass, close up, moody"
+            model={fal.videoModel("wan-2.5")}
+          />
+          <Video
+            prompt="clouds moving across blue sky, timelapse, peaceful"
+            model={fal.videoModel("wan-2.5")}
+          />
+        </Grid>
+        <Title position="bottom" color="#ffffff">
+          Elements
+        </Title>
+      </Clip>
+    </Render>
+  );
+
+  console.log("video tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/react-video-grid.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log("output: output/react-video-grid.mp4");
+}
+
+main().catch(console.error);

--- a/src/ai-sdk/providers/higgsfield.ts
+++ b/src/ai-sdk/providers/higgsfield.ts
@@ -7,6 +7,119 @@ import type {
 const IMAGE_MODELS = ["soul"] as const;
 type ImageModelId = (typeof IMAGE_MODELS)[number];
 
+/**
+ * Available Soul styles for Higgsfield image generation.
+ * Use with `higgsfield.imageModel("soul", { styleId: higgsfield.styles.REALISTIC })`
+ */
+export const SOUL_STYLES = {
+  CREATURES: "b3c8075a-cb4c-42de-b8b3-7099dd2df672",
+  MEDIEVAL: "1fc861ed-5923-41a6-9963-b9f04681dddd",
+  SPOTLIGHT: "40ff999c-f576-443c-b5b3-c7d1391a666e",
+  GIANT_PEOPLE: "a5f63c3b-70eb-4979-af5e-98c7ee1e18e8",
+  RED_BALLOON: "3de71b9e-3973-4828-b246-a34c606e25a7",
+  GREEN_EDITORIAL: "91abc4fe-1cf8-4a77-8ade-d36d46699014",
+  SUBWAY: "d2e8ba04-9935-4dee-8bc4-39ac789746fc",
+  LIBRARY: "6fb3e1f5-d721-4523-ac38-9902f2b2b850",
+  REALISTIC: "1cb4b936-77bf-4f9a-9039-f3d349a4cdbe",
+  DIGITALCAM: "ca4e6ad3-3e93-4e03-81a0-d1722d2c128b",
+  GRILLZ_SELFIE: "255f4045-d68b-42b1-9e4c-f49d3263a9d7",
+  BLEACHED_BROWS: "cc099663-9621-422e-8626-c8ee68953a0c",
+  SITTING_ON_THE_STREET: "7696fd45-6e67-47d7-b800-096ce21cd449",
+  CROSSING_THE_STREET: "d3e2b71d-b24b-462e-bd96-12f7a22b5142",
+  ANGEL_WINGS: "4c24b43b-1984-407a-a0ae-c514f29b7e66",
+  DUPLICATE: "88126a43-86fb-4047-a2d6-c9146d6ca6ce",
+  QUIET_LUXURY: "ff1ad8a2-94e7-4e70-a12f-e992ca9a0d36",
+  FIREPROOF: "373420f7-489e-4a5d-930e-cc4ecfcc23cc",
+  ELEVATOR_MIRROR: "524be50a-4388-4ff5-a843-a73d2dd7ef87",
+  CAM_360: "294bb3ee-eaef-4d2a-93e3-164268803db4",
+  GLITCH: "62355e77-7096-45ae-9bea-e7c5b88c3b70",
+  FASHION_SHOW: "86fc814e-856a-4af0-98b0-d4da75d0030b",
+  PIXELETED_FACE: "34c50302-83ff-487d-b3a9-e35e501d80a7",
+  SUNBATHING: "bc00b419-f8ca-4887-a990-e2760c3cb761",
+  PAPER_FACE: "7fa63380-64b7-48b1-b684-4c9ef37560a9",
+  GRAIN_90S: "f5c094c7-4671-4d86-90d2-369c8fdbd7a5",
+  GEOMINIMAL: "372cc37b-9add-4952-a415-53db3998139f",
+  FOGGY_MORNING: "0fe8ad66-ff61-411f-9186-b392e140b18c",
+  OVEREXPOSED: "d8a35238-ba42-48a0-a76a-186a97734b9d",
+  SUNSET_BEACH: "26241c54-ed78-4ea7-b1bf-d881737c9feb",
+  GIANT_ACCESSORY: "70fbb531-5ee2-492e-8c53-5dbd6923e8c2",
+  RING_SELFIE: "9de8ed26-c8dd-413c-a5e3-47eec97bc243",
+  STREET_VIEW: "a13917c7-02a4-450f-b007-e72d53151980",
+  EDITORIAL_90S: "710f9073-f580-48dc-b5c3-9bbc7cbb7f37",
+  RHYME_BLUES: "c7ea4e7a-c40c-498d-948c-1f6919631f60",
+  CAM_2000S: "181b3796-008a-403b-b31e-a9b760219f17",
+  CCTV: "07a85fb3-4407-4122-a4eb-42124e57734c",
+  OUTFIT_05: "71fecd8c-6696-42df-b5eb-f69e4150ca01",
+  AMALFI_SUMMER: "dab472a6-23f4-4cf8-98fe-f3e256f1b549",
+  BIMBOCORE: "f96913e8-2fcf-4358-8545-75dd6c34c518",
+  SELFIE_05: "8dd89de9-1cff-402e-88a8-580c29d91473",
+  SAND: "ba3d7634-447e-455c-98e3-63705d5403b8",
+  VINTAGE_PHOTOBOOTH: "83caff04-691c-468c-b4a0-fd6bbabe062b",
+  AFTERPARTY_CAM: "5765d07d-1525-4d4d-ae06-9091e2bdac2d",
+  BABYDOLL_MAKEUP: "b7c621b5-9d3c-46a3-8efb-4cdfbc592271",
+  THROUGH_THE_GLASS: "1900111a-4ce8-42a7-9394-7367f0e0385c",
+  GALLERY: "36061eb7-4907-4cba-afb1-47afcf699873",
+  EATING_FOOD: "7df83cc9-1e13-4bd0-b6ff-1e6a456b9e5a",
+  SWORDS_HILL: "5b6f467e-f509-4afe-a8db-4c07a6f3770d",
+  OFFICE_BEACH: "e454956b-caf2-4913-a398-dbc03f1cbedf",
+  HELP_ITS_TOO_BIG: "5ad23bca-4a4b-4316-8c59-b80d7709d8ee",
+  JAPANDI: "0089e17c-d0f0-4d0c-b522-6d25c88a29fc",
+  IPHONE: "1b798b54-03da-446a-93bf-12fcba1050d7",
+  GORPCORE: "96758335-d1d1-42b7-9c21-5ac38c433485",
+  INDIE_SLEAZE: "5a72fec7-a12e-43db-8ef3-1d193b4f7ab4",
+  FAIRYCORE: "7f21e7bd-4df6-4cef-a9a9-9746bceaea1d",
+  TUMBLR: "0367d609-dfa1-4a81-a983-b2b19ecd6480",
+  AVANT_GARDE: "0c636e12-3411-4a65-8d86-67858caf2fa7",
+  HAIRCLIPS: "ea6f4dc0-d6dd-4bdf-a8cf-94ed1db91ab2",
+  BIRTHDAY_MESS: "2d47f079-c021-4b8e-b2c0-3b927a80fc31",
+  CLOUDED_DREAM: "493bda5b-bb4b-46fe-9343-7d5e414534ef",
+  Y2K_POSTERS: "cbefda85-0f76-49bd-82d7-9bcd65be00ca",
+  TOKYO_DRIFT: "ce9a88c2-c962-45e2-abaa-c8979d48f8d5",
+  OBJECT_MAKEUP: "b7908955-2868-4e35-87a0-35e50cb92e5d",
+  GRAFFITI: "0b4dac9a-f73a-4e5b-a5a7-1a40ee40d6ac",
+  SUNBURNT: "e439bd89-8176-4729-b6a4-a9977120507d",
+  HALLWAY_NOIR: "a643a36a-85e6-4e3d-80db-13e4997203cc",
+  FASHION_2000S: "facaafeb-4ab5-4384-92a1-b4086180e9ac",
+  NIGHT_BEACH: "62ba1751-63af-4648-a11c-711ac64e216a",
+  MOVIE: "811de7ab-7aaf-4a6b-b352-cdea6c34c8f1",
+  LONG_LEGS: "12eda704-18e5-4783-aa0f-deba5296cc83",
+  APHEX_TWIN: "5659c554-9367-4a27-8c66-333c072cbbc2",
+  GENERAL: "464ea177-8d40-4940-8d9d-b438bab269c7",
+  NAIL_CHECK: "4b66c2db-8166-4293-b1aa-5269c9effb07",
+  COQUETTE_CORE: "bd78cfc6-9b92-4889-9347-f21dbf0a269c",
+  MIXED_MEDIA: "2fcf02e2-919a-4642-8b31-d58bde5e6bd9",
+  SELFCARE: "d24c016c-9fb1-47d0-9909-19f57a2830d4",
+  GRUNGE: "ad9de607-3941-4540-81ea-ba978ef1550b",
+  DOUBLE_TAKE: "2a1898d0-548f-4433-8503-5721157b93a1",
+  ROOM_505: "673cf0d4-c193-4fa2-8ad3-b4db4611e3ae",
+  FLIGHT_MODE: "3f90dc5b-f474-4259-95c4-d29fbd6be645",
+  ESCALATOR: "bab6e4bd-9093-4bb5-a371-01ef6cbd58ad",
+  BURGUNDY_SUIT: "84c23cef-7eda-4f8f-9931-e3e6af8192d9",
+  FISHEYE: "cc4e7248-dcfe-4c93-b264-2ab418a7556b",
+  SHOE_CHECK: "30458874-d9c0-4d5a-b2b7-597e0eee2404",
+  RAINY_DAY: "53bdadfa-8eb6-4eaa-8923-ebece4faa91c",
+  MT_FUJI: "de0118ba-7c27-49f7-9841-38abe2aae8e1",
+  SEA_BREEZE: "71ac929c-4002-4640-9b65-cb06402844c6",
+  INVERTETHEREAL: "82edba1e-b093-4484-a25e-9276e0454999",
+  Y2K: "6b9e6b4d-325a-4a78-a0fb-a00ddf612380",
+  TOKYO_STREETSTYLE: "99de6fc5-1177-49b9-b2e9-19e17d95bcaf",
+  CHROME_EXIT: "5e01339d-745e-4bba-96f7-e8ce4af79f17",
+  NIGHT_RIDER: "1fba888b-9ab0-447f-a6a4-9ce5251ec2a6",
+  ARTWORK: "b9e2d7dc-78e6-4f7d-95dd-b62690e7b200",
+  GLAZED_DOLL_SKIN_MAKEUP: "a2a42ada-75cc-42a9-be12-cb16c1dec2a8",
+  MOUNT_VIEW: "3c975998-cb5b-4980-80fc-7977e4c60972",
+  BLADE_RUNNER_2049: "53959c8a-4323-4b78-9888-e9f6fb0f6b98",
+  BLACKOUT_FIT: "f8dac072-d11f-438a-b283-fd52fe8aa744",
+  BIKE_MAFIA: "90df2935-3ded-477f-8253-1d67dd939cbe",
+  STATIC_GLOW: "fb9cee2b-632f-4fd4-ae4f-4664deecc0f4",
+  NICOTINE_GLOW: "5dbb6a20-0541-4f06-8352-a2408d8781dc",
+  BRICK_SHADE: "f3968a4f-a125-4c16-8673-45ce9874520e",
+  DMV: "923e4fb0-d4ea-480c-876d-ac7cad862b9d",
+  FISH_EYE_TWIN: "d4775423-d214-4862-b061-47baa1978208",
+  ITS_FRENCH: "79bfaa63-4e12-4ea2-8ada-7d4406eecece",
+  COCKTAIL: "aed71142-673c-4908-a6a7-326d5252eb06",
+} as const;
+
 export interface HiggsfieldImageModelSettings {
   styleId?: string;
   quality?: "720p" | "1080p";
@@ -32,6 +145,10 @@ class HiggsfieldImageModel implements ImageModelV3 {
   private apiSecret: string;
   private baseURL: string;
   private modelSettings: HiggsfieldImageModelSettings;
+
+  get settings(): HiggsfieldImageModelSettings {
+    return this.modelSettings;
+  }
 
   constructor(
     modelId: string,
@@ -235,6 +352,8 @@ export interface HiggsfieldProvider {
     modelId: ImageModelId | (string & {}),
     settings?: HiggsfieldImageModelSettings,
   ): ImageModelV3;
+  /** Available Soul styles for image generation */
+  styles: typeof SOUL_STYLES;
 }
 
 export function createHiggsfield(
@@ -253,6 +372,7 @@ export function createHiggsfield(
         ...modelSettings,
       });
     },
+    styles: SOUL_STYLES,
   };
 }
 

--- a/src/ai-sdk/react/cli.ts
+++ b/src/ai-sdk/react/cli.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "util";
+import { render } from "./render";
+import type { VargElement } from "./types";
+
+const { values, positionals } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    output: { type: "string", short: "o" },
+    cache: { type: "string", short: "c", default: ".cache/ai" },
+    quiet: { type: "boolean", short: "q", default: false },
+  },
+  allowPositionals: true,
+});
+
+const [file] = positionals;
+
+if (!file) {
+  console.error("usage: bun react/cli.ts <component.tsx> [-o output.mp4]");
+  process.exit(1);
+}
+
+const resolvedPath = Bun.resolveSync(file, process.cwd());
+const mod = await import(resolvedPath);
+const component: VargElement = mod.default;
+
+if (!component || component.type !== "render") {
+  console.error("error: default export must be a <Render> element");
+  process.exit(1);
+}
+
+const outputPath =
+  values.output ??
+  `output/${file
+    .replace(/\.tsx?$/, "")
+    .split("/")
+    .pop()}.mp4`;
+
+if (!values.quiet) {
+  console.log(`rendering ${file} → ${outputPath}`);
+}
+
+const buffer = await render(component, {
+  output: outputPath,
+  cache: values.cache,
+  quiet: values.quiet,
+});
+
+if (!values.quiet) {
+  console.log(`done! ${buffer.byteLength} bytes → ${outputPath}`);
+}

--- a/src/ai-sdk/react/elements.ts
+++ b/src/ai-sdk/react/elements.ts
@@ -1,0 +1,146 @@
+import type {
+  AnimateProps,
+  CaptionsProps,
+  ClipProps,
+  ImageProps,
+  MusicProps,
+  OverlayProps,
+  PackshotProps,
+  RenderProps,
+  SliderProps,
+  SpeechProps,
+  SplitProps,
+  SubtitleProps,
+  SwipeProps,
+  TalkingHeadProps,
+  TitleProps,
+  VargElement,
+  VargNode,
+  VideoProps,
+} from "./types";
+
+function normalizeChildren(children: unknown): VargNode[] {
+  if (children === null || children === undefined) return [];
+  if (Array.isArray(children))
+    return children.flat().flatMap(normalizeChildren);
+  return [children as VargNode];
+}
+
+function createElement<T extends VargElement["type"]>(
+  type: T,
+  props: Record<string, unknown>,
+  children: unknown,
+): VargElement<T> {
+  const { children: _, ...restProps } = props;
+  return {
+    type,
+    props: restProps,
+    children: normalizeChildren(children ?? props.children),
+  };
+}
+
+export function Render(props: RenderProps): VargElement<"render"> {
+  return createElement(
+    "render",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Clip(props: ClipProps): VargElement<"clip"> {
+  return createElement(
+    "clip",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Overlay(props: OverlayProps): VargElement<"overlay"> {
+  return createElement(
+    "overlay",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Image(props: ImageProps): VargElement<"image"> {
+  return createElement("image", props as Record<string, unknown>, undefined);
+}
+
+export function Video(props: VideoProps): VargElement<"video"> {
+  return createElement("video", props as Record<string, unknown>, undefined);
+}
+
+export function Animate(props: AnimateProps): VargElement<"animate"> {
+  return createElement("animate", props as Record<string, unknown>, undefined);
+}
+
+export function Speech(props: SpeechProps): VargElement<"speech"> {
+  return createElement(
+    "speech",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function TalkingHead(
+  props: TalkingHeadProps,
+): VargElement<"talking-head"> {
+  return createElement(
+    "talking-head",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Title(props: TitleProps): VargElement<"title"> {
+  return createElement(
+    "title",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Subtitle(props: SubtitleProps): VargElement<"subtitle"> {
+  return createElement(
+    "subtitle",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Music(props: MusicProps): VargElement<"music"> {
+  return createElement("music", props as Record<string, unknown>, undefined);
+}
+
+export function Captions(props: CaptionsProps): VargElement<"captions"> {
+  return createElement("captions", props as Record<string, unknown>, undefined);
+}
+
+export function Split(props: SplitProps): VargElement<"split"> {
+  return createElement(
+    "split",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Slider(props: SliderProps): VargElement<"slider"> {
+  return createElement(
+    "slider",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Swipe(props: SwipeProps): VargElement<"swipe"> {
+  return createElement(
+    "swipe",
+    props as Record<string, unknown>,
+    props.children,
+  );
+}
+
+export function Packshot(props: PackshotProps): VargElement<"packshot"> {
+  return createElement("packshot", props as Record<string, unknown>, undefined);
+}

--- a/src/ai-sdk/react/index.ts
+++ b/src/ai-sdk/react/index.ts
@@ -1,0 +1,43 @@
+export type { SizeValue } from "../providers/editly/types";
+export {
+  Animate,
+  Captions,
+  Clip,
+  Image,
+  Music,
+  Overlay,
+  Packshot,
+  Render,
+  Slider,
+  Speech,
+  Split,
+  Subtitle,
+  Swipe,
+  TalkingHead,
+  Title,
+  Video,
+} from "./elements";
+export { Grid, Split as SplitLayout } from "./layouts";
+export { render, renderStream } from "./render";
+export type {
+  AnimateProps,
+  CaptionsProps,
+  ClipProps,
+  ImageProps,
+  MusicProps,
+  OverlayProps,
+  PackshotProps,
+  PositionProps,
+  RenderOptions,
+  RenderProps,
+  SliderProps,
+  SpeechProps,
+  SplitProps,
+  SubtitleProps,
+  SwipeProps,
+  TalkingHeadProps,
+  TitleProps,
+  VargElement,
+  VargNode,
+  VideoProps,
+} from "./types";

--- a/src/ai-sdk/react/jsx-dev-runtime.ts
+++ b/src/ai-sdk/react/jsx-dev-runtime.ts
@@ -1,0 +1,41 @@
+import type { VargElement, VargNode } from "./types";
+
+type ElementFactory = (props: Record<string, unknown>) => VargElement;
+
+export function jsx(
+  type: ElementFactory,
+  props: Record<string, unknown> | null,
+  key?: string,
+): VargElement {
+  const finalProps = { ...props };
+  if (key !== undefined) {
+    finalProps.key = key;
+  }
+  return type(finalProps);
+}
+
+export function jsxs(
+  type: ElementFactory,
+  props: Record<string, unknown> | null,
+  key?: string,
+): VargElement {
+  return jsx(type, props, key);
+}
+
+export function jsxDEV(
+  type: ElementFactory,
+  props: Record<string, unknown> | null,
+  key?: string,
+): VargElement {
+  return jsx(type, props, key);
+}
+
+export const Fragment = ({ children }: { children?: VargNode }) => children;
+
+export namespace JSX {
+  export type Element = VargElement;
+  export type IntrinsicElements = {};
+  export interface ElementChildrenAttribute {
+    children: {};
+  }
+}

--- a/src/ai-sdk/react/jsx-runtime.ts
+++ b/src/ai-sdk/react/jsx-runtime.ts
@@ -1,0 +1,33 @@
+import type { VargElement, VargNode } from "./types";
+
+type ElementFactory = (props: Record<string, unknown>) => VargElement;
+
+export function jsx(
+  type: ElementFactory,
+  props: Record<string, unknown> | null,
+  key?: string,
+): VargElement {
+  const finalProps = { ...props };
+  if (key !== undefined) {
+    finalProps.key = key;
+  }
+  return type(finalProps);
+}
+
+export function jsxs(
+  type: ElementFactory,
+  props: Record<string, unknown> | null,
+  key?: string,
+): VargElement {
+  return jsx(type, props, key);
+}
+
+export const Fragment = ({ children }: { children?: VargNode }) => children;
+
+export namespace JSX {
+  export type Element = VargElement;
+  export type IntrinsicElements = {};
+  export interface ElementChildrenAttribute {
+    children: {};
+  }
+}

--- a/src/ai-sdk/react/layouts.tsx
+++ b/src/ai-sdk/react/layouts.tsx
@@ -1,0 +1,43 @@
+import type { VargElement } from "./types";
+
+export const Grid = ({
+  columns,
+  rows,
+  children,
+}: {
+  columns?: number;
+  rows?: number;
+  children: VargElement[];
+}) => {
+  const cols = columns ?? children.length;
+  const rowCount = rows ?? Math.ceil(children.length / cols);
+  const positioned = children.map((el, i) => ({
+    ...el,
+    props: {
+      ...el.props,
+      left: (i % cols) / cols,
+      top: Math.floor(i / cols) / rowCount,
+      width: 1 / cols,
+      height: 1 / rowCount,
+    },
+  }));
+  return <>{positioned}</>;
+};
+
+export const Split = ({
+  left,
+  right,
+  direction = "horizontal",
+}: {
+  left: VargElement;
+  right: VargElement;
+  direction?: "horizontal" | "vertical";
+}) => (
+  <Grid
+    columns={direction === "horizontal" ? 2 : 1}
+    rows={direction === "vertical" ? 2 : 1}
+  >
+    {left}
+    {right}
+  </Grid>
+);

--- a/src/ai-sdk/react/react.test.ts
+++ b/src/ai-sdk/react/react.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { fal } from "../fal-provider";
+import { Animate, Clip, Image, Render, render, Title, Video } from "./index";
+
+describe("varg-react elements", () => {
+  test("Render creates correct element structure", () => {
+    const element = Render({
+      width: 1280,
+      height: 720,
+      fps: 30,
+      children: [],
+    });
+
+    expect(element.type).toBe("render");
+    expect(element.props.width).toBe(1280);
+    expect(element.props.height).toBe(720);
+    expect(element.props.fps).toBe(30);
+  });
+
+  test("Video creates correct element structure", () => {
+    const element = Video({
+      prompt: "ocean waves",
+      model: fal.videoModel("wan-2.5"),
+    });
+
+    expect(element.type).toBe("video");
+    expect(element.props.prompt).toBe("ocean waves");
+  });
+
+  test("Clip creates correct element structure", () => {
+    const element = Clip({
+      duration: 5,
+      transition: { name: "fade", duration: 0.5 },
+      children: [],
+    });
+
+    expect(element.type).toBe("clip");
+    expect(element.props.duration).toBe(5);
+    expect(element.props.transition).toEqual({ name: "fade", duration: 0.5 });
+  });
+
+  test("Image creates correct element structure", () => {
+    const element = Image({
+      prompt: "fat tiger on couch",
+      model: fal.imageModel("flux-schnell"),
+      aspectRatio: "16:9",
+      zoom: "in",
+    });
+
+    expect(element.type).toBe("image");
+    expect(element.props.prompt).toBe("fat tiger on couch");
+    expect(element.props.aspectRatio).toBe("16:9");
+    expect(element.props.zoom).toBe("in");
+  });
+
+  test("Title creates correct element with text children", () => {
+    const element = Title({
+      position: "bottom",
+      color: "#ffffff",
+      children: "I'M IN DANGER",
+    });
+
+    expect(element.type).toBe("title");
+    expect(element.props.position).toBe("bottom");
+    expect(element.props.color).toBe("#ffffff");
+    expect(element.children).toContain("I'M IN DANGER");
+  });
+
+  test("Animate creates correct element with nested image", () => {
+    const image = Image({ prompt: "luigi in wheelchair" });
+    const element = Animate({
+      image,
+      model: fal.videoModel("wan-2.5"),
+      motion: "wheels spinning fast",
+      duration: 5,
+    });
+
+    expect(element.type).toBe("animate");
+    expect(element.props.image).toBe(image);
+    expect(element.props.motion).toBe("wheels spinning fast");
+    expect(element.props.duration).toBe(5);
+  });
+
+  test("nested composition builds correct tree", () => {
+    const root = Render({
+      width: 1080,
+      height: 1920,
+      children: [
+        Clip({
+          duration: 5,
+          children: [
+            Image({
+              prompt: "ralph wiggum",
+              model: fal.imageModel("flux-schnell"),
+            }),
+            Title({ children: "HELLO" }),
+          ],
+        }),
+        Clip({
+          duration: 3,
+          transition: { name: "fade", duration: 0.3 },
+          children: [
+            Image({
+              prompt: "fat tiger",
+              model: fal.imageModel("flux-schnell"),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(root.type).toBe("render");
+    expect(root.children.length).toBe(2);
+
+    const clip1 = root.children[0] as ReturnType<typeof Clip>;
+    expect(clip1.type).toBe("clip");
+    expect(clip1.children.length).toBe(2);
+
+    const clip2 = root.children[1] as ReturnType<typeof Clip>;
+    expect(clip2.type).toBe("clip");
+    expect(clip2.props.transition).toEqual({ name: "fade", duration: 0.3 });
+  });
+});
+
+describe("varg-react render", () => {
+  test("render throws on non-render root", async () => {
+    const clip = Clip({ duration: 5, children: [] });
+
+    expect(render(clip)).rejects.toThrow("Root element must be <Render>");
+  });
+
+  test("render requires model prop for image with prompt", async () => {
+    const root = Render({
+      width: 720,
+      height: 720,
+      children: [
+        Clip({
+          duration: 3,
+          children: [Image({ prompt: "test image without model" })],
+        }),
+      ],
+    });
+
+    expect(render(root)).rejects.toThrow("model");
+  });
+});

--- a/src/ai-sdk/react/render.ts
+++ b/src/ai-sdk/react/render.ts
@@ -1,0 +1,21 @@
+import { renderRoot } from "./renderers";
+import type { RenderOptions, VargElement } from "./types";
+
+export async function render(
+  element: VargElement,
+  options: RenderOptions = {},
+): Promise<Uint8Array> {
+  if (element.type !== "render") {
+    throw new Error("Root element must be <Render>");
+  }
+
+  return renderRoot(element as VargElement<"render">, options);
+}
+
+export const renderStream = {
+  async *stream(element: VargElement, options: RenderOptions = {}) {
+    yield { type: "start", progress: 0 };
+    const result = await render(element, options);
+    yield { type: "complete", progress: 100, result };
+  },
+};

--- a/src/ai-sdk/react/renderers/animate.ts
+++ b/src/ai-sdk/react/renderers/animate.ts
@@ -1,0 +1,59 @@
+import { File } from "../../file";
+import type { generateVideo } from "../../generate-video";
+import type { AnimateProps, VargElement } from "../types";
+import type { RenderContext } from "./context";
+import { renderImage } from "./image";
+import { addTask, completeTask, startTask } from "./progress";
+import { computeCacheKey, resolvePath } from "./utils";
+
+export async function renderAnimate(
+  element: VargElement<"animate">,
+  ctx: RenderContext,
+): Promise<string> {
+  const props = element.props as AnimateProps;
+
+  let imagePath: string;
+  if (props.src) {
+    imagePath = props.src;
+  } else if (props.image) {
+    if (props.image.type !== "image") {
+      throw new Error(
+        `Animate 'image' prop must be an <Image /> element, got <${props.image.type} />`,
+      );
+    }
+    imagePath = await renderImage(props.image as VargElement<"image">, ctx);
+  } else {
+    throw new Error("Animate element requires either 'src' or 'image' prop");
+  }
+
+  const model = props.model;
+  if (!model) {
+    throw new Error("Animate element requires 'model' prop");
+  }
+
+  const imageData = await Bun.file(resolvePath(imagePath)).arrayBuffer();
+  const cacheKey = computeCacheKey(element);
+
+  const modelId = typeof model === "string" ? model : model.modelId;
+  const taskId = ctx.progress
+    ? addTask(ctx.progress, "animate", modelId)
+    : null;
+  if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+
+  const { video } = await ctx.generateVideo({
+    model,
+    prompt: {
+      text: props.motion ?? "",
+      images: [new Uint8Array(imageData)],
+    },
+    duration: props.duration ?? 5,
+    cacheKey,
+  } as Parameters<typeof generateVideo>[0]);
+
+  if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+
+  const tempPath = await File.toTemp(video);
+  ctx.tempFiles.push(tempPath);
+
+  return tempPath;
+}

--- a/src/ai-sdk/react/renderers/clip.ts
+++ b/src/ai-sdk/react/renderers/clip.ts
@@ -1,0 +1,188 @@
+import type {
+  AudioLayer,
+  Clip,
+  FillColorLayer,
+  ImageLayer,
+  ImageOverlayLayer,
+  Layer,
+  VideoLayer,
+} from "../../providers/editly/types";
+import type {
+  AnimateProps,
+  ClipProps,
+  ImageProps,
+  SpeechProps,
+  VargElement,
+  VargNode,
+  VideoProps,
+} from "../types";
+import { renderAnimate } from "./animate";
+import type { RenderContext } from "./context";
+import { renderImage } from "./image";
+import { renderSpeech } from "./speech";
+import { renderSubtitle } from "./subtitle";
+import { renderTitle } from "./title";
+import { renderVideo } from "./video";
+
+type PendingLayer =
+  | { type: "sync"; layer: Layer }
+  | { type: "async"; promise: Promise<Layer> };
+
+async function renderClipLayers(
+  children: VargNode[],
+  ctx: RenderContext,
+): Promise<Layer[]> {
+  const pending: PendingLayer[] = [];
+
+  for (const child of children) {
+    if (!child || typeof child !== "object" || !("type" in child)) continue;
+
+    const element = child as VargElement;
+
+    switch (element.type) {
+      case "image": {
+        const props = element.props as ImageProps;
+        const hasPosition =
+          props.left !== undefined ||
+          props.top !== undefined ||
+          props.width !== undefined ||
+          props.height !== undefined;
+
+        pending.push({
+          type: "async",
+          promise: renderImage(element as VargElement<"image">, ctx).then(
+            (path) =>
+              hasPosition
+                ? ({
+                    type: "image-overlay",
+                    path,
+                    zoomDirection: props.zoom,
+                    width: props.width,
+                    height: props.height,
+                    position: { x: props.left ?? 0, y: props.top ?? 0 },
+                  } as ImageOverlayLayer)
+                : ({
+                    type: "image",
+                    path,
+                    resizeMode: props.resize,
+                    zoomDirection: props.zoom,
+                  } as ImageLayer),
+          ),
+        });
+        break;
+      }
+
+      case "video": {
+        const props = element.props as VideoProps;
+        pending.push({
+          type: "async",
+          promise: renderVideo(element as VargElement<"video">, ctx).then(
+            (path) =>
+              ({
+                type: "video",
+                path,
+                resizeMode: props.resize,
+                cutFrom: props.cutFrom,
+                cutTo: props.cutTo,
+                mixVolume: props.keepAudio ? (props.volume ?? 1) : 0,
+                left: props.left,
+                top: props.top,
+                width: props.width,
+                height: props.height,
+              }) as VideoLayer,
+          ),
+        });
+        break;
+      }
+
+      case "animate": {
+        const props = element.props as AnimateProps;
+        pending.push({
+          type: "async",
+          promise: renderAnimate(element as VargElement<"animate">, ctx).then(
+            (path) =>
+              ({
+                type: "video",
+                path,
+                left: props.left,
+                top: props.top,
+                width: props.width,
+                height: props.height,
+              }) as VideoLayer,
+          ),
+        });
+        break;
+      }
+
+      case "title": {
+        pending.push({
+          type: "sync",
+          layer: renderTitle(element as VargElement<"title">),
+        });
+        break;
+      }
+
+      case "subtitle": {
+        pending.push({
+          type: "sync",
+          layer: renderSubtitle(element as VargElement<"subtitle">),
+        });
+        break;
+      }
+
+      case "speech": {
+        const props = element.props as SpeechProps;
+        pending.push({
+          type: "async",
+          promise: renderSpeech(element as VargElement<"speech">, ctx).then(
+            (result) =>
+              ({
+                type: "audio",
+                path: result.path,
+                mixVolume: props.volume ?? 1,
+              }) as AudioLayer,
+          ),
+        });
+        break;
+      }
+    }
+  }
+
+  const layers = await Promise.all(
+    pending.map((p) => (p.type === "sync" ? p.layer : p.promise)),
+  );
+
+  return layers;
+}
+
+export async function renderClip(
+  element: VargElement<"clip">,
+  ctx: RenderContext,
+): Promise<Clip> {
+  const props = element.props as ClipProps;
+  const layers = await renderClipLayers(element.children, ctx);
+
+  const isOverlayVideo = (l: Layer) =>
+    l.type === "video" &&
+    ((l as VideoLayer).left !== undefined ||
+      (l as VideoLayer).top !== undefined ||
+      (l as VideoLayer).width !== undefined ||
+      (l as VideoLayer).height !== undefined);
+
+  const hasBaseLayer = layers.some(
+    (l) =>
+      l.type === "image" ||
+      l.type === "fill-color" ||
+      (l.type === "video" && !isOverlayVideo(l)),
+  );
+
+  if (!hasBaseLayer && layers.length > 0) {
+    layers.unshift({ type: "fill-color", color: "#000000" } as FillColorLayer);
+  }
+
+  return {
+    layers,
+    duration: typeof props.duration === "number" ? props.duration : undefined,
+    transition: props.transition ?? null,
+  };
+}

--- a/src/ai-sdk/react/renderers/context.ts
+++ b/src/ai-sdk/react/renderers/context.ts
@@ -1,0 +1,17 @@
+import type { generateImage } from "ai";
+import type { fileCache } from "../../file-cache";
+import type { generateVideo } from "../../generate-video";
+import type { ProgressTracker } from "./progress";
+
+export interface RenderContext {
+  width: number;
+  height: number;
+  fps: number;
+  cache?: ReturnType<typeof fileCache>;
+  generateImage: typeof generateImage;
+  generateVideo: typeof generateVideo;
+  tempFiles: string[];
+  progress?: ProgressTracker;
+  /** In-memory deduplication for concurrent renders of the same element */
+  pending: Map<string, Promise<string>>;
+}

--- a/src/ai-sdk/react/renderers/image.ts
+++ b/src/ai-sdk/react/renderers/image.ts
@@ -1,0 +1,104 @@
+import type { generateImage } from "ai";
+import { File } from "../../file";
+import type {
+  ImageInput,
+  ImagePrompt,
+  ImageProps,
+  VargElement,
+} from "../types";
+import type { RenderContext } from "./context";
+import { addTask, completeTask, startTask } from "./progress";
+import { computeCacheKey, toFileUrl } from "./utils";
+
+async function resolveImageInput(
+  input: ImageInput,
+  ctx: RenderContext,
+): Promise<Uint8Array> {
+  if (input instanceof Uint8Array) {
+    return input;
+  }
+  if (typeof input === "string") {
+    const response = await fetch(toFileUrl(input));
+    return new Uint8Array(await response.arrayBuffer());
+  }
+  const path = await renderImage(input, ctx);
+  const response = await fetch(toFileUrl(path));
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function resolvePrompt(
+  prompt: ImagePrompt,
+  ctx: RenderContext,
+): Promise<string | { text?: string; images: Uint8Array[] }> {
+  if (typeof prompt === "string") {
+    return prompt;
+  }
+  const resolvedImages = await Promise.all(
+    prompt.images.map((img) => resolveImageInput(img, ctx)),
+  );
+  return { text: prompt.text, images: resolvedImages };
+}
+
+export async function renderImage(
+  element: VargElement<"image">,
+  ctx: RenderContext,
+): Promise<string> {
+  const props = element.props as ImageProps;
+
+  if (props.src) {
+    return props.src;
+  }
+
+  if (!props.prompt) {
+    throw new Error("Image element requires either 'prompt' or 'src'");
+  }
+
+  const model = props.model;
+  if (!model) {
+    throw new Error("Image element requires 'model' prop when using prompt");
+  }
+
+  // Compute cache key for deduplication
+  const cacheKey = computeCacheKey(element);
+  const cacheKeyStr = JSON.stringify(cacheKey);
+
+  // Check if this element is already being rendered (deduplication)
+  const pendingRender = ctx.pending.get(cacheKeyStr);
+  if (pendingRender) {
+    return pendingRender;
+  }
+
+  // Create the render promise and store it for deduplication
+  const renderPromise = (async () => {
+    const resolvedPrompt = await resolvePrompt(props.prompt!, ctx);
+
+    const modelId = typeof model === "string" ? model : model.modelId;
+    const taskId = ctx.progress
+      ? addTask(ctx.progress, "image", modelId)
+      : null;
+    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+
+    const { images } = await ctx.generateImage({
+      model,
+      prompt: resolvedPrompt,
+      aspectRatio: props.aspectRatio,
+      n: 1,
+      cacheKey,
+    } as Parameters<typeof generateImage>[0]);
+
+    if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+
+    const imageData = images[0]!.uint8Array;
+    const tempPath = await File.toTemp({
+      uint8Array: imageData,
+      mimeType: "image/png",
+    });
+    ctx.tempFiles.push(tempPath);
+
+    return tempPath;
+  })();
+
+  ctx.pending.set(cacheKeyStr, renderPromise);
+
+  return renderPromise;
+}

--- a/src/ai-sdk/react/renderers/index.ts
+++ b/src/ai-sdk/react/renderers/index.ts
@@ -1,0 +1,17 @@
+export { renderAnimate } from "./animate";
+export { renderClip } from "./clip";
+export type { RenderContext } from "./context";
+export { renderImage } from "./image";
+export {
+  createProgressTracker,
+  type GenerationType,
+  type ProgressTask,
+  type ProgressTracker,
+  TIME_ESTIMATES,
+} from "./progress";
+export { renderRoot } from "./render";
+export type { SpeechResult } from "./speech";
+export { renderSpeech } from "./speech";
+export { renderTitle } from "./title";
+export { computeCacheKey, getTextContent } from "./utils";
+export { renderVideo } from "./video";

--- a/src/ai-sdk/react/renderers/music.ts
+++ b/src/ai-sdk/react/renderers/music.ts
@@ -1,0 +1,58 @@
+import { generateMusic } from "../../generate-music";
+import type { MusicProps, VargElement } from "../types";
+import type { RenderContext } from "./context";
+import { addTask, completeTask, startTask } from "./progress";
+
+export async function renderMusic(
+  element: VargElement<"music">,
+  ctx: RenderContext,
+): Promise<{ path: string }> {
+  const props = element.props as MusicProps;
+
+  if (!props.prompt || !props.model) {
+    throw new Error("Music generation requires both prompt and model");
+  }
+
+  const cacheKey = JSON.stringify({
+    type: "music",
+    prompt: props.prompt,
+    model: props.model.modelId,
+    duration: props.duration,
+  });
+
+  const modelId = props.model.modelId;
+  const taskId = ctx.progress ? addTask(ctx.progress, "music", modelId) : null;
+
+  const generateFn = async () => {
+    const result = await generateMusic({
+      model: props.model!,
+      prompt: props.prompt!,
+      duration: props.duration,
+    });
+    return result.audio.uint8Array;
+  };
+
+  let audioData: Uint8Array;
+
+  if (ctx.cache) {
+    const cached = await ctx.cache.get(cacheKey);
+    if (cached) {
+      audioData = cached as Uint8Array;
+    } else {
+      if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+      audioData = await generateFn();
+      if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+      await ctx.cache.set(cacheKey, audioData);
+    }
+  } else {
+    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+    audioData = await generateFn();
+    if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+  }
+
+  const tempPath = `/tmp/varg-music-${Date.now()}.mp3`;
+  await Bun.write(tempPath, audioData);
+  ctx.tempFiles.push(tempPath);
+
+  return { path: tempPath };
+}

--- a/src/ai-sdk/react/renderers/progress.ts
+++ b/src/ai-sdk/react/renderers/progress.ts
@@ -1,0 +1,169 @@
+export type GenerationType =
+  | "image"
+  | "video"
+  | "animate"
+  | "speech"
+  | "music"
+  | "editly";
+
+export const TIME_ESTIMATES: Record<GenerationType, number> = {
+  image: 30,
+  video: 120,
+  animate: 90,
+  speech: 5,
+  music: 45,
+  editly: 15,
+};
+
+export const MODEL_TIME_ESTIMATES: Record<string, number> = {
+  // image models - use partial matching
+  "flux/schnell": 3,
+  "flux/dev": 8,
+  "flux-pro": 12,
+  recraft: 10,
+  ideogram: 8,
+  // video models
+  kling: 180,
+  "kling-v2": 180,
+  "kling-v2.5": 180,
+  minimax: 90,
+  luma: 90,
+  runway: 45,
+  veo: 120,
+  // speech models
+  elevenlabs: 5,
+  eleven: 5,
+  // music models
+  "stable-audio": 30,
+  musicgen: 45,
+};
+
+export interface ProgressTask {
+  id: string;
+  type: GenerationType;
+  model: string;
+  status: "pending" | "running" | "done";
+  startedAt?: number;
+  completedAt?: number;
+}
+
+export interface ProgressTracker {
+  tasks: ProgressTask[];
+  onUpdate?: (tracker: ProgressTracker) => void;
+  quiet: boolean;
+}
+
+export function createProgressTracker(quiet = false): ProgressTracker {
+  return {
+    tasks: [],
+    quiet,
+  };
+}
+
+export function addTask(
+  tracker: ProgressTracker,
+  type: GenerationType,
+  model: string,
+): string {
+  const id = `${type}-${tracker.tasks.length}`;
+  tracker.tasks.push({ id, type, model, status: "pending" });
+  return id;
+}
+
+export function startTask(tracker: ProgressTracker, id: string): void {
+  const task = tracker.tasks.find((t) => t.id === id);
+  if (task) {
+    task.status = "running";
+    task.startedAt = Date.now();
+    if (!tracker.quiet) {
+      logTaskStart(task);
+    }
+  }
+  tracker.onUpdate?.(tracker);
+}
+
+const CACHE_THRESHOLD_MS = 1000;
+
+export function completeTask(tracker: ProgressTracker, id: string): void {
+  const task = tracker.tasks.find((t) => t.id === id);
+  if (task) {
+    task.status = "done";
+    task.completedAt = Date.now();
+    const duration = task.startedAt ? task.completedAt - task.startedAt : 0;
+    const wasCached = duration < CACHE_THRESHOLD_MS;
+    if (!tracker.quiet) {
+      logTaskComplete(task, wasCached);
+    }
+  }
+  tracker.onUpdate?.(tracker);
+}
+
+function getEstimate(task: ProgressTask): number {
+  const modelLower = task.model.toLowerCase();
+  for (const [key, estimate] of Object.entries(MODEL_TIME_ESTIMATES)) {
+    if (modelLower.includes(key.toLowerCase())) {
+      return estimate;
+    }
+  }
+  return TIME_ESTIMATES[task.type];
+}
+
+function logTaskStart(task: ProgressTask): void {
+  const estimate = getEstimate(task);
+  console.log(`⏳ generating ${task.type} with ${task.model} (~${estimate}s)`);
+}
+
+function logTaskComplete(task: ProgressTask, cached: boolean): void {
+  const duration =
+    task.completedAt && task.startedAt
+      ? ((task.completedAt - task.startedAt) / 1000).toFixed(1)
+      : "?";
+  if (cached) {
+    console.log(`⚡ ${task.type} from cache`);
+  } else {
+    console.log(`✓ ${task.type} done (${duration}s)`);
+  }
+}
+
+export function getTotalEstimate(tracker: ProgressTracker): number {
+  return tracker.tasks.reduce((sum, task) => sum + getEstimate(task), 0);
+}
+
+export function getElapsedTime(tracker: ProgressTracker): number {
+  const completed = tracker.tasks.filter((t) => t.status === "done");
+  const running = tracker.tasks.find((t) => t.status === "running");
+
+  let elapsed = 0;
+  for (const task of completed) {
+    if (task.startedAt && task.completedAt) {
+      elapsed += (task.completedAt - task.startedAt) / 1000;
+    }
+  }
+  if (running?.startedAt) {
+    elapsed += (Date.now() - running.startedAt) / 1000;
+  }
+  return elapsed;
+}
+
+export function getProgress(tracker: ProgressTracker): number {
+  const total = tracker.tasks.length;
+  if (total === 0) return 0;
+  const done = tracker.tasks.filter((t) => t.status === "done").length;
+  return Math.round((done / total) * 100);
+}
+
+export function renderProgressBar(tracker: ProgressTracker): string {
+  const progress = getProgress(tracker);
+  const total = getTotalEstimate(tracker);
+  const elapsed = getElapsedTime(tracker);
+
+  const width = 30;
+  const filled = Math.round((progress / 100) * width);
+  const empty = width - filled;
+  const bar = "█".repeat(filled) + "░".repeat(empty);
+
+  const done = tracker.tasks.filter((t) => t.status === "done").length;
+  const totalTasks = tracker.tasks.length;
+
+  return `[${bar}] ${progress}% (${done}/${totalTasks} tasks, ~${Math.round(total - elapsed)}s remaining)`;
+}

--- a/src/ai-sdk/react/renderers/render.ts
+++ b/src/ai-sdk/react/renderers/render.ts
@@ -1,0 +1,208 @@
+import { generateImage } from "ai";
+import { withCache } from "../../cache";
+import { fileCache } from "../../file-cache";
+import { generateVideo } from "../../generate-video";
+import { editly } from "../../providers/editly";
+import type {
+  AudioTrack,
+  Clip,
+  Layer,
+  VideoLayer,
+} from "../../providers/editly/types";
+import type {
+  ClipProps,
+  MusicProps,
+  OverlayProps,
+  RenderOptions,
+  RenderProps,
+  SpeechProps,
+  VargElement,
+} from "../types";
+import { renderAnimate } from "./animate";
+import { renderClip } from "./clip";
+import type { RenderContext } from "./context";
+import { renderImage } from "./image";
+import { renderMusic } from "./music";
+import {
+  addTask,
+  completeTask,
+  createProgressTracker,
+  startTask,
+} from "./progress";
+import { renderSpeech } from "./speech";
+import { resolvePath } from "./utils";
+import { renderVideo } from "./video";
+
+interface RenderedOverlay {
+  path: string;
+  props: OverlayProps;
+  isVideo: boolean;
+}
+
+export async function renderRoot(
+  element: VargElement<"render">,
+  options: RenderOptions,
+): Promise<Uint8Array> {
+  const props = element.props as RenderProps;
+  const progress = createProgressTracker(options.quiet ?? false);
+
+  const ctx: RenderContext = {
+    width: props.width ?? 1920,
+    height: props.height ?? 1080,
+    fps: props.fps ?? 30,
+    cache: options.cache ? fileCache({ dir: options.cache }) : undefined,
+    generateImage: options.cache
+      ? withCache(generateImage, { storage: fileCache({ dir: options.cache }) })
+      : generateImage,
+    generateVideo: options.cache
+      ? withCache(generateVideo, { storage: fileCache({ dir: options.cache }) })
+      : generateVideo,
+    tempFiles: [],
+    progress,
+    pending: new Map(),
+  };
+
+  const clipElements: VargElement<"clip">[] = [];
+  const overlayElements: VargElement<"overlay">[] = [];
+  const audioTracks: AudioTrack[] = [];
+
+  for (const child of element.children) {
+    if (!child || typeof child !== "object" || !("type" in child)) continue;
+
+    const childElement = child as VargElement;
+
+    if (childElement.type === "clip") {
+      clipElements.push(childElement as VargElement<"clip">);
+    } else if (childElement.type === "overlay") {
+      overlayElements.push(childElement as VargElement<"overlay">);
+    } else if (childElement.type === "speech") {
+      const result = await renderSpeech(
+        childElement as VargElement<"speech">,
+        ctx,
+      );
+      const speechProps = childElement.props as SpeechProps;
+      audioTracks.push({
+        path: result.path,
+        mixVolume: speechProps.volume ?? 1,
+      });
+    } else if (childElement.type === "music") {
+      const musicProps = childElement.props as MusicProps;
+      const cutFrom = musicProps.cutFrom;
+      const cutTo =
+        musicProps.cutTo ??
+        (musicProps.duration !== undefined
+          ? (cutFrom ?? 0) + musicProps.duration
+          : undefined);
+
+      let path: string;
+      if (musicProps.src) {
+        path = resolvePath(musicProps.src);
+      } else if (musicProps.prompt && musicProps.model) {
+        const result = await renderMusic(
+          childElement as VargElement<"music">,
+          ctx,
+        );
+        path = result.path;
+      } else {
+        throw new Error("Music requires either src or prompt+model");
+      }
+
+      audioTracks.push({
+        path,
+        mixVolume: musicProps.volume ?? 1,
+        cutFrom,
+        cutTo,
+      });
+    }
+  }
+
+  const renderedOverlays: RenderedOverlay[] = [];
+  for (const overlay of overlayElements) {
+    const overlayProps = overlay.props as OverlayProps;
+    for (const child of overlay.children) {
+      if (!child || typeof child !== "object" || !("type" in child)) continue;
+      const childElement = child as VargElement;
+
+      let path: string | undefined;
+      const isVideo =
+        childElement.type === "video" || childElement.type === "animate";
+
+      if (childElement.type === "video") {
+        path = await renderVideo(childElement as VargElement<"video">, ctx);
+      } else if (childElement.type === "animate") {
+        path = await renderAnimate(childElement as VargElement<"animate">, ctx);
+      } else if (childElement.type === "image") {
+        path = await renderImage(childElement as VargElement<"image">, ctx);
+      }
+
+      if (path) {
+        renderedOverlays.push({ path, props: overlayProps, isVideo });
+
+        if (isVideo && overlayProps.keepAudio) {
+          audioTracks.push({
+            path,
+            mixVolume: overlayProps.volume ?? 1,
+          });
+        }
+      }
+    }
+  }
+
+  const renderedClips = await Promise.all(
+    clipElements.map((clipElement) => renderClip(clipElement, ctx)),
+  );
+
+  const clips: Clip[] = [];
+  let currentTime = 0;
+
+  for (let i = 0; i < clipElements.length; i++) {
+    const clipElement = clipElements[i];
+    const clip = renderedClips[i];
+    if (!clipElement || !clip) {
+      throw new Error(`Missing clip data at index ${i}`);
+    }
+    const clipProps = clipElement.props as ClipProps;
+    const clipDuration =
+      typeof clipProps.duration === "number" ? clipProps.duration : 3;
+
+    for (const overlay of renderedOverlays) {
+      const overlayLayer: VideoLayer = {
+        type: "video",
+        path: overlay.path,
+        cutFrom: currentTime,
+        cutTo: currentTime + clipDuration,
+        left: overlay.props.left,
+        top: overlay.props.top,
+        width: overlay.props.width,
+        height: overlay.props.height,
+      };
+      clip.layers.push(overlayLayer as Layer);
+    }
+
+    clips.push(clip);
+
+    currentTime += clipDuration;
+    if (i < clipElements.length - 1 && clip.transition) {
+      currentTime -= clip.transition.duration ?? 0;
+    }
+  }
+
+  const outPath = options.output ?? `output/varg-${Date.now()}.mp4`;
+
+  const editlyTaskId = addTask(progress, "editly", "ffmpeg");
+  startTask(progress, editlyTaskId);
+
+  await editly({
+    outPath,
+    width: ctx.width,
+    height: ctx.height,
+    fps: ctx.fps,
+    clips,
+    audioTracks: audioTracks.length > 0 ? audioTracks : undefined,
+  });
+
+  completeTask(progress, editlyTaskId);
+
+  const result = await Bun.file(outPath).arrayBuffer();
+  return new Uint8Array(result);
+}

--- a/src/ai-sdk/react/renderers/speech.ts
+++ b/src/ai-sdk/react/renderers/speech.ts
@@ -1,0 +1,53 @@
+import { experimental_generateSpeech as generateSpeech } from "ai";
+import { File } from "../../file";
+import type { SpeechProps, VargElement } from "../types";
+import type { RenderContext } from "./context";
+import { addTask, completeTask, startTask } from "./progress";
+import { computeCacheKey, getTextContent } from "./utils";
+
+export interface SpeechResult {
+  path: string;
+  duration?: number;
+}
+
+export async function renderSpeech(
+  element: VargElement<"speech">,
+  ctx: RenderContext,
+): Promise<SpeechResult> {
+  const props = element.props as SpeechProps;
+  const text = getTextContent(element.children);
+
+  if (!text) {
+    throw new Error("Speech element requires text content");
+  }
+
+  const model = props.model;
+  if (!model) {
+    throw new Error("Speech element requires 'model' prop");
+  }
+
+  const cacheKey = computeCacheKey(element);
+
+  const modelId = typeof model === "string" ? model : model.modelId;
+  const taskId = ctx.progress ? addTask(ctx.progress, "speech", modelId) : null;
+  if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+
+  const { audio } = await generateSpeech({
+    model,
+    text,
+    voice: props.voice ?? "adam",
+    cacheKey,
+  } as Parameters<typeof generateSpeech>[0]);
+
+  if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+
+  const tempPath = await File.toTemp({
+    uint8Array: audio.uint8Array,
+    mimeType: "audio/mpeg",
+  });
+  ctx.tempFiles.push(tempPath);
+
+  return {
+    path: tempPath,
+  };
+}

--- a/src/ai-sdk/react/renderers/subtitle.ts
+++ b/src/ai-sdk/react/renderers/subtitle.ts
@@ -1,0 +1,16 @@
+import type { SubtitleLayer } from "../../providers/editly/types";
+import type { SubtitleProps, VargElement } from "../types";
+import { getTextContent } from "./utils";
+
+export function renderSubtitle(
+  element: VargElement<"subtitle">,
+): SubtitleLayer {
+  const props = element.props as SubtitleProps;
+  const text = getTextContent(element.children);
+
+  return {
+    type: "subtitle",
+    text,
+    backgroundColor: props.backgroundColor,
+  };
+}

--- a/src/ai-sdk/react/renderers/title.ts
+++ b/src/ai-sdk/react/renderers/title.ts
@@ -1,0 +1,17 @@
+import type { TitleLayer } from "../../providers/editly/types";
+import type { TitleProps, VargElement } from "../types";
+import { getTextContent } from "./utils";
+
+export function renderTitle(element: VargElement<"title">): TitleLayer {
+  const props = element.props as TitleProps;
+  const text = getTextContent(element.children);
+
+  return {
+    type: "title",
+    text,
+    textColor: props.color,
+    position: props.position,
+    start: props.start,
+    stop: props.end,
+  };
+}

--- a/src/ai-sdk/react/renderers/utils.ts
+++ b/src/ai-sdk/react/renderers/utils.ts
@@ -1,0 +1,124 @@
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import type { VargElement, VargNode } from "../types";
+
+export function resolvePath(path: string): string {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+  return resolve(process.cwd(), path);
+}
+
+export function toFileUrl(path: string): string {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+  return `file://${resolvePath(path)}`;
+}
+
+type CacheKeyPart = string | number | boolean | null | undefined;
+
+function isVargElement(v: unknown): v is VargElement {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    "type" in v &&
+    "props" in v &&
+    "children" in v
+  );
+}
+
+function isLocalFilePath(v: string): boolean {
+  if (v.startsWith("http://") || v.startsWith("https://")) return false;
+  if (v.startsWith("data:")) return false;
+  const resolved = resolvePath(v);
+  return existsSync(resolved);
+}
+
+function getFileFingerprint(path: string): string {
+  const resolved = resolvePath(path);
+  const stat = statSync(resolved);
+  return `${path}:${stat.mtimeMs}:${stat.size}`;
+}
+
+function serializeValue(v: unknown): string {
+  if (typeof v === "string") {
+    if (isLocalFilePath(v)) {
+      return getFileFingerprint(v);
+    }
+    return v;
+  }
+  if (v instanceof Uint8Array) {
+    return Buffer.from(v).toString("base64");
+  }
+  if (Array.isArray(v)) {
+    return `[${v.map(serializeValue).join(",")}]`;
+  }
+  if (v && typeof v === "object") {
+    const entries = Object.entries(v)
+      .map(([key, val]) => `${key}:${serializeValue(val)}`)
+      .join(",");
+    return `{${entries}}`;
+  }
+  return String(v);
+}
+
+export function computeCacheKey(element: VargElement): CacheKeyPart[] {
+  const key: CacheKeyPart[] = [element.type];
+
+  for (const [k, v] of Object.entries(element.props)) {
+    if (k === "children") continue;
+    if (k === "model" && v && typeof v === "object" && "modelId" in v) {
+      const model = v as {
+        provider?: string;
+        modelId: string;
+        settings?: Record<string, unknown>;
+      };
+      key.push("model", model.provider ?? "", model.modelId);
+      // Include model settings in cache key (e.g., higgsfield styleId, quality)
+      if (model.settings) {
+        key.push("modelSettings", serializeValue(model.settings));
+      }
+      continue;
+    }
+    if (typeof v === "string") {
+      if (isLocalFilePath(v)) {
+        key.push(k, getFileFingerprint(v));
+      } else {
+        key.push(k, v);
+      }
+    } else if (typeof v === "number" || typeof v === "boolean") {
+      key.push(k, v);
+    } else if (v === null || v === undefined) {
+      key.push(k, v);
+    } else if (v instanceof Uint8Array) {
+      key.push(k, Buffer.from(v).toString("base64"));
+    } else if (isVargElement(v)) {
+      key.push(k, ...computeCacheKey(v));
+    } else if (Array.isArray(v) || typeof v === "object") {
+      key.push(k, serializeValue(v));
+    }
+  }
+
+  for (const child of element.children) {
+    if (typeof child === "string") {
+      key.push("text", child);
+    } else if (typeof child === "number") {
+      key.push("num", child);
+    } else if (isVargElement(child)) {
+      key.push("child", ...computeCacheKey(child));
+    }
+  }
+
+  return key;
+}
+
+export function getTextContent(node: VargNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(getTextContent).join("");
+  if (node && typeof node === "object" && "children" in node) {
+    return node.children.map(getTextContent).join("");
+  }
+  return "";
+}

--- a/src/ai-sdk/react/renderers/video.ts
+++ b/src/ai-sdk/react/renderers/video.ts
@@ -1,0 +1,126 @@
+import { File } from "../../file";
+import type { generateVideo } from "../../generate-video";
+import type {
+  ImageInput,
+  VargElement,
+  VideoPrompt,
+  VideoProps,
+} from "../types";
+import type { RenderContext } from "./context";
+import { renderImage } from "./image";
+import { addTask, completeTask, startTask } from "./progress";
+import { computeCacheKey, toFileUrl } from "./utils";
+
+async function resolveImageInput(
+  input: ImageInput,
+  ctx: RenderContext,
+): Promise<Uint8Array> {
+  if (input instanceof Uint8Array) {
+    return input;
+  }
+  if (typeof input === "string") {
+    const response = await fetch(toFileUrl(input));
+    return new Uint8Array(await response.arrayBuffer());
+  }
+  const path = await renderImage(input, ctx);
+  const response = await fetch(toFileUrl(path));
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function resolveMediaInput(
+  input: Uint8Array | string | undefined,
+): Promise<Uint8Array | undefined> {
+  if (!input) return undefined;
+  if (input instanceof Uint8Array) return input;
+  const response = await fetch(toFileUrl(input));
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function resolvePrompt(
+  prompt: VideoPrompt,
+  ctx: RenderContext,
+): Promise<
+  | string
+  | {
+      text?: string;
+      images?: Uint8Array[];
+      audio?: Uint8Array;
+      video?: Uint8Array;
+    }
+> {
+  if (typeof prompt === "string") {
+    return prompt;
+  }
+  const [resolvedImages, resolvedAudio, resolvedVideo] = await Promise.all([
+    prompt.images
+      ? Promise.all(prompt.images.map((img) => resolveImageInput(img, ctx)))
+      : undefined,
+    resolveMediaInput(prompt.audio),
+    resolveMediaInput(prompt.video),
+  ]);
+  return {
+    text: prompt.text,
+    images: resolvedImages,
+    audio: resolvedAudio,
+    video: resolvedVideo,
+  };
+}
+
+export async function renderVideo(
+  element: VargElement<"video">,
+  ctx: RenderContext,
+): Promise<string> {
+  const props = element.props as VideoProps;
+
+  if (props.src && !props.prompt) {
+    return props.src;
+  }
+
+  if (!props.prompt) {
+    throw new Error("Video element requires either 'prompt' or 'src'");
+  }
+
+  const model = props.model;
+  if (!model) {
+    throw new Error("Video element requires 'model' prop when using prompt");
+  }
+
+  // Compute cache key for deduplication
+  const cacheKey = computeCacheKey(element);
+  const cacheKeyStr = JSON.stringify(cacheKey);
+
+  // Check if this element is already being rendered (deduplication)
+  const pendingRender = ctx.pending.get(cacheKeyStr);
+  if (pendingRender) {
+    return pendingRender;
+  }
+
+  // Create the render promise and store it for deduplication
+  const renderPromise = (async () => {
+    const resolvedPrompt = await resolvePrompt(props.prompt!, ctx);
+
+    const modelId = typeof model === "string" ? model : model.modelId;
+    const taskId = ctx.progress
+      ? addTask(ctx.progress, "video", modelId)
+      : null;
+    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+
+    const { video } = await ctx.generateVideo({
+      model,
+      prompt: resolvedPrompt,
+      duration: 5,
+      cacheKey,
+    } as Parameters<typeof generateVideo>[0]);
+
+    if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+
+    const tempPath = await File.toTemp(video);
+    ctx.tempFiles.push(tempPath);
+
+    return tempPath;
+  })();
+
+  ctx.pending.set(cacheKeyStr, renderPromise);
+
+  return renderPromise;
+}

--- a/src/ai-sdk/react/types.ts
+++ b/src/ai-sdk/react/types.ts
@@ -1,0 +1,227 @@
+import type { ImageModelV3, SpeechModelV3 } from "@ai-sdk/provider";
+import type { MusicModelV3 } from "../music-model";
+import type {
+  Position,
+  ResizeMode,
+  SizeValue,
+  TransitionOptions,
+} from "../providers/editly/types";
+import type { VideoModelV3 } from "../video-model";
+
+export type VargElementType =
+  | "render"
+  | "clip"
+  | "overlay"
+  | "image"
+  | "video"
+  | "animate"
+  | "speech"
+  | "talking-head"
+  | "title"
+  | "subtitle"
+  | "music"
+  | "captions"
+  | "split"
+  | "slider"
+  | "swipe"
+  | "packshot";
+
+export interface VargElement<T extends VargElementType = VargElementType> {
+  type: T;
+  props: Record<string, unknown>;
+  children: VargNode[];
+}
+
+export type VargNode =
+  | VargElement
+  | string
+  | number
+  | null
+  | undefined
+  | VargNode[];
+
+export interface BaseProps {
+  key?: string | number;
+}
+
+export interface PositionProps {
+  left?: SizeValue;
+  top?: SizeValue;
+  width?: SizeValue;
+  height?: SizeValue;
+}
+
+export interface VolumeProps {
+  volume?: number;
+}
+
+export interface AudioProps extends VolumeProps {
+  keepAudio?: boolean;
+}
+
+export type TrimProps =
+  | { cutFrom?: number; cutTo?: number; duration?: never }
+  | { cutFrom?: number; cutTo?: never; duration?: number };
+
+// Root container - sets dimensions, fps, contains clips
+export interface RenderProps extends BaseProps {
+  width?: number;
+  height?: number;
+  fps?: number;
+  normalize?: boolean;
+  children?: VargNode;
+}
+
+export interface ClipProps extends BaseProps {
+  duration?: number | "auto";
+  transition?: TransitionOptions;
+  children?: VargNode;
+}
+
+export interface OverlayProps extends BaseProps, PositionProps, AudioProps {
+  children?: VargNode;
+}
+
+export type ImageInput = Uint8Array | string | VargElement<"image">;
+export type ImagePrompt = string | { text?: string; images: ImageInput[] };
+
+export interface ImageProps extends BaseProps, PositionProps {
+  prompt?: ImagePrompt;
+  src?: string;
+  model?: ImageModelV3;
+  aspectRatio?: `${number}:${number}`;
+  zoom?: "in" | "out" | "left" | "right";
+  resize?: ResizeMode;
+  position?: Position;
+  size?: { width: string; height: string };
+  removeBackground?: boolean;
+}
+
+export type VideoPrompt =
+  | string
+  | {
+      text?: string;
+      images?: ImageInput[];
+      audio?: Uint8Array | string;
+      video?: Uint8Array | string;
+    };
+
+export type VideoProps = BaseProps &
+  PositionProps &
+  AudioProps &
+  TrimProps & {
+    prompt?: VideoPrompt;
+    src?: string;
+    model?: VideoModelV3;
+    resize?: ResizeMode;
+  };
+
+// Image-to-video animation
+export interface AnimateProps extends BaseProps, PositionProps {
+  image?: VargElement<"image">;
+  src?: string;
+  model?: VideoModelV3;
+  motion?: string;
+  duration?: number;
+}
+
+export interface SpeechProps extends BaseProps, VolumeProps {
+  voice?: string;
+  model?: SpeechModelV3;
+  id?: string;
+  children?: string;
+}
+
+export interface TalkingHeadProps extends BaseProps {
+  character?: string;
+  src?: string;
+  voice?: string;
+  model?: VideoModelV3;
+  lipsyncModel?: VideoModelV3;
+  position?:
+    | Position
+    | { left?: string; right?: string; top?: string; bottom?: string };
+  size?: { width: string; height: string };
+  children?: string;
+}
+
+export interface TitleProps extends BaseProps {
+  position?: Position;
+  color?: string;
+  start?: number;
+  end?: number;
+  children?: string;
+}
+
+export interface SubtitleProps extends BaseProps {
+  backgroundColor?: string;
+  children?: string;
+}
+
+export type MusicProps = BaseProps &
+  VolumeProps &
+  TrimProps & {
+    prompt?: string;
+    model?: MusicModelV3;
+    src?: string;
+    loop?: boolean;
+    ducking?: boolean;
+  };
+
+export interface CaptionsProps extends BaseProps {
+  src?: string | VargElement<"speech">;
+  srt?: string;
+  style?: "tiktok" | "karaoke" | "bounce" | "typewriter";
+  color?: string;
+  activeColor?: string;
+  fontSize?: number;
+}
+
+export interface SplitProps extends BaseProps {
+  direction?: "horizontal" | "vertical";
+  children?: VargNode;
+}
+
+export interface SliderProps extends BaseProps {
+  direction?: "horizontal" | "vertical";
+  children?: VargNode;
+}
+
+export interface SwipeProps extends BaseProps {
+  direction?: "left" | "right" | "up" | "down";
+  interval?: number;
+  children?: VargNode;
+}
+
+export interface PackshotProps extends BaseProps {
+  background?: VargElement<"image">;
+  logo?: string;
+  cta?: string;
+  ctaColor?: string;
+  blinkCta?: boolean;
+}
+
+export interface RenderOptions {
+  output?: string;
+  cache?: string;
+  quiet?: boolean;
+}
+
+export interface ElementPropsMap {
+  render: RenderProps;
+  clip: ClipProps;
+  overlay: OverlayProps;
+  image: ImageProps;
+  video: VideoProps;
+  animate: AnimateProps;
+  speech: SpeechProps;
+  "talking-head": TalkingHeadProps;
+  title: TitleProps;
+  subtitle: SubtitleProps;
+  music: MusicProps;
+  captions: CaptionsProps;
+  split: SplitProps;
+  slider: SliderProps;
+  swipe: SwipeProps;
+  packshot: PackshotProps;
+}

--- a/src/ai-sdk/studio/index.ts
+++ b/src/ai-sdk/studio/index.ts
@@ -1,0 +1,26 @@
+import { resolve } from "node:path";
+import { createStudioServer } from "./server";
+
+// Parse arguments: bun run studio [file.tsx] [--cache=.cache/ai]
+let initialFile: string | undefined;
+let cacheDir = ".cache/ai";
+
+for (const arg of process.argv.slice(2)) {
+  if (arg.startsWith("--cache=")) {
+    cacheDir = arg.replace("--cache=", "");
+  } else if (arg.endsWith(".tsx") || arg.endsWith(".ts")) {
+    initialFile = resolve(arg);
+  }
+}
+
+console.log("varg studio starting...");
+console.log(`cache folder: ${cacheDir}`);
+if (initialFile) {
+  console.log(`initial file: ${initialFile}`);
+}
+
+const { port } = createStudioServer({ cacheDir, initialFile });
+
+console.log(`\nopen http://localhost:${port}`);
+console.log("  /editor - code editor");
+console.log("  /cache  - cache viewer");

--- a/src/ai-sdk/studio/scanner.ts
+++ b/src/ai-sdk/studio/scanner.ts
@@ -1,0 +1,102 @@
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { CacheEntry, CacheItem, ImageData, VideoData } from "./types";
+
+function extractBase64(data: ImageData | VideoData): string | null {
+  if (
+    "uint8ArrayData" in data &&
+    data.uint8ArrayData?.__type === "Uint8Array"
+  ) {
+    return data.uint8ArrayData.data;
+  }
+  if ("_data" in data && data._data?.__type === "Uint8Array") {
+    return data._data.data;
+  }
+  if ("base64" in data && data.base64) {
+    return data.base64;
+  }
+  return null;
+}
+
+function detectMediaType(
+  filename: string,
+  value: unknown,
+): "image" | "video" | "unknown" {
+  if (filename.startsWith("generateImage")) return "image";
+  if (filename.startsWith("generateVideo")) return "video";
+
+  if (value && typeof value === "object") {
+    const v = value as Record<string, unknown>;
+    if ("images" in v) return "image";
+    if ("video" in v) return "video";
+  }
+
+  return "unknown";
+}
+
+export async function scanCacheFolder(cacheDir: string): Promise<CacheItem[]> {
+  const items: CacheItem[] = [];
+
+  try {
+    const files = await readdir(cacheDir);
+
+    for (const file of files) {
+      if (!file.endsWith(".json") || file === ".gitkeep") continue;
+
+      const filePath = join(cacheDir, file);
+      const fileStat = await stat(filePath);
+
+      try {
+        const content = await Bun.file(filePath).text();
+        const entry = JSON.parse(content) as CacheEntry;
+        const type = detectMediaType(file, entry.value);
+
+        items.push({
+          id: file.replace(".json", ""),
+          filename: file,
+          type,
+          size: fileStat.size,
+          createdAt: fileStat.mtime,
+          metadata: { expires: entry.expires },
+        });
+      } catch {}
+    }
+  } catch (err) {
+    console.error("failed to scan cache folder:", err);
+  }
+
+  return items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+}
+
+export async function getCacheItemMedia(
+  cacheDir: string,
+  id: string,
+): Promise<{ type: "image" | "video"; data: string; mimeType: string } | null> {
+  const filePath = join(cacheDir, `${id}.json`);
+
+  try {
+    const content = await Bun.file(filePath).text();
+    const entry = JSON.parse(content) as CacheEntry;
+    const value = entry.value as Record<string, unknown>;
+
+    if ("images" in value && Array.isArray(value.images)) {
+      const firstImage = value.images[0] as ImageData;
+      const base64 = extractBase64(firstImage);
+      if (base64) {
+        return { type: "image", data: base64, mimeType: "image/jpeg" };
+      }
+    }
+
+    if ("video" in value && typeof value.video === "object") {
+      const video = value.video as VideoData;
+      const base64 = extractBase64(video);
+      if (base64) {
+        return { type: "video", data: base64, mimeType: "video/mp4" };
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/ai-sdk/studio/server.ts
+++ b/src/ai-sdk/studio/server.ts
@@ -1,0 +1,554 @@
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { getCacheItemMedia, scanCacheFolder } from "./scanner";
+import { extractStages, serializeStages } from "./stages";
+import {
+  createStepSession,
+  deleteSession,
+  executeNextStage,
+  executeStage,
+  getSession,
+  getSessionStatus,
+  getStagePreviewPath,
+} from "./step-renderer";
+import type { CacheItem, RenderProgress, RenderRequest } from "./types";
+
+const DEFAULT_CACHE_DIR = ".cache/ai";
+const DEFAULT_OUTPUT_DIR = "output/studio";
+const DEFAULT_SHARES_DIR = "output/studio/shares";
+
+interface StudioConfig {
+  cacheDir: string;
+  outputDir: string;
+  port: number;
+  initialFile?: string;
+}
+
+interface ShareData {
+  code: string;
+  videoUrl?: string;
+  createdAt: string;
+}
+
+interface TemplateInfo {
+  id: string;
+  name: string;
+  filename: string;
+}
+
+function fileNameToReadable(filename: string): string {
+  return basename(filename, ".tsx")
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (c) => c.toLowerCase());
+}
+
+function scanTemplates(dir: string): TemplateInfo[] {
+  const templates: TemplateInfo[] = [];
+
+  if (!existsSync(dir)) return templates;
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (
+      entry.isFile() &&
+      entry.name.endsWith(".tsx") &&
+      !entry.name.startsWith("_")
+    ) {
+      const id = basename(entry.name, ".tsx");
+      templates.push({
+        id,
+        name: fileNameToReadable(entry.name),
+        filename: entry.name,
+      });
+    }
+  }
+
+  return templates.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function createStudioServer(config: Partial<StudioConfig> = {}) {
+  const cacheDir = resolve(config.cacheDir ?? DEFAULT_CACHE_DIR);
+  const outputDir = resolve(config.outputDir ?? DEFAULT_OUTPUT_DIR);
+  const sharesDir = resolve(DEFAULT_SHARES_DIR);
+  const port = config.port ?? 8282;
+  const initialFile = config.initialFile;
+
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+  if (!existsSync(sharesDir)) {
+    mkdirSync(sharesDir, { recursive: true });
+  }
+
+  let cachedItems: CacheItem[] = [];
+
+  async function refreshCache() {
+    if (existsSync(cacheDir)) {
+      cachedItems = await scanCacheFolder(cacheDir);
+    }
+  }
+
+  const activeRenders = new Map<string, AbortController>();
+
+  async function executeRender(
+    code: string,
+    renderId: string,
+    onProgress: (progress: RenderProgress) => void,
+    signal: AbortSignal,
+  ): Promise<string> {
+    const outputPath = join(outputDir, `${renderId}.mp4`);
+    const tempDir = join(import.meta.dir, "../examples");
+    const tempFile = join(tempDir, `_studio_${renderId}.tsx`);
+
+    onProgress({ step: "parsing", progress: 0, message: "parsing code..." });
+    await Bun.write(tempFile, code);
+    onProgress({
+      step: "rendering",
+      progress: 0.1,
+      message: "starting render...",
+    });
+
+    try {
+      console.log(`[render] importing ${tempFile}`);
+      const mod = await import(tempFile);
+      const element = mod.default;
+
+      if (
+        !element ||
+        typeof element !== "object" ||
+        element.type !== "render"
+      ) {
+        throw new Error("file must export a <Render> element as default");
+      }
+
+      console.log("[render] starting render pipeline");
+      const { render } = await import("../react/render");
+
+      await render(element, {
+        output: outputPath,
+        cache: cacheDir,
+        quiet: false,
+      });
+
+      console.log(`[render] complete: ${outputPath}`);
+      onProgress({ step: "complete", progress: 1, message: "done!" });
+      return outputPath;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[render] error: ${msg}`);
+      if (err instanceof Error && err.stack) {
+        console.error(err.stack);
+      }
+      throw new Error(msg);
+    } finally {
+      try {
+        if (await Bun.file(tempFile).exists()) {
+          await Bun.$`rm ${tempFile}`;
+        }
+      } catch {}
+    }
+  }
+
+  const server = Bun.serve({
+    port,
+    idleTimeout: 255,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const method = req.method;
+      const path = url.pathname;
+
+      if (path.startsWith("/api/")) {
+        console.log(`${method} ${path}`);
+      }
+
+      if (url.pathname === "/" || url.pathname === "/editor") {
+        const html = await Bun.file(
+          join(import.meta.dir, "ui/index.html"),
+        ).text();
+        return new Response(html, { headers: { "content-type": "text/html" } });
+      }
+
+      if (url.pathname === "/cache") {
+        const html = await Bun.file(
+          join(import.meta.dir, "ui/cache.html"),
+        ).text();
+        return new Response(html, { headers: { "content-type": "text/html" } });
+      }
+
+      if (url.pathname === "/api/items") {
+        await refreshCache();
+        return Response.json(cachedItems);
+      }
+
+      if (url.pathname.startsWith("/api/media/")) {
+        const id = decodeURIComponent(url.pathname.replace("/api/media/", ""));
+        const media = await getCacheItemMedia(cacheDir, id);
+        if (!media) return new Response("not found", { status: 404 });
+        const buffer = Buffer.from(media.data, "base64");
+        return new Response(buffer, {
+          headers: { "content-type": media.mimeType },
+        });
+      }
+
+      if (url.pathname === "/api/initial-code") {
+        if (!initialFile) {
+          return Response.json({ code: null });
+        }
+        const file = Bun.file(initialFile);
+        if (!(await file.exists())) {
+          return Response.json({ code: null, error: "file not found" });
+        }
+        const code = await file.text();
+        return Response.json({ code, path: initialFile });
+      }
+
+      if (url.pathname === "/api/templates") {
+        const examplesDir = join(import.meta.dir, "../examples");
+        const templates = scanTemplates(examplesDir).map((t) => ({
+          id: t.id,
+          name: t.name,
+        }));
+        return Response.json(templates);
+      }
+
+      if (url.pathname.startsWith("/api/templates/")) {
+        const id = url.pathname.replace("/api/templates/", "");
+        const examplesDir = join(import.meta.dir, "../examples");
+        const templates = scanTemplates(examplesDir);
+        const template = templates.find((t) => t.id === id);
+        if (!template) return new Response("not found", { status: 404 });
+        const code = await Bun.file(
+          join(examplesDir, template.filename),
+        ).text();
+        return Response.json({ code });
+      }
+
+      if (url.pathname === "/api/render" && req.method === "POST") {
+        const body = (await req.json()) as RenderRequest;
+        const renderId = `render-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const controller = new AbortController();
+        activeRenders.set(renderId, controller);
+
+        const stream = new ReadableStream({
+          async start(streamController) {
+            const encoder = new TextEncoder();
+            const send = (event: string, data: unknown) => {
+              streamController.enqueue(
+                encoder.encode(
+                  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
+                ),
+              );
+            };
+
+            try {
+              send("start", { renderId });
+              const outputPath = await executeRender(
+                body.code,
+                renderId,
+                (progress) => send("progress", progress),
+                controller.signal,
+              );
+              send("complete", { videoUrl: `/api/output/${renderId}.mp4` });
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : "unknown error";
+              send("error", { message });
+            } finally {
+              activeRenders.delete(renderId);
+              streamController.close();
+            }
+          },
+        });
+
+        return new Response(stream, {
+          headers: {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+          },
+        });
+      }
+
+      if (url.pathname.startsWith("/api/render/") && req.method === "DELETE") {
+        const renderId = url.pathname.replace("/api/render/", "");
+        const controller = activeRenders.get(renderId);
+        if (controller) {
+          controller.abort();
+          activeRenders.delete(renderId);
+          return Response.json({ stopped: true });
+        }
+        return Response.json({ stopped: false });
+      }
+
+      if (url.pathname.startsWith("/api/output/")) {
+        const filename = url.pathname.replace("/api/output/", "");
+        const filePath = join(outputDir, filename);
+        const file = Bun.file(filePath);
+        if (!(await file.exists()))
+          return new Response("not found", { status: 404 });
+        return new Response(file, { headers: { "content-type": "video/mp4" } });
+      }
+
+      if (url.pathname === "/api/share" && req.method === "POST") {
+        const body = (await req.json()) as { code: string; videoUrl?: string };
+        const shareId = Math.random().toString(36).slice(2, 10);
+        const shareData: ShareData = {
+          code: body.code,
+          videoUrl: body.videoUrl,
+          createdAt: new Date().toISOString(),
+        };
+        await Bun.write(
+          join(sharesDir, `${shareId}.json`),
+          JSON.stringify(shareData),
+        );
+        return Response.json({ shareId, url: `/s/${shareId}` });
+      }
+
+      if (url.pathname.startsWith("/api/share/")) {
+        const shareId = url.pathname.replace("/api/share/", "");
+        const sharePath = join(sharesDir, `${shareId}.json`);
+        const file = Bun.file(sharePath);
+        if (!(await file.exists()))
+          return new Response("not found", { status: 404 });
+        const data = await file.json();
+        return Response.json(data);
+      }
+
+      if (url.pathname.startsWith("/s/")) {
+        const html = await Bun.file(
+          join(import.meta.dir, "ui/index.html"),
+        ).text();
+        return new Response(html, { headers: { "content-type": "text/html" } });
+      }
+
+      if (url.pathname === "/api/step/stages" && req.method === "POST") {
+        const body = (await req.json()) as { code: string };
+        const tempDir = join(import.meta.dir, "../examples");
+        const tempFile = join(tempDir, `_stages_${Date.now()}.tsx`);
+
+        try {
+          await Bun.write(tempFile, body.code);
+          const mod = await import(tempFile);
+          const element = mod.default;
+
+          if (
+            !element ||
+            typeof element !== "object" ||
+            element.type !== "render"
+          ) {
+            return Response.json(
+              { error: "file must export a <Render> element as default" },
+              { status: 400 },
+            );
+          }
+
+          const extracted = extractStages(element);
+          const serialized = serializeStages(extracted);
+
+          return Response.json(serialized);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return Response.json({ error: message }, { status: 400 });
+        } finally {
+          try {
+            if (await Bun.file(tempFile).exists()) {
+              await Bun.$`rm ${tempFile}`;
+            }
+          } catch {}
+        }
+      }
+
+      if (url.pathname === "/api/step/session" && req.method === "POST") {
+        const body = (await req.json()) as { code: string };
+        const tempDir = join(import.meta.dir, "../examples");
+        const tempFile = join(tempDir, `_session_${Date.now()}.tsx`);
+
+        try {
+          await Bun.write(tempFile, body.code);
+          const mod = await import(tempFile);
+          const element = mod.default;
+
+          if (
+            !element ||
+            typeof element !== "object" ||
+            element.type !== "render"
+          ) {
+            return Response.json(
+              { error: "file must export a <Render> element as default" },
+              { status: 400 },
+            );
+          }
+
+          const session = createStepSession(body.code, element, cacheDir);
+          const status = getSessionStatus(session);
+
+          return Response.json(status);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return Response.json({ error: message }, { status: 400 });
+        } finally {
+          try {
+            if (await Bun.file(tempFile).exists()) {
+              await Bun.$`rm ${tempFile}`;
+            }
+          } catch {}
+        }
+      }
+
+      if (url.pathname === "/api/step/next" && req.method === "POST") {
+        const body = (await req.json()) as { sessionId: string };
+        const session = getSession(body.sessionId);
+
+        if (!session) {
+          return Response.json({ error: "session not found" }, { status: 404 });
+        }
+
+        try {
+          const result = await executeNextStage(session);
+
+          if (!result) {
+            return Response.json({
+              done: true,
+              status: getSessionStatus(session),
+            });
+          }
+
+          return Response.json({
+            done: false,
+            stage: {
+              id: result.stage.id,
+              type: result.stage.type,
+              label: result.stage.label,
+              status: result.stage.status,
+            },
+            result: result.result,
+            isLast: result.isLast,
+            status: getSessionStatus(session),
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return Response.json(
+            { error: message, status: getSessionStatus(session) },
+            { status: 500 },
+          );
+        }
+      }
+
+      if (url.pathname === "/api/step/run" && req.method === "POST") {
+        const body = (await req.json()) as {
+          sessionId: string;
+          stageId: string;
+        };
+        const session = getSession(body.sessionId);
+
+        if (!session) {
+          return Response.json({ error: "session not found" }, { status: 404 });
+        }
+
+        try {
+          const result = await executeStage(session, body.stageId);
+          return Response.json({
+            result,
+            status: getSessionStatus(session),
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return Response.json(
+            { error: message, status: getSessionStatus(session) },
+            { status: 500 },
+          );
+        }
+      }
+
+      if (
+        url.pathname.match(/^\/api\/step\/preview\/[^/]+\/[^/]+$/) &&
+        req.method === "GET"
+      ) {
+        const parts = url.pathname.split("/");
+        const sessionId = parts[4];
+        const stageId = parts[5];
+
+        if (!sessionId || !stageId) {
+          return new Response("invalid path", { status: 400 });
+        }
+
+        const session = getSession(sessionId);
+        if (!session) {
+          return new Response("session not found", { status: 404 });
+        }
+
+        const previewPath = getStagePreviewPath(session, stageId);
+        if (!previewPath) {
+          return new Response("preview not found", { status: 404 });
+        }
+
+        const file = Bun.file(previewPath);
+        if (!(await file.exists())) {
+          return new Response("file not found", { status: 404 });
+        }
+
+        const mimeType = previewPath.endsWith(".mp4")
+          ? "video/mp4"
+          : previewPath.endsWith(".mp3")
+            ? "audio/mp3"
+            : "image/png";
+
+        return new Response(file, { headers: { "content-type": mimeType } });
+      }
+
+      if (
+        url.pathname.match(/^\/api\/step\/session\/[^/]+$/) &&
+        req.method === "GET"
+      ) {
+        const sessionId = url.pathname.split("/").pop();
+        if (!sessionId) {
+          return new Response("invalid path", { status: 400 });
+        }
+
+        const session = getSession(sessionId);
+        if (!session) {
+          return Response.json({ error: "session not found" }, { status: 404 });
+        }
+
+        return Response.json(getSessionStatus(session));
+      }
+
+      if (
+        url.pathname.match(/^\/api\/step\/session\/[^/]+$/) &&
+        req.method === "DELETE"
+      ) {
+        const sessionId = url.pathname.split("/").pop();
+        if (!sessionId) {
+          return new Response("invalid path", { status: 400 });
+        }
+
+        deleteSession(sessionId);
+        return Response.json({ deleted: true });
+      }
+
+      if (url.pathname === "/api/step/render" && req.method === "POST") {
+        const body = (await req.json()) as { sessionId: string };
+        const session = getSession(body.sessionId);
+
+        if (!session) {
+          return Response.json({ error: "session not found" }, { status: 404 });
+        }
+
+        try {
+          const { finalizeRender } = await import("./step-renderer");
+          const videoPath = await finalizeRender(session, outputDir);
+          const videoUrl = `/api/output/${videoPath.split("/").pop()}`;
+          return Response.json({ videoUrl, path: videoPath });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return Response.json({ error: message }, { status: 500 });
+        }
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  return { server, port };
+}

--- a/src/ai-sdk/studio/stages.ts
+++ b/src/ai-sdk/studio/stages.ts
@@ -1,0 +1,251 @@
+import type { VargElement, VargNode } from "../react/types";
+
+export type StageType = "image" | "video" | "animate" | "speech" | "music";
+
+export interface RenderStage {
+  id: string;
+  type: StageType;
+  label: string;
+  element: VargElement;
+  path: string[]; // path in the tree for identification
+  dependsOn: string[]; // stage ids this depends on
+  status: "pending" | "running" | "complete" | "error";
+  result?: StageResult;
+}
+
+export interface StageResult {
+  type: "image" | "video" | "audio";
+  path: string;
+  previewUrl?: string;
+  mimeType: string;
+}
+
+export interface ExtractedStages {
+  stages: RenderStage[];
+  order: string[]; // topologically sorted stage ids
+}
+
+/**
+ * Extracts all renderable stages from a JSX tree in dependency order.
+ * Images come before videos that use them, etc.
+ */
+export function extractStages(element: VargElement): ExtractedStages {
+  const stages: RenderStage[] = [];
+  let stageCounter = 0;
+
+  function generateId(): string {
+    return `stage-${stageCounter++}`;
+  }
+
+  function getLabel(type: StageType, element: VargElement): string {
+    const props = element.props as Record<string, unknown>;
+
+    if (type === "image") {
+      const prompt = props.prompt;
+      if (typeof prompt === "string") {
+        return `image: ${prompt.slice(0, 30)}${prompt.length > 30 ? "..." : ""}`;
+      }
+      if (prompt && typeof prompt === "object" && "text" in prompt) {
+        const text = (prompt as { text?: string }).text ?? "";
+        return `image: ${text.slice(0, 30)}${text.length > 30 ? "..." : ""}`;
+      }
+      if (props.src) {
+        return `image: ${String(props.src).split("/").pop()}`;
+      }
+      return "image";
+    }
+
+    if (type === "video") {
+      const prompt = props.prompt;
+      if (typeof prompt === "string") {
+        return `video: ${prompt.slice(0, 30)}${prompt.length > 30 ? "..." : ""}`;
+      }
+      if (prompt && typeof prompt === "object" && "text" in prompt) {
+        const text = (prompt as { text?: string }).text ?? "";
+        return `video: ${text.slice(0, 30)}${text.length > 30 ? "..." : ""}`;
+      }
+      if (props.src) {
+        return `video: ${String(props.src).split("/").pop()}`;
+      }
+      return "video";
+    }
+
+    if (type === "animate") {
+      const motion = props.motion;
+      return motion ? `animate: ${motion}` : "animate";
+    }
+
+    if (type === "speech") {
+      const text = getTextContent(element.children);
+      return `speech: ${text.slice(0, 30)}${text.length > 30 ? "..." : ""}`;
+    }
+
+    if (type === "music") {
+      const prompt = props.prompt;
+      if (typeof prompt === "string") {
+        return `music: ${prompt.slice(0, 30)}${prompt.length > 30 ? "..." : ""}`;
+      }
+      if (props.src) {
+        return `music: ${String(props.src).split("/").pop()}`;
+      }
+      return "music";
+    }
+
+    return type;
+  }
+
+  function getTextContent(children: VargNode[]): string {
+    const texts: string[] = [];
+    for (const child of children) {
+      if (typeof child === "string") {
+        texts.push(child);
+      } else if (typeof child === "number") {
+        texts.push(String(child));
+      }
+    }
+    return texts.join(" ");
+  }
+
+  function walkTree(
+    node: VargNode,
+    path: string[],
+    parentDeps: string[],
+  ): string[] {
+    if (!node || typeof node !== "object" || !("type" in node)) {
+      return [];
+    }
+
+    const element = node as VargElement;
+    const currentPath = [...path, element.type];
+    const collectedDeps: string[] = [...parentDeps];
+
+    // Check if this is a renderable stage
+    const stageTypes: StageType[] = [
+      "image",
+      "video",
+      "animate",
+      "speech",
+      "music",
+    ];
+
+    if (stageTypes.includes(element.type as StageType)) {
+      const stageType = element.type as StageType;
+      const props = element.props as Record<string, unknown>;
+
+      // Skip if it's just a src reference (no generation needed)
+      if (props.src && !props.prompt) {
+        return [];
+      }
+
+      // For video/animate with image inputs, we need to find dependent images first
+      const imageDeps: string[] = [];
+
+      if (stageType === "video" || stageType === "animate") {
+        // Check prompt.images for nested Image elements
+        const prompt = props.prompt as { images?: VargNode[] } | undefined;
+        if (prompt?.images) {
+          for (const imgInput of prompt.images) {
+            if (
+              imgInput &&
+              typeof imgInput === "object" &&
+              "type" in imgInput
+            ) {
+              const imgElement = imgInput as VargElement;
+              if (imgElement.type === "image") {
+                const deps = walkTree(imgElement, currentPath, collectedDeps);
+                imageDeps.push(...deps);
+              }
+            }
+          }
+        }
+
+        // Check for image prop in animate
+        if (stageType === "animate" && props.image) {
+          const imgElement = props.image as VargElement;
+          if (imgElement.type === "image") {
+            const deps = walkTree(imgElement, currentPath, collectedDeps);
+            imageDeps.push(...deps);
+          }
+        }
+      }
+
+      const id = generateId();
+      const stage: RenderStage = {
+        id,
+        type: stageType,
+        label: getLabel(stageType, element),
+        element,
+        path: currentPath,
+        dependsOn: [...new Set([...collectedDeps, ...imageDeps])],
+        status: "pending",
+      };
+
+      stages.push(stage);
+      return [id];
+    }
+
+    // For container elements (render, clip, overlay), recurse into children
+    const childDeps: string[] = [];
+    for (const child of element.children) {
+      const deps = walkTree(child, currentPath, collectedDeps);
+      childDeps.push(...deps);
+    }
+
+    return childDeps;
+  }
+
+  // Start walking from root
+  if (element.type === "render") {
+    walkTree(element, [], []);
+  }
+
+  // Topological sort based on dependencies
+  const order = topologicalSort(stages);
+
+  return { stages, order };
+}
+
+function topologicalSort(stages: RenderStage[]): string[] {
+  const result: string[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  const stageMap = new Map(stages.map((s) => [s.id, s]));
+
+  function visit(id: string) {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) {
+      throw new Error(`Circular dependency detected at stage ${id}`);
+    }
+
+    visiting.add(id);
+    const stage = stageMap.get(id);
+    if (stage) {
+      for (const depId of stage.dependsOn) {
+        visit(depId);
+      }
+    }
+    visiting.delete(id);
+    visited.add(id);
+    result.push(id);
+  }
+
+  for (const stage of stages) {
+    visit(stage.id);
+  }
+
+  return result;
+}
+
+/**
+ * Serializes stages for API response (strips non-serializable element)
+ */
+export function serializeStages(extracted: ExtractedStages): {
+  stages: Omit<RenderStage, "element">[];
+  order: string[];
+} {
+  return {
+    stages: extracted.stages.map(({ element, ...rest }) => rest),
+    order: extracted.order,
+  };
+}

--- a/src/ai-sdk/studio/step-renderer.ts
+++ b/src/ai-sdk/studio/step-renderer.ts
@@ -1,0 +1,280 @@
+import { generateImage } from "ai";
+import { withCache } from "../cache";
+import { File } from "../file";
+import { fileCache } from "../file-cache";
+import { generateVideo } from "../generate-video";
+import { renderAnimate } from "../react/renderers/animate";
+import type { RenderContext } from "../react/renderers/context";
+import { renderImage } from "../react/renderers/image";
+import { renderMusic } from "../react/renderers/music";
+import { createProgressTracker } from "../react/renderers/progress";
+import { renderSpeech } from "../react/renderers/speech";
+import { renderVideo } from "../react/renderers/video";
+import type { RenderProps, VargElement } from "../react/types";
+import type { ExtractedStages, RenderStage, StageResult } from "./stages";
+import { extractStages } from "./stages";
+
+export interface StepSession {
+  id: string;
+  code: string;
+  rootElement: VargElement;
+  extracted: ExtractedStages;
+  ctx: RenderContext;
+  results: Map<string, StageResult>;
+  currentStageIndex: number;
+}
+
+const sessions = new Map<string, StepSession>();
+
+export function createStepSession(
+  code: string,
+  rootElement: VargElement,
+  cacheDir?: string,
+): StepSession {
+  const props = rootElement.props as RenderProps;
+  const cache = cacheDir ? fileCache({ dir: cacheDir }) : undefined;
+
+  const ctx: RenderContext = {
+    width: props.width ?? 1920,
+    height: props.height ?? 1080,
+    fps: props.fps ?? 30,
+    cache,
+    generateImage: cache
+      ? withCache(generateImage, { storage: cache })
+      : generateImage,
+    generateVideo: cache
+      ? withCache(generateVideo, { storage: cache })
+      : generateVideo,
+    tempFiles: [],
+    progress: createProgressTracker(false),
+    pending: new Map(),
+  };
+
+  const extracted = extractStages(rootElement);
+  const sessionId = `step-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const session: StepSession = {
+    id: sessionId,
+    code,
+    rootElement,
+    extracted,
+    ctx,
+    results: new Map(),
+    currentStageIndex: 0,
+  };
+
+  sessions.set(sessionId, session);
+  return session;
+}
+
+export function getSession(sessionId: string): StepSession | undefined {
+  return sessions.get(sessionId);
+}
+
+export function deleteSession(sessionId: string): void {
+  sessions.delete(sessionId);
+}
+
+export async function executeStage(
+  session: StepSession,
+  stageId: string,
+): Promise<StageResult> {
+  const stage = session.extracted.stages.find((s) => s.id === stageId);
+  if (!stage) {
+    throw new Error(`Stage ${stageId} not found`);
+  }
+
+  for (const depId of stage.dependsOn) {
+    if (!session.results.has(depId)) {
+      throw new Error(`Dependency ${depId} not yet executed`);
+    }
+  }
+
+  stage.status = "running";
+  console.log(`[step] executing stage ${stageId}: ${stage.label}`);
+
+  try {
+    let result: StageResult;
+
+    switch (stage.type) {
+      case "image": {
+        const path = await renderImage(
+          stage.element as VargElement<"image">,
+          session.ctx,
+        );
+        result = {
+          type: "image",
+          path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "image/png",
+        };
+        break;
+      }
+
+      case "video": {
+        const path = await renderVideo(
+          stage.element as VargElement<"video">,
+          session.ctx,
+        );
+        result = {
+          type: "video",
+          path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "video/mp4",
+        };
+        break;
+      }
+
+      case "animate": {
+        const path = await renderAnimate(
+          stage.element as VargElement<"animate">,
+          session.ctx,
+        );
+        result = {
+          type: "video",
+          path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "video/mp4",
+        };
+        break;
+      }
+
+      case "speech": {
+        const speechResult = await renderSpeech(
+          stage.element as VargElement<"speech">,
+          session.ctx,
+        );
+        result = {
+          type: "audio",
+          path: speechResult.path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "audio/mp3",
+        };
+        break;
+      }
+
+      case "music": {
+        const musicResult = await renderMusic(
+          stage.element as VargElement<"music">,
+          session.ctx,
+        );
+        result = {
+          type: "audio",
+          path: musicResult.path,
+          previewUrl: `/api/step/preview/${session.id}/${stageId}`,
+          mimeType: "audio/mp3",
+        };
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown stage type: ${stage.type}`);
+    }
+
+    stage.status = "complete";
+    stage.result = result;
+    session.results.set(stageId, result);
+    console.log(`[step] stage ${stageId} complete: ${result.path}`);
+
+    return result;
+  } catch (error) {
+    stage.status = "error";
+    console.error(`[step] stage ${stageId} failed:`, error);
+    throw error;
+  }
+}
+
+export async function executeNextStage(session: StepSession): Promise<{
+  stage: RenderStage;
+  result: StageResult;
+  isLast: boolean;
+} | null> {
+  const { order } = session.extracted;
+
+  if (session.currentStageIndex >= order.length) {
+    return null;
+  }
+
+  const stageId = order[session.currentStageIndex];
+  if (!stageId) {
+    return null;
+  }
+
+  const stage = session.extracted.stages.find((s) => s.id === stageId);
+  if (!stage) {
+    return null;
+  }
+
+  const result = await executeStage(session, stageId);
+  session.currentStageIndex++;
+
+  return {
+    stage,
+    result,
+    isLast: session.currentStageIndex >= order.length,
+  };
+}
+
+export function getStagePreviewPath(
+  session: StepSession,
+  stageId: string,
+): string | null {
+  const result = session.results.get(stageId);
+  return result?.path ?? null;
+}
+
+export async function finalizeRender(
+  session: StepSession,
+  outputDir: string,
+): Promise<string> {
+  const allComplete = session.extracted.stages.every(
+    (s) => s.status === "complete",
+  );
+  if (!allComplete) {
+    throw new Error("Not all stages are complete");
+  }
+
+  const { render } = await import("../react/render");
+  const outputPath = `${outputDir}/render-${session.id}.mp4`;
+
+  await render(session.rootElement, {
+    output: outputPath,
+    cache: session.ctx.cache ? ".cache/ai" : undefined,
+    quiet: true,
+  });
+
+  return outputPath;
+}
+
+export function getSessionStatus(session: StepSession): {
+  sessionId: string;
+  totalStages: number;
+  completedStages: number;
+  currentStageIndex: number;
+  stages: Array<{
+    id: string;
+    type: string;
+    label: string;
+    status: string;
+    hasResult: boolean;
+    dependsOn: string[];
+  }>;
+} {
+  return {
+    sessionId: session.id,
+    totalStages: session.extracted.stages.length,
+    completedStages: session.results.size,
+    currentStageIndex: session.currentStageIndex,
+    stages: session.extracted.order.map((id) => {
+      const stage = session.extracted.stages.find((s) => s.id === id)!;
+      return {
+        id: stage.id,
+        type: stage.type,
+        label: stage.label,
+        status: stage.status,
+        hasResult: session.results.has(id),
+        dependsOn: stage.dependsOn,
+      };
+    }),
+  };
+}

--- a/src/ai-sdk/studio/types.ts
+++ b/src/ai-sdk/studio/types.ts
@@ -1,0 +1,60 @@
+export interface CacheItem {
+  id: string;
+  filename: string;
+  type: "image" | "video" | "unknown";
+  size: number;
+  createdAt: Date;
+  metadata: Record<string, unknown>;
+}
+
+export interface CacheEntry {
+  value: unknown;
+  expires: number;
+}
+
+export interface ImageData {
+  uint8ArrayData?: {
+    __type: "Uint8Array";
+    data: string;
+  };
+  base64?: string;
+  url?: string;
+}
+
+export interface VideoData {
+  _data?: {
+    __type: "Uint8Array";
+    data: string;
+  };
+  uint8ArrayData?: {
+    __type: "Uint8Array";
+    data: string;
+  };
+  base64?: string;
+  url?: string;
+}
+
+export interface RenderRequest {
+  code: string;
+  cacheDir?: string;
+}
+
+export interface RenderProgress {
+  step: "parsing" | "rendering" | "complete" | "error";
+  progress: number;
+  message: string;
+}
+
+export interface Template {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface HistoryItem {
+  id: string;
+  code: string;
+  videoUrl: string;
+  thumbnail?: string;
+  createdAt: Date;
+}

--- a/src/ai-sdk/studio/ui/cache.html
+++ b/src/ai-sdk/studio/ui/cache.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>cache viewer - varg studio</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { 
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0a0a0a;
+      color: #fafafa;
+      min-height: 100vh;
+    }
+    header {
+      height: 48px;
+      padding: 0 1rem;
+      border-bottom: 1px solid #222;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+    .logo { font-weight: 600; font-size: 0.875rem; }
+    .nav { display: flex; gap: 0.25rem; }
+    .nav-btn {
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.375rem;
+      border: none;
+      background: transparent;
+      color: #888;
+      font-size: 0.8rem;
+      cursor: pointer;
+      text-decoration: none;
+      transition: all 0.15s;
+    }
+    .nav-btn:hover { color: #fff; background: #141414; }
+    .nav-btn.active { color: #fff; background: #141414; }
+    .header-right { display: flex; align-items: center; gap: 1rem; }
+    .stats { color: #666; font-size: 0.8rem; }
+    .refresh-btn {
+      padding: 0.375rem 0.75rem;
+      border-radius: 0.375rem;
+      border: 1px solid #333;
+      background: transparent;
+      color: #888;
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+    .refresh-btn:hover { border-color: #555; color: #fff; }
+    .filters {
+      padding: 1rem 2rem;
+      display: flex;
+      gap: 0.5rem;
+    }
+    .filter-btn {
+      padding: 0.5rem 1rem;
+      border-radius: 0.5rem;
+      border: 1px solid #333;
+      background: transparent;
+      color: #888;
+      cursor: pointer;
+      font-size: 0.8rem;
+      transition: all 0.2s;
+    }
+    .filter-btn:hover { border-color: #555; color: #fff; }
+    .filter-btn.active { background: #fff; color: #000; border-color: #fff; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1rem;
+      padding: 1rem 2rem 2rem;
+    }
+    .card {
+      background: #141414;
+      border-radius: 0.75rem;
+      overflow: hidden;
+      border: 1px solid #222;
+      transition: border-color 0.2s;
+    }
+    .card:hover { border-color: #444; }
+    .card-media {
+      aspect-ratio: 16/9;
+      background: #000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      cursor: pointer;
+    }
+    .card-media img, .card-media video {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+    .card-info { padding: 0.875rem; }
+    .card-type {
+      display: inline-block;
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.7rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+    .card-type.image { background: #1a3a1a; color: #4ade80; }
+    .card-type.video { background: #1a1a3a; color: #818cf8; }
+    .card-title {
+      font-size: 0.75rem;
+      color: #999;
+      word-break: break-all;
+      line-height: 1.4;
+    }
+    .card-meta {
+      display: flex;
+      gap: 1rem;
+      margin-top: 0.5rem;
+      font-size: 0.7rem;
+      color: #555;
+    }
+    .empty {
+      text-align: center;
+      padding: 4rem;
+      color: #666;
+    }
+    .modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.9);
+      z-index: 1000;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .modal.open { display: flex; }
+    .modal-content {
+      max-width: 90vw;
+      max-height: 90vh;
+      position: relative;
+    }
+    .modal-content img, .modal-content video {
+      max-width: 90vw;
+      max-height: 90vh;
+      object-fit: contain;
+      border-radius: 0.5rem;
+    }
+    .modal-close {
+      position: absolute;
+      top: -2.5rem;
+      right: 0;
+      background: none;
+      border: none;
+      color: #888;
+      font-size: 1.5rem;
+      cursor: pointer;
+    }
+    .modal-close:hover { color: #fff; }
+    .mute-toggle {
+      position: absolute;
+      bottom: 1rem;
+      right: 1rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.375rem;
+      border: 1px solid #444;
+      background: rgba(0,0,0,0.7);
+      color: #fff;
+      font-size: 0.75rem;
+      cursor: pointer;
+    }
+    .mute-toggle:hover { background: rgba(0,0,0,0.9); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">varg studio</div>
+    <nav class="nav">
+      <a href="/editor" class="nav-btn">editor</a>
+      <a href="/cache" class="nav-btn active">cache</a>
+    </nav>
+    <div class="header-right">
+      <span class="stats" id="stats"></span>
+      <button class="refresh-btn" onclick="refresh()">refresh</button>
+    </div>
+  </header>
+  
+  <div class="filters">
+    <button class="filter-btn active" data-filter="all">all</button>
+    <button class="filter-btn" data-filter="image">images</button>
+    <button class="filter-btn" data-filter="video">videos</button>
+  </div>
+  
+  <div id="grid" class="grid"></div>
+  
+  <div id="modal" class="modal" onclick="closeModal(event)">
+    <div class="modal-content">
+      <button class="modal-close" onclick="closeModal()">&times;</button>
+      <div id="modal-media"></div>
+    </div>
+  </div>
+
+  <script>
+    let items = [];
+    let filter = 'all';
+
+    async function fetchItems() {
+      const res = await fetch('/api/items');
+      items = await res.json();
+      updateStats();
+      renderGrid();
+    }
+
+    function updateStats() {
+      const images = items.filter(i => i.type === 'image').length;
+      const videos = items.filter(i => i.type === 'video').length;
+      document.getElementById('stats').textContent = 
+        items.length + ' items (' + images + ' images, ' + videos + ' videos)';
+    }
+
+    function formatSize(bytes) {
+      if (bytes < 1024) return bytes + ' B';
+      if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+      return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+    }
+
+    function formatDate(dateStr) {
+      const date = new Date(dateStr);
+      return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+    }
+
+    function renderGrid() {
+      const grid = document.getElementById('grid');
+      const filtered = filter === 'all' ? items : items.filter(i => i.type === filter);
+      
+      if (filtered.length === 0) {
+        grid.innerHTML = '<div class="empty">no items found</div>';
+        return;
+      }
+
+      grid.innerHTML = filtered.map(item => {
+        const mediaUrl = '/api/media/' + encodeURIComponent(item.id);
+        const mediaHtml = item.type === 'video' 
+          ? '<video src="' + mediaUrl + '" muted loop preload="metadata" onmouseenter="this.play()" onmouseleave="this.pause();this.currentTime=0"></video>'
+          : '<img src="' + mediaUrl + '" alt="' + item.id + '" loading="lazy">';
+        
+        return '<div class="card">' +
+          '<div class="card-media" onclick="openModal(\'' + item.type + '\', \'' + mediaUrl + '\')">' + mediaHtml + '</div>' +
+          '<div class="card-info">' +
+            '<span class="card-type ' + item.type + '">' + item.type + '</span>' +
+            '<div class="card-title">' + item.id + '</div>' +
+            '<div class="card-meta">' +
+              '<span>' + formatSize(item.size) + '</span>' +
+              '<span>' + formatDate(item.createdAt) + '</span>' +
+            '</div>' +
+          '</div>' +
+        '</div>';
+      }).join('');
+    }
+
+    function refresh() { fetchItems(); }
+
+    document.querySelectorAll('.filter-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        filter = btn.dataset.filter;
+        renderGrid();
+      });
+    });
+
+    function openModal(type, url) {
+      const modal = document.getElementById('modal');
+      const mediaContainer = document.getElementById('modal-media');
+      if (type === 'video') {
+        mediaContainer.innerHTML = '<video id="modal-video" src="' + url + '" controls autoplay loop muted></video>' +
+          '<button class="mute-toggle" onclick="toggleMute()"><span id="mute-icon">muted</span></button>';
+      } else {
+        mediaContainer.innerHTML = '<img src="' + url + '">';
+      }
+      modal.classList.add('open');
+    }
+
+    function toggleMute() {
+      const video = document.getElementById('modal-video');
+      if (!video) return;
+      video.muted = !video.muted;
+      document.getElementById('mute-icon').textContent = video.muted ? 'muted' : 'unmuted';
+    }
+
+    function closeModal(e) {
+      if (e && e.target !== e.currentTarget) return;
+      document.getElementById('modal').classList.remove('open');
+      document.getElementById('modal-media').innerHTML = '';
+    }
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeModal();
+    });
+
+    fetchItems();
+  </script>
+</body>
+</html>

--- a/src/ai-sdk/studio/ui/index.html
+++ b/src/ai-sdk/studio/ui/index.html
@@ -1,0 +1,1820 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>varg studio</title>
+  <link rel="stylesheet" href="https://unpkg.com/drawflow@0.0.60/dist/drawflow.min.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0a0a0a;
+      --bg-secondary: #141414;
+      --border: #222;
+      --border-hover: #444;
+      --text: #fafafa;
+      --text-muted: #888;
+      --accent: #3b82f6;
+      --accent-hover: #2563eb;
+      --success: #22c55e;
+      --error: #ef4444;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      overflow: hidden;
+    }
+    header {
+      height: 48px;
+      padding: 0 1rem;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+    .logo {
+      font-weight: 600;
+      font-size: 0.875rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .nav {
+      display: flex;
+      gap: 0.25rem;
+    }
+    .nav-btn {
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.375rem;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    .nav-btn:hover { color: var(--text); background: var(--bg-secondary); }
+    .nav-btn.active { color: var(--text); background: var(--bg-secondary); }
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    select {
+      padding: 0.375rem 0.5rem;
+      border-radius: 0.375rem;
+      border: 1px solid var(--border);
+      background: var(--bg-secondary);
+      color: var(--text);
+      font-size: 0.8rem;
+      cursor: pointer;
+    }
+    select:hover { border-color: var(--border-hover); }
+    .main {
+      display: flex;
+      height: calc(100vh - 48px);
+    }
+    .editor-pane {
+      flex: 1;
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+    }
+    .preview-pane {
+      width: 480px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    #editor-container {
+      flex: 1;
+      overflow: hidden;
+    }
+    .preview-header {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      flex-shrink: 0;
+    }
+    .preview-content {
+      flex: 1;
+      background: #000;
+      position: relative;
+      overflow: hidden;
+      min-height: 200px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .preview-video {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+    }
+    .preview-placeholder {
+      color: var(--text-muted);
+      font-size: 0.875rem;
+      text-align: center;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+    .preview-placeholder-icon {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+      opacity: 0.5;
+    }
+    .progress-section {
+      padding: 1rem;
+      border-top: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .progress-bar-container {
+      height: 4px;
+      background: var(--bg-secondary);
+      border-radius: 2px;
+      overflow: hidden;
+      margin-bottom: 0.5rem;
+    }
+    .progress-bar {
+      height: 100%;
+      background: var(--accent);
+      width: 0%;
+      transition: width 0.3s ease;
+    }
+    .progress-bar.complete { background: var(--success); }
+    .progress-bar.error { background: var(--error); }
+    .progress-text {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+    .controls {
+      padding: 1rem;
+      border-top: 1px solid var(--border);
+      display: flex;
+      gap: 0.5rem;
+      flex-shrink: 0;
+    }
+    .btn {
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      border: 1px solid var(--border);
+      background: var(--bg-secondary);
+      color: var(--text);
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: all 0.15s;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+    .btn:hover { border-color: var(--border-hover); }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-primary {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+    .btn-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+    .btn-danger {
+      background: var(--error);
+      border-color: var(--error);
+    }
+    .btn-danger:hover { background: #dc2626; border-color: #dc2626; }
+    .btn-toggle {
+      position: relative;
+    }
+    .btn-toggle.active {
+      background: var(--success);
+      border-color: var(--success);
+    }
+    .history-section {
+      padding: 1rem;
+      border-top: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .history-title {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.75rem;
+    }
+    .history-grid {
+      display: flex;
+      gap: 0.5rem;
+      overflow-x: auto;
+      padding-bottom: 0.5rem;
+    }
+    .history-item {
+      width: 80px;
+      flex-shrink: 0;
+      cursor: pointer;
+      border-radius: 0.375rem;
+      overflow: hidden;
+      border: 2px solid transparent;
+      transition: border-color 0.15s;
+    }
+    .history-item:hover { border-color: var(--border-hover); }
+    .history-item.active { border-color: var(--accent); }
+    .history-thumb {
+      width: 100%;
+      aspect-ratio: 9/16;
+      background: var(--bg-secondary);
+      object-fit: cover;
+    }
+    .history-meta {
+      padding: 0.25rem;
+      font-size: 0.625rem;
+      color: var(--text-muted);
+      text-align: center;
+    }
+    .spinner {
+      width: 24px;
+      height: 24px;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    
+    /* Step mode timeline */
+    .stage-timeline {
+      padding: 1rem;
+      border-top: 1px solid var(--border);
+      flex-shrink: 0;
+      display: none;
+    }
+    .stage-timeline.active {
+      display: block;
+    }
+    .stage-timeline-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 0.75rem;
+    }
+    .stage-timeline-title {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .stage-timeline-hint {
+      font-size: 0.625rem;
+      color: var(--text-muted);
+      opacity: 0.7;
+    }
+    .stage-timeline-hint kbd {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      padding: 0.125rem 0.375rem;
+      font-family: inherit;
+      font-size: 0.625rem;
+    }
+    .stage-track {
+      display: flex;
+      gap: 0.5rem;
+      overflow-x: auto;
+      padding-bottom: 0.5rem;
+      scrollbar-width: thin;
+      scrollbar-color: var(--border) transparent;
+    }
+    .stage-track::-webkit-scrollbar {
+      height: 4px;
+    }
+    .stage-track::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    .stage-track::-webkit-scrollbar-thumb {
+      background: var(--border);
+      border-radius: 2px;
+    }
+    .stage-item {
+      flex-shrink: 0;
+      width: 100px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 0.5rem;
+      padding: 0.625rem;
+      cursor: default;
+      transition: all 0.2s ease;
+      position: relative;
+      overflow: hidden;
+    }
+    .stage-item::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: transparent;
+      transition: background 0.2s ease;
+    }
+    .stage-item.pending {
+      opacity: 0.5;
+    }
+    .stage-item.running {
+      border-color: var(--accent);
+      box-shadow: 0 0 12px rgba(59, 130, 246, 0.25);
+    }
+    .stage-item.running::before {
+      background: var(--accent);
+      animation: stage-pulse 1.5s ease-in-out infinite;
+    }
+    @keyframes stage-pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+    .stage-item.complete {
+      cursor: pointer;
+      border-color: var(--success);
+    }
+    .stage-item.complete::before {
+      background: var(--success);
+    }
+    .stage-item.complete:hover {
+      border-color: var(--success);
+      background: rgba(34, 197, 94, 0.1);
+    }
+    .stage-item.error {
+      border-color: var(--error);
+    }
+    .stage-item.error::before {
+      background: var(--error);
+    }
+    .stage-item.selected {
+      border-color: var(--accent);
+      background: rgba(59, 130, 246, 0.1);
+    }
+    .stage-icon {
+      font-size: 1.25rem;
+      margin-bottom: 0.375rem;
+    }
+    .stage-label {
+      font-size: 0.7rem;
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: 0.25rem;
+    }
+    .stage-status {
+      font-size: 0.625rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+    .stage-item.running .stage-status {
+      color: var(--accent);
+    }
+    .stage-item.complete .stage-status {
+      color: var(--success);
+    }
+    .stage-item.error .stage-status {
+      color: var(--error);
+    }
+    .stage-connector {
+      flex-shrink: 0;
+      width: 24px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .stage-connector-line {
+      width: 100%;
+      height: 2px;
+      background: var(--border);
+      position: relative;
+    }
+    .stage-connector-line.complete {
+      background: var(--success);
+    }
+    .stage-connector-line::after {
+      content: '';
+      position: absolute;
+      right: -4px;
+      top: -3px;
+      border: 4px solid transparent;
+      border-left-color: var(--border);
+    }
+    .stage-connector-line.complete::after {
+      border-left-color: var(--success);
+    }
+    
+    /* Mode toggle */
+    .mode-toggle {
+      display: flex;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 0.375rem;
+      overflow: hidden;
+    }
+    .mode-toggle-btn {
+      padding: 0.375rem 0.625rem;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 0.7rem;
+      cursor: pointer;
+      transition: all 0.15s;
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .mode-toggle-btn:hover {
+      color: var(--text);
+    }
+    .mode-toggle-btn.active {
+      background: var(--accent);
+      color: var(--text);
+    }
+    .mode-toggle-btn:first-child {
+      border-right: 1px solid var(--border);
+    }
+    
+    /* Next step button */
+    .btn-next {
+      background: linear-gradient(135deg, var(--accent), #6366f1);
+      border-color: transparent;
+      position: relative;
+      overflow: hidden;
+    }
+    .btn-next::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -100%;
+      width: 100%;
+      height: 100%;
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
+      transition: left 0.5s;
+    }
+    .btn-next:hover::before {
+      left: 100%;
+    }
+    .btn-next:hover {
+      background: linear-gradient(135deg, var(--accent-hover), #4f46e5);
+    }
+    .btn-next:disabled {
+      background: var(--bg-secondary);
+      border-color: var(--border);
+    }
+    .btn-next:disabled::before {
+      display: none;
+    }
+    .error-banner {
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid var(--error);
+      border-radius: 0.375rem;
+      padding: 0.75rem 1rem;
+      margin: 1rem;
+      font-size: 0.8rem;
+      color: var(--error);
+    }
+
+    /* Editor pane header with view toggle */
+    .editor-pane-header {
+      height: 36px;
+      padding: 0 0.75rem;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-shrink: 0;
+    }
+    .view-toggle {
+      display: flex;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 0.375rem;
+      overflow: hidden;
+    }
+    .view-toggle-btn {
+      padding: 0.25rem 0.625rem;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 0.7rem;
+      cursor: pointer;
+      transition: all 0.15s;
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .view-toggle-btn:hover { color: var(--text); }
+    .view-toggle-btn.active {
+      background: var(--accent);
+      color: var(--text);
+    }
+    .view-toggle-btn:first-child {
+      border-right: 1px solid var(--border);
+    }
+    .editor-pane-content {
+      flex: 1;
+      position: relative;
+      overflow: hidden;
+    }
+    #editor-container, #nodes-container {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+    #nodes-container {
+      display: none;
+      background: var(--bg);
+    }
+    #nodes-container.active { display: block; }
+    #editor-container.hidden { display: none; }
+
+    /* Drawflow dark theme */
+    #drawflow {
+      width: 100%;
+      height: 100%;
+      background: var(--bg);
+      background-size: 20px 20px;
+      background-image:
+        linear-gradient(to right, #1a1a1a 1px, transparent 1px),
+        linear-gradient(to bottom, #1a1a1a 1px, transparent 1px);
+    }
+    .drawflow .drawflow-node {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      min-width: 160px;
+      color: var(--text);
+      font-size: 0.8rem;
+    }
+    .drawflow .drawflow-node.selected {
+      border-color: var(--accent);
+      box-shadow: 0 0 12px rgba(59, 130, 246, 0.3);
+    }
+    .drawflow .drawflow-node .inputs, .drawflow .drawflow-node .outputs {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .drawflow .drawflow-node .input, .drawflow .drawflow-node .output {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      border: 2px solid var(--border);
+      background: var(--bg);
+    }
+    .drawflow .drawflow-node .input:hover, .drawflow .drawflow-node .output:hover {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+    .drawflow .connection .main-path {
+      stroke: var(--accent);
+      stroke-width: 2px;
+    }
+    .drawflow .connection .main-path:hover {
+      stroke-width: 3px;
+    }
+
+    /* Custom node styles */
+    .node-title {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: rgba(255,255,255,0.02);
+      border-radius: 7px 7px 0 0;
+    }
+    .node-title-icon { font-size: 1rem; }
+    .node-content {
+      padding: 8px;
+    }
+    .node-preview {
+      width: 100%;
+      max-height: 120px;
+      object-fit: contain;
+      border-radius: 4px;
+      background: #000;
+    }
+    .node-preview-placeholder {
+      height: 80px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.3);
+      border-radius: 4px;
+      color: var(--text-muted);
+      font-size: 0.7rem;
+    }
+    .node-label {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      margin-top: 6px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .node-status {
+      font-size: 0.625rem;
+      text-transform: uppercase;
+      margin-top: 4px;
+      letter-spacing: 0.03em;
+    }
+    .node-status.pending { color: var(--text-muted); }
+    .node-status.running { color: var(--accent); }
+    .node-status.complete { color: var(--success); }
+    .node-status.error { color: var(--error); }
+    .node-btn {
+      margin-top: 8px;
+      padding: 4px 8px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--bg);
+      color: var(--text);
+      font-size: 0.65rem;
+      cursor: pointer;
+      width: 100%;
+    }
+    .node-btn:hover {
+      border-color: var(--accent);
+      background: rgba(59, 130, 246, 0.1);
+    }
+    .node-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .drawflow-node.complete { border-color: var(--success); }
+    .drawflow-node.running {
+      border-color: var(--accent);
+      box-shadow: 0 0 12px rgba(59, 130, 246, 0.25);
+    }
+    .drawflow-node.error { border-color: var(--error); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">
+      <span>varg studio</span>
+    </div>
+    <nav class="nav">
+      <a href="/editor" class="nav-btn active">editor</a>
+      <a href="/cache" class="nav-btn">cache</a>
+    </nav>
+    <div class="header-right">
+      <select id="template-select">
+        <option value="">select template...</option>
+      </select>
+    </div>
+  </header>
+  
+  <main class="main">
+    <div class="editor-pane">
+      <div class="editor-pane-header">
+        <div class="view-toggle">
+          <button class="view-toggle-btn active" id="view-code-btn" title="Code view">
+            <span>{ }</span> code
+          </button>
+          <button class="view-toggle-btn" id="view-nodes-btn" title="Node view">
+            <span>◎</span> nodes
+          </button>
+        </div>
+        <div style="font-size: 0.7rem; color: var(--text-muted);">
+          <span id="view-hint">cmd+enter to run</span>
+        </div>
+      </div>
+      <div class="editor-pane-content">
+        <div id="editor-container"></div>
+        <div id="nodes-container">
+          <div id="drawflow"></div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="preview-pane">
+      <div class="preview-header">preview</div>
+      
+      <div class="preview-content" id="preview-content">
+        <div class="preview-placeholder">
+          <div class="preview-placeholder-icon">▶</div>
+          <div>click run to generate</div>
+        </div>
+      </div>
+      
+      <div class="progress-section" id="progress-section" style="display: none;">
+        <div class="progress-bar-container">
+          <div class="progress-bar" id="progress-bar"></div>
+        </div>
+        <div class="progress-text" id="progress-text">ready</div>
+      </div>
+      
+      <div class="controls">
+        <div class="mode-toggle">
+          <button class="mode-toggle-btn active" id="mode-all-btn" title="Run all stages at once">
+            <span>⚡</span> all
+          </button>
+          <button class="mode-toggle-btn" id="mode-step-btn" title="Run stages one by one">
+            <span>👣</span> step
+          </button>
+        </div>
+        <button class="btn btn-primary" id="run-btn">
+          <span>▶</span> run
+        </button>
+        <button class="btn btn-next" id="next-btn" style="display: none;">
+          <span>→</span> next
+        </button>
+        <button class="btn btn-toggle" id="auto-btn">
+          <span>⟳</span> auto
+        </button>
+        <button class="btn btn-danger" id="stop-btn" disabled>
+          <span>⬜</span> stop
+        </button>
+        <button class="btn" id="share-btn" style="margin-left: auto;">
+          <span>🔗</span> share
+        </button>
+      </div>
+      
+      <div class="stage-timeline" id="stage-timeline">
+        <div class="stage-timeline-header">
+          <div class="stage-timeline-title">stages</div>
+          <div class="stage-timeline-hint"><kbd>Space</kbd> next step</div>
+        </div>
+        <div class="stage-track" id="stage-track"></div>
+      </div>
+      
+      <div class="history-section">
+        <div class="history-title">history</div>
+        <div class="history-grid" id="history-grid">
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script src="https://unpkg.com/drawflow@0.0.60/dist/drawflow.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/loader.js"></script>
+  <script>
+    const DEFAULT_CODE = `import { fal } from "../fal-provider";
+import { Clip, Image, Render, Video } from "../react";
+
+export default (
+  <Render width={1080} height={1920}>
+    <Clip duration={5}>
+      <Video
+        prompt={{
+          text: "A person walking through a neon-lit city at night",
+          images: [
+            Image({
+              prompt: "cyberpunk street scene, neon lights, rain",
+              model: fal.imageModel("flux-schnell"),
+            }),
+          ],
+        }}
+        model={fal.videoModel("kling-v2.5")}
+        duration={5}
+      />
+    </Clip>
+  </Render>
+);`;
+
+    let editor;
+    let isRendering = false;
+    let autoMode = false;
+    let currentRenderId = null;
+    let debounceTimer = null;
+    let history = JSON.parse(localStorage.getItem('varg-history') || '[]');
+    
+    // Step mode state
+    let stepMode = false;
+    let stepSession = null;
+    let stages = [];
+    let currentStageIndex = -1;
+    let selectedStageId = null;
+
+    // View mode state
+    let currentView = 'code';
+    let drawflowEditor = null;
+    let renderingFinal = false;
+
+    // Initialize Drawflow
+    function initDrawflow() {
+      const container = document.getElementById('drawflow');
+      drawflowEditor = new Drawflow(container);
+      drawflowEditor.reroute = true;
+      drawflowEditor.start();
+
+      drawflowEditor.on('nodeSelected', (nodeId) => {
+        const stage = stages.find(s => s.nodeId === nodeId);
+        if (stage && stage.status === 'complete') {
+          selectedStageId = stage.id;
+          renderStageTimeline();
+          if (stage.result) {
+            showStagePreview({ result: stage.result });
+          }
+        }
+      });
+    }
+
+    async function setView(view) {
+      currentView = view;
+      document.getElementById('view-code-btn').classList.toggle('active', view === 'code');
+      document.getElementById('view-nodes-btn').classList.toggle('active', view === 'nodes');
+      document.getElementById('editor-container').classList.toggle('hidden', view === 'nodes');
+      document.getElementById('nodes-container').classList.toggle('active', view === 'nodes');
+
+      if (view === 'nodes') {
+        document.getElementById('view-hint').textContent = 'click node to preview';
+        if (stages.length > 0) {
+          renderNodeGraph();
+        } else {
+          // Auto-parse stages when switching to nodes view
+          await parseStagesForNodeView();
+        }
+      } else {
+        document.getElementById('view-hint').textContent = 'cmd+enter to run';
+      }
+    }
+
+    async function parseStagesForNodeView() {
+      if (!drawflowEditor) {
+        showEmptyNodeGraph();
+        return;
+      }
+
+      const code = editor.getValue();
+      try {
+        const res = await fetch('/api/step/session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error || 'Failed to parse stages');
+        }
+
+        const data = await res.json();
+        stepSession = data;
+        stages = data.stages.map(s => ({ ...s, status: 'pending' }));
+        currentStageIndex = -1;
+        selectedStageId = null;
+
+        renderNodeGraph();
+        renderStageTimeline();
+
+      } catch (err) {
+        console.error('Failed to parse stages:', err);
+        showParseErrorNode(err.message);
+      }
+    }
+
+    function showParseErrorNode(message) {
+      if (!drawflowEditor) return;
+      drawflowEditor.clear();
+      const html = `
+        <div class="node-title" style="background: rgba(239,68,68,0.1);">
+          <span class="node-title-icon">⚠️</span>
+          <span>parse error</span>
+        </div>
+        <div class="node-content">
+          <div class="node-label" style="color: var(--error); white-space: normal;">${message}</div>
+          <button class="node-btn" onclick="setView('code')">← back to code</button>
+        </div>
+      `;
+      drawflowEditor.addNode('error', 0, 0, 200, 150, 'error', {}, html);
+    }
+
+    function showEmptyNodeGraph() {
+      if (!drawflowEditor) return;
+      drawflowEditor.clear();
+      const html = `
+        <div class="node-title">
+          <span class="node-title-icon">💡</span>
+          <span>no stages</span>
+        </div>
+        <div class="node-content">
+          <div class="node-preview-placeholder">run in step mode first</div>
+        </div>
+      `;
+      drawflowEditor.addNode('empty', 0, 0, 200, 150, 'empty-node', {}, html);
+    }
+
+    function renderNodeGraph() {
+      if (!drawflowEditor || stages.length === 0) return;
+
+      drawflowEditor.clear();
+
+      const nodeWidth = 180;
+      const nodeHeight = 180;
+      const gapX = 100;
+      const gapY = 50;
+      const startX = 50;
+      const startY = 50;
+
+      // Build dependency graph and calculate levels
+      const stageMap = new Map(stages.map(s => [s.id, s]));
+      const levels = new Map(); // stageId -> level (depth)
+      const children = new Map(); // stageId -> stages that depend on it
+      
+      // Initialize children map
+      stages.forEach(s => { children.set(s.id, []); });
+      
+      // Build reverse dependency (who depends on me)
+      stages.forEach(s => {
+        (s.dependsOn || []).forEach(depId => {
+          if (children.has(depId)) {
+            children.get(depId).push(s.id);
+          }
+        });
+      });
+
+      // Calculate levels using BFS from roots (nodes with no dependencies)
+      function calculateLevels() {
+        const queue = [];
+        
+        // Find root nodes (no dependencies)
+        stages.forEach(s => {
+          if (!s.dependsOn || s.dependsOn.length === 0) {
+            levels.set(s.id, 0);
+            queue.push(s.id);
+          }
+        });
+        
+        // BFS to assign levels
+        while (queue.length > 0) {
+          const currentId = queue.shift();
+          const currentLevel = levels.get(currentId);
+          
+          children.get(currentId).forEach(childId => {
+            const childStage = stageMap.get(childId);
+            if (!childStage) return;
+            
+            // Child's level is max of all its dependencies + 1
+            const depLevels = (childStage.dependsOn || [])
+              .map(d => levels.get(d) ?? -1)
+              .filter(l => l >= 0);
+            
+            if (depLevels.length === (childStage.dependsOn || []).length) {
+              // All dependencies have levels assigned
+              const newLevel = Math.max(...depLevels) + 1;
+              if (!levels.has(childId) || levels.get(childId) < newLevel) {
+                levels.set(childId, newLevel);
+                queue.push(childId);
+              }
+            }
+          });
+        }
+        
+        // Handle any unassigned (shouldn't happen with valid DAG)
+        stages.forEach(s => {
+          if (!levels.has(s.id)) {
+            levels.set(s.id, 0);
+          }
+        });
+      }
+      
+      calculateLevels();
+
+      // Group stages by level
+      const levelGroups = new Map();
+      stages.forEach(s => {
+        const level = levels.get(s.id);
+        if (!levelGroups.has(level)) {
+          levelGroups.set(level, []);
+        }
+        levelGroups.get(level).push(s);
+      });
+
+      const maxLevel = Math.max(...levels.values());
+      const stageNodeIds = new Map(); // stageId -> drawflow nodeId
+
+      // Render nodes level by level (left to right)
+      for (let level = 0; level <= maxLevel; level++) {
+        const group = levelGroups.get(level) || [];
+        const x = startX + level * (nodeWidth + gapX);
+        
+        group.forEach((stage, idx) => {
+          // Center vertically based on group size
+          const totalHeight = group.length * (nodeHeight + gapY) - gapY;
+          const offsetY = (500 - totalHeight) / 2; // Center in ~500px viewport
+          const y = startY + Math.max(0, offsetY) + idx * (nodeHeight + gapY);
+
+          const icon = getStageIcon(stage.type);
+          const statusClass = stage.status;
+          const hasPreview = stage.result?.previewUrl;
+
+          let previewHtml = '';
+          if (hasPreview) {
+            const url = stage.result.previewUrl;
+            if (stage.result.mimeType?.startsWith('image/') || stage.type === 'image') {
+              previewHtml = `<img class="node-preview" src="${url}" alt="preview">`;
+            } else if (stage.result.mimeType?.startsWith('video/') || stage.type === 'video' || stage.type === 'animate') {
+              previewHtml = `<video class="node-preview" src="${url}" muted loop></video>`;
+            } else if (stage.result.mimeType?.startsWith('audio/') || stage.type === 'speech' || stage.type === 'music') {
+              previewHtml = `<div class="node-preview-placeholder">🎵 audio</div>`;
+            }
+          } else {
+            previewHtml = `<div class="node-preview-placeholder">click to generate</div>`;
+          }
+
+          const btnHtml = stage.status === 'pending' 
+            ? `<button class="node-btn" onclick="event.stopPropagation(); generateNodeStage('${stage.id}')">▶ generate</button>`
+            : '';
+
+          const html = `
+            <div class="node-title">
+              <span class="node-title-icon">${icon}</span>
+              <span>${stage.type}</span>
+            </div>
+            <div class="node-content">
+              ${previewHtml}
+              <div class="node-label" title="${stage.label}">${stage.label}</div>
+              <div class="node-status ${statusClass}">${stage.status}</div>
+              ${btnHtml}
+            </div>
+          `;
+
+          // Input count = number of dependencies, output = 1 (for children or render node)
+          const inputCount = (stage.dependsOn || []).length || 0;
+          const hasChildren = children.get(stage.id)?.length > 0;
+          const outputCount = 1; // Always 1 output (to children or render)
+
+          const nodeId = drawflowEditor.addNode(
+            stage.type,
+            inputCount > 0 ? inputCount : 0,
+            outputCount,
+            x,
+            y,
+            statusClass,
+            { stageId: stage.id },
+            html
+          );
+
+          stage.nodeId = nodeId;
+          stageNodeIds.set(stage.id, nodeId);
+        });
+      }
+
+      // Add connections based on actual dependencies
+      stages.forEach(stage => {
+        const targetNodeId = stageNodeIds.get(stage.id);
+        (stage.dependsOn || []).forEach((depId, depIndex) => {
+          const sourceNodeId = stageNodeIds.get(depId);
+          if (sourceNodeId && targetNodeId) {
+            // Connect source output to target input
+            const inputNum = depIndex + 1;
+            drawflowEditor.addConnection(sourceNodeId, targetNodeId, 'output_1', `input_${inputNum}`);
+          }
+        });
+      });
+
+      // Find leaf nodes (no children) to connect to render node
+      const leafStages = stages.filter(s => {
+        const childList = children.get(s.id) || [];
+        return childList.length === 0;
+      });
+
+      // Add final "Render" root node
+      const allComplete = stages.every(s => s.status === 'complete');
+      const renderX = startX + (maxLevel + 1) * (nodeWidth + gapX);
+      const renderY = startY + (500 - nodeHeight) / 4; // Roughly centered
+
+      let renderPreviewHtml = '';
+      const hasRenderResult = currentVideoUrl || stepSession?.renderResult?.previewUrl;
+      
+      if (renderingFinal) {
+        renderPreviewHtml = `<div class="node-preview-placeholder"><div class="spinner"></div></div>`;
+      } else if (hasRenderResult) {
+        const url = currentVideoUrl || stepSession.renderResult.previewUrl;
+        renderPreviewHtml = `<video class="node-preview" src="${url}" muted loop></video>`;
+      } else if (allComplete) {
+        renderPreviewHtml = `<div class="node-preview-placeholder">ready to render</div>`;
+      } else {
+        renderPreviewHtml = `<div class="node-preview-placeholder">waiting for stages...</div>`;
+      }
+
+      const renderBtnHtml = (allComplete && !hasRenderResult && !renderingFinal)
+        ? `<button class="node-btn" onclick="event.stopPropagation(); runFinalRender()" style="background: var(--accent); border-color: var(--accent);">▶ render</button>`
+        : '';
+
+      const renderStatusText = renderingFinal ? 'rendering...' : (hasRenderResult ? 'complete' : (allComplete ? 'ready' : 'pending'));
+      const renderStatusClass = renderingFinal ? 'running' : (hasRenderResult ? 'complete' : 'pending');
+
+      const renderHtml = `
+        <div class="node-title" style="background: rgba(59,130,246,0.15);">
+          <span class="node-title-icon">🎬</span>
+          <span>render</span>
+        </div>
+        <div class="node-content">
+          ${renderPreviewHtml}
+          <div class="node-label">final output</div>
+          <div class="node-status ${renderStatusClass}">${renderStatusText}</div>
+          ${renderBtnHtml}
+        </div>
+      `;
+
+      const renderNodeId = drawflowEditor.addNode(
+        'render',
+        leafStages.length || 1,
+        0,
+        renderX,
+        renderY,
+        renderingFinal ? 'running' : (hasRenderResult ? 'complete' : 'pending'),
+        { type: 'render' },
+        renderHtml
+      );
+
+      // Connect all leaf nodes to render node
+      leafStages.forEach((stage, idx) => {
+        const sourceNodeId = stageNodeIds.get(stage.id);
+        if (sourceNodeId) {
+          drawflowEditor.addConnection(sourceNodeId, renderNodeId, 'output_1', `input_${idx + 1}`);
+        }
+      });
+
+      // Play videos on hover
+      document.querySelectorAll('.node-preview').forEach(el => {
+        if (el.tagName === 'VIDEO') {
+          el.addEventListener('mouseenter', () => el.play());
+          el.addEventListener('mouseleave', () => { el.pause(); el.currentTime = 0; });
+        }
+      });
+    }
+
+    async function generateNodeStage(stageId) {
+      if (!stepSession || isRendering) return;
+
+      const stage = stages.find(s => s.id === stageId);
+      if (!stage) return;
+
+      // Check if all dependencies are complete
+      const incompleteDeps = (stage.dependsOn || [])
+        .map(depId => stages.find(s => s.id === depId))
+        .filter(dep => dep && dep.status !== 'complete');
+      
+      if (incompleteDeps.length > 0) {
+        const depNames = incompleteDeps.map(d => d.label).join(', ');
+        alert(`Complete dependencies first: ${depNames}`);
+        return;
+      }
+      
+      const stageIndex = stages.findIndex(s => s.id === stageId);
+
+      isRendering = true;
+      stages[stageIndex].status = 'running';
+      renderNodeGraph();
+      renderStageTimeline();
+
+      try {
+        const res = await fetch('/api/step/run', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: stepSession.sessionId, stageId }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.message || 'Stage execution failed');
+        }
+
+        const data = await res.json();
+        stages[stageIndex].status = 'complete';
+        stages[stageIndex].result = data.result;
+        currentStageIndex = Math.max(currentStageIndex, stageIndex);
+
+        selectedStageId = stageId;
+        renderNodeGraph();
+        renderStageTimeline();
+        showStagePreview(data);
+
+      } catch (err) {
+        stages[stageIndex].status = 'error';
+        renderNodeGraph();
+        renderStageTimeline();
+        showError(err.message);
+      }
+
+      isRendering = false;
+    }
+
+    async function runFinalRender() {
+      if (!stepSession || isRendering) return;
+      
+      const allComplete = stages.every(s => s.status === 'complete');
+      if (!allComplete) {
+        alert('Complete all stages first');
+        return;
+      }
+
+      isRendering = true;
+      renderingFinal = true;
+      renderNodeGraph();
+      updateProgress(0.5, 'rendering final video...');
+      document.getElementById('progress-section').style.display = 'block';
+
+      try {
+        const res = await fetch('/api/step/render', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: stepSession.sessionId }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error || err.message || 'Final render failed');
+        }
+
+        const data = await res.json();
+        currentVideoUrl = data.videoUrl;
+        
+        renderingFinal = false;
+        renderNodeGraph();
+        showVideo(data.videoUrl);
+        addToHistory(editor.getValue(), data.videoUrl);
+        updateProgress(1, 'render complete');
+        document.getElementById('progress-bar').className = 'progress-bar complete';
+
+      } catch (err) {
+        renderingFinal = false;
+        renderNodeGraph();
+        showError(err.message);
+        updateProgress(0, err.message);
+        document.getElementById('progress-bar').className = 'progress-bar error';
+      }
+
+      isRendering = false;
+    }
+
+    document.getElementById('view-code-btn').addEventListener('click', () => setView('code'));
+    document.getElementById('view-nodes-btn').addEventListener('click', () => setView('nodes'));
+
+    require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs' } });
+
+    require(['vs/editor/editor.main'], () => {
+      monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+        noSemanticValidation: true,
+        noSyntaxValidation: true,
+      });
+
+      monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+        jsx: monaco.languages.typescript.JsxEmit.React,
+        jsxFactory: 'createElement',
+        target: monaco.languages.typescript.ScriptTarget.ESNext,
+        moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+        allowNonTsExtensions: true,
+      });
+
+      monaco.editor.defineTheme('varg-dark', {
+        base: 'vs-dark',
+        inherit: true,
+        rules: [],
+        colors: {
+          'editor.background': '#0a0a0a',
+          'editor.lineHighlightBackground': '#141414',
+          'editorLineNumber.foreground': '#444',
+          'editorLineNumber.activeForeground': '#888',
+        }
+      });
+
+      editor = monaco.editor.create(document.getElementById('editor-container'), {
+        value: localStorage.getItem('varg-code') || DEFAULT_CODE,
+        language: 'typescript',
+        theme: 'varg-dark',
+        fontSize: 13,
+        fontFamily: 'SF Mono, Menlo, Monaco, monospace',
+        lineNumbers: 'on',
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        padding: { top: 16, bottom: 16 },
+        automaticLayout: true,
+        tabSize: 2,
+      });
+
+      editor.onDidChangeModelContent(() => {
+        localStorage.setItem('varg-code', editor.getValue());
+        if (autoMode && !isRendering) {
+          clearTimeout(debounceTimer);
+          debounceTimer = setTimeout(() => startRender(), 2000);
+        }
+      });
+
+      loadInitialCode();
+    });
+
+    async function loadTemplates() {
+      const res = await fetch('/api/templates');
+      const templates = await res.json();
+      const select = document.getElementById('template-select');
+      templates.forEach(t => {
+        const opt = document.createElement('option');
+        opt.value = t.id;
+        opt.textContent = t.name;
+        select.appendChild(opt);
+      });
+    }
+
+    async function loadInitialCode() {
+      const res = await fetch('/api/initial-code');
+      const data = await res.json();
+      if (data.code) {
+        editor.setValue(data.code);
+        localStorage.setItem('varg-code', data.code);
+      }
+    }
+
+    document.getElementById('template-select').addEventListener('change', async (e) => {
+      if (!e.target.value) return;
+      const res = await fetch('/api/templates/' + e.target.value);
+      const { code } = await res.json();
+      editor.setValue(code);
+      e.target.value = '';
+    });
+
+    document.getElementById('run-btn').addEventListener('click', () => {
+      if (stepMode) {
+        startStepSession();
+      } else {
+        startRender();
+      }
+    });
+    
+    document.getElementById('next-btn').addEventListener('click', executeNextStep);
+    
+    document.getElementById('mode-all-btn').addEventListener('click', () => {
+      setStepMode(false);
+    });
+    
+    document.getElementById('mode-step-btn').addEventListener('click', () => {
+      setStepMode(true);
+    });
+    
+    document.getElementById('auto-btn').addEventListener('click', () => {
+      autoMode = !autoMode;
+      document.getElementById('auto-btn').classList.toggle('active', autoMode);
+    });
+
+    document.getElementById('stop-btn').addEventListener('click', stopRender);
+
+    document.addEventListener('keydown', (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        if (stepMode) {
+          startStepSession();
+        } else {
+          startRender();
+        }
+      }
+      if (e.key === 'Escape' && isRendering) {
+        stopRender();
+      }
+      // Space to execute next step in step mode
+      if (e.code === 'Space' && stepMode && stepSession && !isRendering) {
+        // Don't trigger if focused on editor or input
+        if (document.activeElement.tagName !== 'INPUT' && 
+            document.activeElement.tagName !== 'TEXTAREA' &&
+            !document.activeElement.closest('#editor-container')) {
+          e.preventDefault();
+          executeNextStep();
+        }
+      }
+    });
+    
+    function setStepMode(enabled) {
+      stepMode = enabled;
+      document.getElementById('mode-all-btn').classList.toggle('active', !enabled);
+      document.getElementById('mode-step-btn').classList.toggle('active', enabled);
+      document.getElementById('stage-timeline').classList.toggle('active', enabled && stages.length > 0);
+      document.getElementById('next-btn').style.display = enabled && stepSession ? 'flex' : 'none';
+      document.getElementById('auto-btn').style.display = enabled ? 'none' : 'flex';
+      
+      if (!enabled) {
+        // Reset step state when switching to run-all mode
+        stepSession = null;
+        stages = [];
+        currentStageIndex = -1;
+        selectedStageId = null;
+        renderStageTimeline();
+      }
+    }
+    
+    function getStageIcon(type) {
+      const icons = {
+        image: '🖼️',
+        video: '🎬',
+        animate: '🎬',
+        speech: '🎤',
+        music: '🎵',
+        default: '⚙️'
+      };
+      return icons[type] || icons.default;
+    }
+    
+    function renderStageTimeline() {
+      const track = document.getElementById('stage-track');
+      const timeline = document.getElementById('stage-timeline');
+      
+      if (stages.length === 0) {
+        timeline.classList.remove('active');
+        track.innerHTML = '';
+        if (currentView === 'nodes') showEmptyNodeGraph();
+        return;
+      }
+      
+      if (stepMode) {
+        timeline.classList.add('active');
+      }
+
+      if (currentView === 'nodes') {
+        renderNodeGraph();
+      }
+      
+      let html = '';
+      stages.forEach((stage, index) => {
+        const isSelected = stage.id === selectedStageId;
+        const statusClass = stage.status + (isSelected ? ' selected' : '');
+        
+        // Add connector before each stage except the first
+        if (index > 0) {
+          const prevComplete = stages[index - 1].status === 'complete';
+          html += `
+            <div class="stage-connector">
+              <div class="stage-connector-line ${prevComplete ? 'complete' : ''}"></div>
+            </div>
+          `;
+        }
+        
+        html += `
+          <div class="stage-item ${statusClass}" 
+               data-stage-id="${stage.id}" 
+               data-stage-index="${index}"
+               onclick="selectStage('${stage.id}')">
+            <div class="stage-icon">${getStageIcon(stage.type)}</div>
+            <div class="stage-label" title="${stage.label}">${stage.label}</div>
+            <div class="stage-status">${stage.status}</div>
+          </div>
+        `;
+      });
+      
+      track.innerHTML = html;
+    }
+    
+    async function selectStage(stageId) {
+      const stage = stages.find(s => s.id === stageId);
+      if (!stage || stage.status !== 'complete') return;
+      
+      selectedStageId = stageId;
+      renderStageTimeline();
+      
+      // Show stored result directly (preview URL already available)
+      if (stage.result) {
+        showStagePreview({ result: stage.result });
+      }
+    }
+    
+    function showStagePreview(data) {
+      const container = document.getElementById('preview-content');
+      console.log('[preview] showStagePreview called with:', data);
+      
+      if (!data || !data.result) {
+        container.innerHTML = `<div class="preview-placeholder">
+          <div class="preview-placeholder-icon">📭</div>
+          <div>no preview available</div>
+        </div>`;
+        return;
+      }
+      
+      const { type, previewUrl, mimeType } = data.result;
+      console.log('[preview] type:', type, 'previewUrl:', previewUrl, 'mimeType:', mimeType);
+      
+      if (mimeType?.startsWith('video/') || type === 'video' || type === 'animate') {
+        container.innerHTML = `<video class="preview-video" src="${previewUrl}" controls autoplay loop></video>`;
+      } else if (mimeType?.startsWith('image/') || type === 'image') {
+        container.innerHTML = `<img class="preview-video" src="${previewUrl}" alt="Stage preview" style="object-fit: contain; max-width: 100%; max-height: 100%;">`;
+      } else if (mimeType?.startsWith('audio/') || type === 'speech' || type === 'music') {
+        container.innerHTML = `
+          <div style="display: flex; flex-direction: column; align-items: center; gap: 1rem;">
+            <div style="font-size: 3rem;">${type === 'music' ? '🎵' : '🎤'}</div>
+            <audio controls src="${previewUrl}" style="width: 80%;"></audio>
+          </div>
+        `;
+      } else {
+        container.innerHTML = `<div class="preview-placeholder">
+          <div class="preview-placeholder-icon">✓</div>
+          <div>stage complete</div>
+        </div>`;
+      }
+    }
+    
+    async function startStepSession() {
+      if (isRendering) return;
+      
+      isRendering = true;
+      updateUI('rendering');
+      
+      const code = editor.getValue();
+      
+      try {
+        const res = await fetch('/api/step/session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+        
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.message || 'Failed to create step session');
+        }
+        
+        const data = await res.json();
+        stepSession = data;
+        stages = data.stages.map(s => ({ ...s, status: 'pending' }));
+        currentStageIndex = -1;
+        selectedStageId = null;
+        
+        renderStageTimeline();
+        document.getElementById('next-btn').style.display = 'flex';
+        document.getElementById('next-btn').disabled = false;
+        
+        updateProgress(0, 'session ready — click next to start');
+        updateUI('idle');
+        
+        // Show placeholder for step mode
+        const container = document.getElementById('preview-content');
+        container.innerHTML = `<div class="preview-placeholder">
+          <div class="preview-placeholder-icon">👣</div>
+          <div>step through ${stages.length} stage${stages.length > 1 ? 's' : ''}</div>
+        </div>`;
+        
+      } catch (err) {
+        showError(err.message);
+        updateUI('error');
+      }
+      
+      isRendering = false;
+    }
+    
+    async function executeNextStep() {
+      if (!stepSession || isRendering) return;
+      
+      const nextIndex = currentStageIndex + 1;
+      if (nextIndex >= stages.length) {
+        // All stages complete
+        document.getElementById('next-btn').disabled = true;
+        return;
+      }
+      
+      isRendering = true;
+      currentStageIndex = nextIndex;
+      stages[nextIndex].status = 'running';
+      renderStageTimeline();
+      
+      document.getElementById('next-btn').disabled = true;
+      updateProgress((nextIndex / stages.length), `executing: ${stages[nextIndex].label}`);
+      document.getElementById('progress-section').style.display = 'block';
+      
+      try {
+        const res = await fetch('/api/step/next', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: stepSession.sessionId }),
+        });
+        
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.message || 'Step execution failed');
+        }
+        
+        const data = await res.json();
+        stages[nextIndex].status = 'complete';
+        stages[nextIndex].result = data.result;
+        
+        // Auto-select and show the completed stage
+        selectedStageId = stages[nextIndex].id;
+        renderStageTimeline();
+        showStagePreview(data);
+        
+        const progress = (nextIndex + 1) / stages.length;
+        if (nextIndex + 1 >= stages.length) {
+          updateProgress(1, 'all stages complete');
+          document.getElementById('progress-bar').className = 'progress-bar complete';
+          document.getElementById('next-btn').disabled = true;
+          
+          // Add to history if final result is a video
+          if (data.result?.type === 'video' && data.result?.previewUrl) {
+            addToHistory(editor.getValue(), data.result.previewUrl);
+          }
+        } else {
+          updateProgress(progress, `${nextIndex + 1}/${stages.length} complete — ready for next`);
+          document.getElementById('next-btn').disabled = false;
+        }
+        
+      } catch (err) {
+        stages[nextIndex].status = 'error';
+        renderStageTimeline();
+        showError(err.message);
+        updateUI('error');
+      }
+      
+      isRendering = false;
+    }
+
+    async function startRender() {
+      if (isRendering) return;
+      
+      isRendering = true;
+      updateUI('rendering');
+      
+      const code = editor.getValue();
+      
+      try {
+        const res = await fetch('/api/render', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n\n');
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            const eventMatch = line.match(/event: (\w+)/);
+            const dataMatch = line.match(/data: (.+)/);
+            if (!eventMatch || !dataMatch) continue;
+
+            const event = eventMatch[1];
+            const data = JSON.parse(dataMatch[1]);
+
+            if (event === 'start') {
+              currentRenderId = data.renderId;
+            } else if (event === 'progress') {
+              updateProgress(data.progress, data.message);
+            } else if (event === 'complete') {
+              showVideo(data.videoUrl);
+              addToHistory(code, data.videoUrl);
+              updateUI('complete');
+            } else if (event === 'error') {
+              showError(data.message);
+              updateUI('error');
+            }
+          }
+        }
+      } catch (err) {
+        showError(err.message);
+        updateUI('error');
+      }
+
+      isRendering = false;
+      currentRenderId = null;
+    }
+
+    async function stopRender() {
+      if (!currentRenderId) return;
+      await fetch('/api/render/' + currentRenderId, { method: 'DELETE' });
+      isRendering = false;
+      currentRenderId = null;
+      updateUI('idle');
+    }
+
+    function updateUI(state) {
+      const runBtn = document.getElementById('run-btn');
+      const stopBtn = document.getElementById('stop-btn');
+      const nextBtn = document.getElementById('next-btn');
+      const progressSection = document.getElementById('progress-section');
+      const progressBar = document.getElementById('progress-bar');
+
+      if (state === 'rendering') {
+        runBtn.disabled = true;
+        stopBtn.disabled = false;
+        if (stepMode) {
+          nextBtn.disabled = true;
+        }
+        progressSection.style.display = 'block';
+        progressBar.className = 'progress-bar';
+      } else if (state === 'complete') {
+        runBtn.disabled = false;
+        stopBtn.disabled = true;
+        progressBar.className = 'progress-bar complete';
+      } else if (state === 'error') {
+        runBtn.disabled = false;
+        stopBtn.disabled = true;
+        progressBar.className = 'progress-bar error';
+      } else {
+        runBtn.disabled = false;
+        stopBtn.disabled = true;
+        if (!stepMode) {
+          progressSection.style.display = 'none';
+        }
+      }
+    }
+
+    function updateProgress(progress, message) {
+      document.getElementById('progress-bar').style.width = (progress * 100) + '%';
+      document.getElementById('progress-text').textContent = message;
+    }
+
+    function showVideo(url) {
+      const container = document.getElementById('preview-content');
+      container.innerHTML = `<video class="preview-video" src="${url}" controls autoplay loop></video>`;
+    }
+
+    function showError(message) {
+      const container = document.getElementById('preview-content');
+      container.innerHTML = `<div class="error-banner">${message}</div>`;
+    }
+
+    function addToHistory(code, videoUrl) {
+      const item = {
+        id: Date.now().toString(),
+        code,
+        videoUrl,
+        createdAt: new Date().toISOString(),
+      };
+      history.unshift(item);
+      if (history.length > 10) history = history.slice(0, 10);
+      localStorage.setItem('varg-history', JSON.stringify(history));
+      renderHistory();
+    }
+
+    function renderHistory() {
+      const grid = document.getElementById('history-grid');
+      grid.innerHTML = history.map(item => `
+        <div class="history-item" onclick="loadHistory('${item.id}')">
+          <video class="history-thumb" src="${item.videoUrl}" muted></video>
+          <div class="history-meta">${new Date(item.createdAt).toLocaleTimeString()}</div>
+        </div>
+      `).join('');
+    }
+
+    function loadHistory(id) {
+      const item = history.find(h => h.id === id);
+      if (!item) return;
+      editor.setValue(item.code);
+      showVideo(item.videoUrl);
+    }
+
+    let currentVideoUrl = null;
+
+    document.getElementById('share-btn').addEventListener('click', async () => {
+      const code = editor.getValue();
+      const res = await fetch('/api/share', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, videoUrl: currentVideoUrl }),
+      });
+      const { url } = await res.json();
+      const fullUrl = window.location.origin + url;
+      await navigator.clipboard.writeText(fullUrl);
+      alert('Link copied to clipboard: ' + fullUrl);
+    });
+
+    async function loadSharedCode() {
+      const path = window.location.pathname;
+      if (!path.startsWith('/s/')) return;
+      const shareId = path.replace('/s/', '');
+      try {
+        const res = await fetch('/api/share/' + shareId);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.code && editor) {
+          editor.setValue(data.code);
+        }
+        if (data.videoUrl) {
+          showVideo(data.videoUrl);
+          currentVideoUrl = data.videoUrl;
+        }
+      } catch {}
+    }
+
+    loadTemplates();
+    renderHistory();
+    setTimeout(loadSharedCode, 500);
+    
+    // Init drawflow after DOM is ready
+    if (typeof Drawflow !== 'undefined') {
+      initDrawflow();
+    } else {
+      console.error('Drawflow not available');
+    }
+  </script>
+</body>
+</html>

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,9 +1,6 @@
-/**
- * CLI commands exports
- */
-
 export { findCmd, showFindHelp } from "./find.tsx";
 export { helpCmd, showHelp } from "./help.tsx";
 export { listCmd, showListHelp } from "./list.tsx";
+export { renderCmd } from "./render.tsx";
 export { runCmd, showRunHelp, showTargetHelp } from "./run.tsx";
 export { showWhichHelp, whichCmd } from "./which.tsx";

--- a/src/cli/commands/render.tsx
+++ b/src/cli/commands/render.tsx
@@ -1,0 +1,71 @@
+import { defineCommand } from "citty";
+import { render } from "../../ai-sdk/react/render";
+import type { VargElement } from "../../ai-sdk/react/types";
+
+export const renderCmd = defineCommand({
+  meta: {
+    name: "render",
+    description: "render a react component to video",
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "component file (.tsx)",
+      required: true,
+    },
+    output: {
+      type: "string",
+      alias: "o",
+      description: "output path",
+    },
+    cache: {
+      type: "string",
+      alias: "c",
+      description: "cache directory",
+      default: ".cache/ai",
+    },
+    quiet: {
+      type: "boolean",
+      alias: "q",
+      description: "minimal output",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const file = args.file as string;
+
+    if (!file) {
+      console.error("usage: varg render <component.tsx> [-o output.mp4]");
+      process.exit(1);
+    }
+
+    const resolvedPath = Bun.resolveSync(file, process.cwd());
+    const mod = await import(resolvedPath);
+    const component: VargElement = mod.default;
+
+    if (!component || component.type !== "render") {
+      console.error("error: default export must be a <Render> element");
+      process.exit(1);
+    }
+
+    const outputPath =
+      args.output ??
+      `output/${file
+        .replace(/\.tsx?$/, "")
+        .split("/")
+        .pop()}.mp4`;
+
+    if (!args.quiet) {
+      console.log(`rendering ${file} → ${outputPath}`);
+    }
+
+    const buffer = await render(component, {
+      output: outputPath,
+      cache: args.cache,
+    });
+
+    if (!args.quiet) {
+      console.log(`done! ${buffer.byteLength} bytes → ${outputPath}`);
+    }
+  },
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import {
   findCmd,
   helpCmd,
   listCmd,
+  renderCmd,
   runCmd,
   showFindHelp,
   showHelp,
@@ -99,6 +100,7 @@ const main = defineCommand({
   },
   subCommands: {
     run: runCmd,
+    render: renderCmd,
     list: listCmd,
     ls: listCmd,
     find: findCmd,

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsxImportSource": "react"
+  },
+  "include": ["src/cli/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "moduleDetection": "force",
     "jsx": "react-jsx",
+    "jsxImportSource": "@/ai-sdk/react",
     "allowJs": true,
 
     // Bundler mode
@@ -40,6 +41,7 @@
     "cli",
     "service",
     "utilities",
-    "pipeline"
+    "pipeline",
+    "src/cli"
   ]
 }


### PR DESCRIPTION
- **fix: test**
- **feat: draft idea jsx for video**
- **feat: ralph example**
- **fix: build**
- **refactor(react): split render.ts into modular renderer files**
- **refactor(react): separate Render root from Video layer element**
- **refactor(docs): show TalkingHead as composition pattern instead of built-in component**
- **feat(react): add Speech renderer for TTS generation**
- **feat(ai-sdk): add biome config for examples with tsx-specific rules**
- **feat(ai-sdk): add ralph-talking example demonstrating TalkingHead composition**
- **refactor(ai-sdk): use function call syntax for Image in TalkingHead composition**
- **feat(react): add runtime type check for Animate image prop**
- **feat(ai-sdk): support pixel and fractional positioning for Image and Video layers**
- **feat(ai-sdk): add Music component for background audio tracks**
- **feat(react): add Overlay element for continuous PiP across clips**
- **chore: add cases**
- **feat(react): add Grid/Split layouts with examples**
- **feat(ai-sdk): add react-video-grid example with 2x2 AI-generated video layout**
- **fix(react): add default duration to video renderer, use JSX children in Split**
- **feat(react): parallelize clip/layer rendering, support flexible image inputs**
- **feat(examples): add react-madi character video example with image-to-image editing**
- **feat(examples): animate madi images with image-to-video**
- **feat(react): add cutFrom/cutTo/duration trim support to Music component**
- **feat(examples): add duration trim to react-madi music track**
- **feat(ai-sdk): add cache viewer studio for inspecting cached images/videos**
- **feat(examples): simplify react-madi example - use local audio, remove transitions**
- **feat(react): add nested element support to cache key computation, add animate debug logging**
- **feat: add model to cache key (breaking)**
- **fix(react): add fill-color base when all videos are overlays**
- **docs: format prompting guide for markdown**
- **feat: use prompting guide for better Madi**
- **feat(react): add cli for rendering component files**
- **feat(react): add local file path support to renderers**
- **feat(react): add subtitle layer support to clip renderer**
- **fix(editly): respect per-layer mixVolume for video audio**
- **feat(ai-sdk): add orange-portrait example with multi-image prompting**
- **feat(ai-sdk): refine orange-portrait prompts for consistency and cinematic quality**
- **feat(ai-sdk): simplify orange-portrait video prompt for natural movement**
- **feat(ai-sdk): improve orange-portrait image prompt with structured reference-based approach**
- **feat(ai-sdk): change orange-portrait framing from close-up to three-quarter**
- **feat: add cli varg tool**
- **fix: husky prepare script for publish compatibility**
- **feat(ai-sdk): add cue-based prompt composition system for orange-portrait**
- **feat(react): add music generation support with prompt+model**
- **feat(ai-sdk): refactor orange-portrait-cues with separate image/video cue systems**
- **feat(cues): type-safe prompt composition with required image/video cue fields**
- **chore: bump version to 0.4.0-alpha.1**
- **feat(react): add progress tracking for render pipeline (#18)**
- **feat(scripts): add studio script for ai-sdk development (#19)**
- **fix(react): improve cache key computation for local files and binary data**
- **feat(editly): add SizeValue type for explicit pixel/percentage positioning**
- **feat(studio): add web-based editor with monaco, templates, and sharing**
- **feat: fix higgsfield provider; add example**
- **feat: remove refactored drafts**
- **fix: dedublication (#20)**
- **feat(examples): update react-madi to use elevenlabs music generation with dynamic prompts**
- **chore: ignore worktrees**
- **docs: add varg-react landing page**
- **feat(studio): add step-by-step rendering mode (#21)**
- **feat(studio): allow loading file on startup via CLI argument**
- **feat: add seadream**
- **feat(studio): add node graph view with drawflow for visualizing render stages**
- **feat(studio): add render node with final video output and loading state**
- **feat(examples): add multi-clip branching example for non-linear video composition**
- **feat: add all templates**
- **fix(cache): include model settings in cache key for higgsfield provider**
- **feat(higgsfield): add Soul style presets and apply CAM_360 to onlyfans example**
- **feat(studio): implement tree-based node layout using dependency graph**
