### PR TITLE
refactor(render): remove default mode to fix cache pollution

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,7 +1,7 @@
 export { findCmd, showFindHelp } from "./find.tsx";
 export { helpCmd, showHelp } from "./help.tsx";
 export { listCmd, showListHelp } from "./list.tsx";
-export { fastCmd, previewCmd, renderCmd } from "./render.ts";
+export { previewCmd, renderCmd } from "./render.ts";
 export { runCmd, showRunHelp, showTargetHelp } from "./run.tsx";
 export { studioCmd } from "./studio.ts";
 export { showWhichHelp, whichCmd } from "./which.tsx";

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -127,8 +127,7 @@ async function runRender(
   const outputPath = (args.output as string) ?? `output/${basename}.mp4`;
 
   if (!args.quiet) {
-    const modeLabel =
-      mode === "preview" ? " (fast)" : mode === "strict" ? "" : " (preview)";
+    const modeLabel = mode === "preview" ? " (fast)" : "";
     console.log(`rendering ${file} → ${outputPath}${modeLabel}`);
   }
 
@@ -163,21 +162,10 @@ export const renderCmd = defineCommand({
 export const previewCmd = defineCommand({
   meta: {
     name: "preview",
-    description: "render with fallback placeholders on errors",
-  },
-  args: sharedArgs,
-  async run({ args }) {
-    await runRender(args, "default", "preview");
-  },
-});
-
-export const fastCmd = defineCommand({
-  meta: {
-    name: "fast",
     description: "render with all placeholders (no generation)",
   },
   args: sharedArgs,
   async run({ args }) {
-    await runRender(args, "preview", "fast");
+    await runRender(args, "preview", "preview");
   },
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,6 @@ import { defineCommand, runMain } from "citty";
 import { registry } from "../core/registry";
 import { allDefinitions } from "../definitions";
 import {
-  fastCmd,
   findCmd,
   helpCmd,
   listCmd,
@@ -107,7 +106,6 @@ const main = defineCommand({
     run: runCmd,
     render: renderCmd,
     preview: previewCmd,
-    fast: fastCmd,
     studio: studioCmd,
     list: listCmd,
     ls: listCmd,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -202,7 +202,7 @@ export interface PackshotProps extends BaseProps {
   duration?: number;
 }
 
-export type RenderMode = "strict" | "default" | "preview";
+export type RenderMode = "strict" | "preview";
 
 export interface DefaultModels {
   image?: ImageModelV3;


### PR DESCRIPTION
## Summary

- removes `default` render mode due to cache pollution bug (#35)
- only `strict` and `preview` modes remain
- removes duplicate `fast` cli command (was identical to `preview`)

## Changes

| mode | behavior |
|------|----------|
| `strict` | fail on API errors (default) |
| `preview` | all placeholders, no API calls |

## Why

the `default` mode had a bug where:
1. image API fails → placeholder used → video generates with placeholder → cached
2. next run: image succeeds → video returns cached placeholder-based result

see #35 for details and potential future solutions if we want to bring back default mode.

## Breaking Changes

- `RenderMode` type no longer includes `"default"`
- `varg fast` command removed (use `varg preview` instead)
- default mode is now `strict` instead of `default`