### PR TITLE
feat(react): add Batch component for concurrent multi-video rendering

### DIFF
--- a/src/react/elements.ts
+++ b/src/react/elements.ts
@@ -1,4 +1,5 @@
 import type {
+  BatchProps,
   CaptionsProps,
   ClipProps,
   ImageProps,
@@ -36,6 +37,14 @@ function createElement<T extends VargElement["type"]>(
     props: restProps,
     children: normalizeChildren(children ?? props.children),
   };
+}
+
+export function Batch(props: BatchProps): VargElement<"batch"> {
+  return createElement(
+    "batch",
+    props as Record<string, unknown>,
+    props.children,
+  );
 }
 
 export function Render(props: RenderProps): VargElement<"render"> {

--- a/src/react/examples/batch-demo.tsx
+++ b/src/react/examples/batch-demo.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource vargai */
+
+import { fal } from "vargai/ai";
+import { Batch, Clip, Image, Render, Video } from "vargai/react";
+
+const HOOKS = [
+  "Stop satisfying everyone around you",
+  "Your comfort zone is killing your potential",
+  "Nobody is coming to save you",
+  "The only limit is your imagination",
+];
+
+const character = Image({
+  prompt: "confident young entrepreneur, casual hoodie, minimalist background",
+  model: fal.imageModel("flux-schnell"),
+  aspectRatio: "9:16",
+});
+
+export default (
+  <Batch parallel={2} output="output/hooks">
+    {HOOKS.map((hook) => (
+      <Render
+        key={hook}
+        name={hook.toLowerCase().replace(/\s+/g, "-")}
+        width={1080}
+        height={1920}
+      >
+        <Clip duration={5}>
+          <Video
+            prompt={{
+              text: `person speaking directly to camera: "${hook}"`,
+              images: [character],
+            }}
+            model={fal.videoModel("kling-v2.5")}
+          />
+        </Clip>
+      </Render>
+    ))}
+  </Batch>
+);

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,6 +1,7 @@
 export type { SizeValue } from "../ai-sdk/providers/editly/types";
 export { assets } from "./assets";
 export {
+  Batch,
   Captions,
   Clip,
   Image,
@@ -18,8 +19,9 @@ export {
   Video,
 } from "./elements";
 export { Grid, SplitLayout } from "./layouts";
-export { render, renderStream } from "./render";
+export { type BatchResult, render, renderBatch, renderStream } from "./render";
 export type {
+  BatchProps,
   CaptionsProps,
   ClipProps,
   ImageProps,

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -1,16 +1,22 @@
 import { renderRoot } from "./renderers";
+import { type BatchResult, renderBatch } from "./renderers/batch";
 import type { RenderOptions, VargElement } from "./types";
 
 export async function render(
   element: VargElement,
   options: RenderOptions = {},
 ): Promise<Uint8Array> {
+  if (element.type === "batch") {
+    throw new Error("Use renderBatch() for <Batch> elements");
+  }
   if (element.type !== "render") {
     throw new Error("Root element must be <Render>");
   }
 
   return renderRoot(element as VargElement<"render">, options);
 }
+
+export { renderBatch, type BatchResult };
 
 export const renderStream = {
   async *stream(element: VargElement, options: RenderOptions = {}) {

--- a/src/react/renderers/batch.ts
+++ b/src/react/renderers/batch.ts
@@ -1,0 +1,76 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  BatchProps,
+  RenderOptions,
+  RenderProps,
+  VargElement,
+} from "../types";
+import { renderRoot } from "./render";
+
+export interface BatchResult {
+  name: string;
+  path: string;
+  buffer: Uint8Array;
+}
+
+export async function renderBatch(
+  element: VargElement<"batch">,
+  options: RenderOptions,
+): Promise<BatchResult[]> {
+  const props = element.props as BatchProps;
+  const parallel = props.parallel ?? 1;
+  const outputDir = props.output ?? options.output ?? "output";
+
+  mkdirSync(outputDir, { recursive: true });
+
+  const renderElements: VargElement<"render">[] = [];
+  for (const child of element.children) {
+    if (!child || typeof child !== "object" || !("type" in child)) continue;
+    const childElement = child as VargElement;
+    if (childElement.type === "render") {
+      renderElements.push(childElement as VargElement<"render">);
+    }
+  }
+
+  if (renderElements.length === 0) {
+    throw new Error("Batch requires at least one <Render> child");
+  }
+
+  const results: BatchResult[] = [];
+  const total = renderElements.length;
+
+  const renderOne = async (
+    renderElement: VargElement<"render">,
+    index: number,
+  ): Promise<BatchResult> => {
+    const renderProps = renderElement.props as RenderProps;
+    const name = renderProps.name ?? `video-${index}`;
+    const outputPath = join(outputDir, `${name}.mp4`);
+
+    if (!options.quiet) {
+      console.log(`[${index + 1}/${total}] rendering ${name}...`);
+    }
+
+    const buffer = await renderRoot(renderElement, {
+      ...options,
+      output: outputPath,
+    });
+
+    if (!options.quiet) {
+      console.log(`[${index + 1}/${total}] done: ${outputPath}`);
+    }
+
+    return { name, path: outputPath, buffer };
+  };
+
+  for (let i = 0; i < renderElements.length; i += parallel) {
+    const batch = renderElements.slice(i, i + parallel);
+    const batchResults = await Promise.all(
+      batch.map((el, j) => renderOne(el, i + j)),
+    );
+    results.push(...batchResults);
+  }
+
+  return results;
+}

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { VideoModelV3 } from "../ai-sdk/video-model";
 
 export type VargElementType =
+  | "batch"
   | "render"
   | "clip"
   | "overlay"
@@ -62,8 +63,18 @@ export type TrimProps =
   | { cutFrom?: number; cutTo?: number; duration?: never }
   | { cutFrom?: number; cutTo?: never; duration?: number };
 
+export interface BatchProps extends BaseProps {
+  /** Number of concurrent renders (default: 1) */
+  parallel?: number;
+  /** Output directory for all videos */
+  output?: string;
+  children?: VargNode;
+}
+
 // Root container - sets dimensions, fps, contains clips
 export interface RenderProps extends BaseProps {
+  /** Name for output file (used in batch mode) */
+  name?: string;
   width?: number;
   height?: number;
   fps?: number;
@@ -221,6 +232,7 @@ export interface RenderOptions {
 }
 
 export interface ElementPropsMap {
+  batch: BatchProps;
   render: RenderProps;
   clip: ClipProps;
   overlay: OverlayProps;


### PR DESCRIPTION
## Summary

- adds `<Batch>` wrapper component to render multiple videos with concurrency control
- supports `parallel` prop for concurrent renders (default: 1)
- fail-fast behavior - first error stops the batch
- each `<Render>` child uses `name` prop for output filename

## Usage

```tsx
<Batch parallel={4} output="output/hooks">
  {HOOKS.map((hook) => (
    <Render key={hook} name={hook.toLowerCase().replace(/\s+/g, "-")}>
      <Clip duration={5}>
        <Video prompt={hook} />
      </Clip>
    </Render>
  ))}
</Batch>
```

## Changes

- `src/react/types.ts` - added `batch` type, `BatchProps`, `name` to `RenderProps`
- `src/react/elements.ts` - added `Batch()` function
- `src/react/renderers/batch.ts` - new renderer with chunked concurrency
- `src/react/render.ts` - exports `renderBatch`
- `src/react/index.ts` - exports `Batch`, `BatchProps`, `renderBatch`, `BatchResult`
- `src/cli/commands/render.tsx` - handles batch in cli
- `src/react/examples/batch-demo.tsx` - example file