### PR TITLE
fix(title): auto-size font to fit frame width and add titlePosition to packshot

### DIFF
--- a/src/ai-sdk/providers/editly/layers.ts
+++ b/src/ai-sdk/providers/editly/layers.ts
@@ -588,7 +588,13 @@ export function getTitleFilter(
 ): string {
   const text = escapeDrawText(layer.text);
   const color = layer.textColor ?? "white";
-  const fontSize = Math.round(Math.min(width, height) * 0.08);
+
+  // Auto-size font to fit within 90% of frame width (same approach as subtitle)
+  const maxFontSize = Math.round(Math.min(width, height) * 0.08);
+  const maxTextWidth = width * 0.9;
+  // Average char width ≈ fontSize * 0.55 for sans-serif fonts
+  const fittedFontSize = Math.floor(maxTextWidth / (layer.text.length * 0.55));
+  const fontSize = Math.max(16, Math.min(maxFontSize, fittedFontSize));
 
   let x = "(w-text_w)/2";
   let y = "(h-text_h)/2";
@@ -665,7 +671,14 @@ export function getTitleBackgroundFilter(
 
   const text = escapeDrawText(layer.text);
   const textColor = layer.textColor ?? "white";
-  const fontSize = Math.round(Math.min(width, height) * 0.1);
+
+  // Auto-size font to fit within 90% of frame width
+  const maxFontSizeBg = Math.round(Math.min(width, height) * 0.1);
+  const maxTextWidthBg = width * 0.9;
+  const fittedFontSizeBg = Math.floor(
+    maxTextWidthBg / (layer.text.length * 0.55),
+  );
+  const fontSize = Math.max(16, Math.min(maxFontSizeBg, fittedFontSizeBg));
 
   const fontFile = layer.fontPath
     ? `:fontfile='${escapeDrawText(layer.fontPath)}'`

--- a/src/react/renderers/packshot.ts
+++ b/src/react/renderers/packshot.ts
@@ -134,7 +134,7 @@ export async function renderPackshot(
       type: "title",
       text: props.title,
       textColor: props.titleColor ?? "#FFFFFF",
-      position: "center",
+      position: resolvePosition(props.titlePosition ?? "center"),
     };
     layers.push(titleLayer);
   }

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -210,6 +210,8 @@ export interface PackshotProps extends BaseProps {
   title?: string;
   /** Title text color (hex, default: "#FFFFFF") */
   titleColor?: string;
+  /** Title position on screen (default: "center") */
+  titlePosition?: Position;
   /** CTA button text */
   cta?: string;
   /**


### PR DESCRIPTION
## Summary
- Title text (`getTitleFilter`) and title-background text (`getTitleBackgroundFilter`) now auto-shrink to fit within 90% of frame width, using the same approach as the subtitle fix in #67
- Added `titlePosition` prop to `PackshotProps` so packshot title can be positioned (`top`/`center`/`bottom`) instead of being hardcoded to `center`

## Problem
Long title text like "START YOUR 14-DAY ALIGNMENT" overflows the frame on 1080x1920 videos — `getTitleFilter` used a fixed `min(w,h) * 0.08` = 86px font size, producing ~1419px of text width on a 1080px frame.

## Fix
```ts
const maxFontSize = Math.round(Math.min(width, height) * 0.08);
const maxTextWidth = width * 0.9;
const fittedFontSize = Math.floor(maxTextWidth / (layer.text.length * 0.55));
const fontSize = Math.max(16, Math.min(maxFontSize, fittedFontSize));
```
Short text keeps the original large size. Long text shrinks to fit. Floor at 16px.

Follows the same pattern established in #67 for subtitles.