### PR TITLE
feat(react): add cutFrom/cutTo props to Clip

### DIFF
--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -75,6 +75,10 @@ export interface RenderProps extends BaseProps {
 export interface ClipProps extends BaseProps {
   duration?: number | "auto";
   transition?: TransitionOptions;
+  /** Start trim point in seconds (e.g., 1 to start from 1 second) */
+  cutFrom?: number;
+  /** End trim point in seconds (e.g., 3 to end at 3 seconds) */
+  cutTo?: number;
   children?: VargNode;
 }
 


### PR DESCRIPTION
## Summary

- Add `cutFrom` and `cutTo` optional props to `ClipProps` interface
- Propagate clip-level trim options to all video layers within the clip
- Video-level `cutFrom`/`cutTo` take precedence over clip-level settings

## Usage

```tsx
// Trim all videos in a clip from 1s to 5s
<Clip cutFrom={1} cutTo={5}>
  <Video src="video1.mp4" />
  <Video src="video2.mp4" />
</Clip>

// Video-level props still take precedence
<Clip cutFrom={1} cutTo={5}>
  <Video src="video1.mp4" cutFrom={2} />  {/* Uses cutFrom=2, cutTo=5 */}
</Clip>
```