### PR TITLE
fix(captions): fix stretched text, compression artifacts, and add position prop

### DIFF
--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -289,7 +289,7 @@ export async function renderRoot(
     startTask(progress, captionsTaskId);
 
     const { $ } = await import("bun");
-    await $`ffmpeg -y -i ${tempOutPath} -vf "ass=${captionsResult.assPath}" -c:a copy ${finalOutPath}`.quiet();
+    await $`ffmpeg -y -i ${tempOutPath} -vf "ass=${captionsResult.assPath}" -crf 18 -preset slow -c:a copy ${finalOutPath}`.quiet();
 
     ctx.tempFiles.push(tempOutPath);
     completeTask(progress, captionsTaskId);

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -172,6 +172,7 @@ export interface CaptionsProps extends BaseProps {
   src?: string | VargElement<"speech">;
   srt?: string;
   style?: "tiktok" | "karaoke" | "bounce" | "typewriter";
+  position?: "top" | "center" | "bottom";
   color?: string;
   activeColor?: string;
   fontSize?: number;


### PR DESCRIPTION
## Summary

- **Fix stretched/elongated font**: Add `PlayResX`/`PlayResY` to ASS header matching actual video dimensions. Without these, libass defaults to 384x288 (4:3), causing ~2.37x vertical stretch on 9:16 videos.
- **Fix black background box**: Set `backColor` to fully transparent (`&H00000000`) in tiktok preset. The semi-opaque `&H80000000` was rendering a visible rectangle behind each word.
- **Fix compression artifacts**: Add `-crf 18 -preset slow` to the ffmpeg captions burn pass. Default CRF 23 was causing blocky halos around text edges.
- **Bump tiktok font size**: `fontSize` 32→72, `outline` 3→4 for proper visibility at 1080x1920.
- **Add `position` prop**: `"top" | "center" | "bottom"` for caption vertical placement.

## Files changed

| File | Change |
|------|--------|
| `src/react/renderers/captions.ts` | PlayRes fix, backColor fix, font size bump, position mapping |
| `src/react/renderers/render.ts` | CRF 18 + preset slow on ffmpeg burn |
| `src/react/types.ts` | `position` prop on `CaptionsProps` |