### PR TITLE
fix(fal): use image_size for flux models to fix aspect ratio

### DIFF
--- a/src/ai-sdk/providers/fal.ts
+++ b/src/ai-sdk/providers/fal.ts
@@ -58,7 +58,12 @@ const IMAGE_MODELS: Record<string, string> = {
 };
 
 // Models that use image_size instead of aspect_ratio
-const IMAGE_SIZE_MODELS = new Set(["seedream-v4.5/edit"]);
+const IMAGE_SIZE_MODELS = new Set([
+  "flux-schnell",
+  "flux-dev",
+  "flux-pro",
+  "seedream-v4.5/edit",
+]);
 
 // Map aspect ratio strings to image_size enum values
 const ASPECT_RATIO_TO_IMAGE_SIZE: Record<string, string> = {


### PR DESCRIPTION
## Summary

fixes aspect ratio being ignored for flux models (flux-schnell, flux-dev, flux-pro).

## Problem

flux models use `image_size` enum parameter, not `aspect_ratio`. without this fix:
- `aspectRatio: "1:1"` was ignored
- images defaulted to `landscape_4_3` (1024x768)
- resulted in squashed images when rendered into square canvas

## Fix

added flux models to `IMAGE_SIZE_MODELS` set so `aspectRatio` gets correctly mapped to `image_size` enum values like `"square"`, `"portrait_16_9"`, etc.

## Test

before fix - image was 1024x768 (4:3):
```
$ ffprobe /tmp/cached-cat.png
1024,768
```

after fix - image is 512x512 (1:1):
```
$ bun run src/cli/index.ts render test-render.tsx -o output/test-fixed.mp4
rendering test-render.tsx → output/test-fixed.mp4
⏳ generating image with flux-schnell (~30s)
[fal-provider] seedream input: {
  "prompt": "cute orange cat sitting on a couch",
  "num_images": 1,
  "image_size": "square"
}
✓ image done (1.6s)
⏳ generating editly with ffmpeg (~15s)
Output: output/test-fixed.mp4
⚡ editly from cache
done! 195071 bytes → output/test-fixed.mp4

$ ffprobe /tmp/fixed-cat.png
512,512
```