### PR TITLE
fix(subtitle): auto-size font to fit frame width

### DIFF
--- a/src/ai-sdk/providers/editly/layers.ts
+++ b/src/ai-sdk/providers/editly/layers.ts
@@ -620,7 +620,13 @@ export function getSubtitleFilter(
   const text = escapeDrawText(layer.text);
   const textColor = layer.textColor ?? "white";
   const bgColor = layer.backgroundColor ?? "black@0.7";
-  const fontSize = Math.round(Math.min(width, height) * 0.05);
+
+  // Auto-size font to fit within 90% of frame width
+  const maxFontSize = Math.round(Math.min(width, height) * 0.05);
+  const maxTextWidth = width * 0.9;
+  // Average char width ≈ fontSize * 0.55 for sans-serif fonts
+  const fittedFontSize = Math.floor(maxTextWidth / (layer.text.length * 0.55));
+  const fontSize = Math.max(16, Math.min(maxFontSize, fittedFontSize));
   const boxPadding = Math.round(fontSize * 0.4);
 
   const fontFile = layer.fontPath


### PR DESCRIPTION
## Summary
- Subtitle text that exceeds the video frame width now auto-shrinks to fit within 90% of the frame
- Previously, `getSubtitleFilter()` used a fixed font size of `5% * min(width, height)` regardless of text length, causing long text (e.g. disclaimers) to overflow and get clipped on both sides
- The fix estimates text pixel width using a `0.55` char-width-to-fontSize ratio (standard for sans-serif), then picks `min(maxFontSize, fittedFontSize)` clamped to a 16px floor
- Short text renders at the same size as before (capped at the original max); only long text shrinks

Resolves subtitle overflow for disclaimer text like "Scientifically designed for subconscious alignment. Results may vary." on 1080x1920 videos.