### PR TITLE
refactor(editly): simplify backend interface

### DIFF
--- a/src/ai-sdk/providers/editly/backends/index.ts
+++ b/src/ai-sdk/providers/editly/backends/index.ts
@@ -1,6 +1,7 @@
 export { LocalBackend, localBackend } from "./local";
 export type {
   FFmpegBackend,
+  FFmpegInput,
   FFmpegRunOptions,
   FFmpegRunResult,
   VideoInfo,

--- a/src/ai-sdk/providers/editly/backends/local.ts
+++ b/src/ai-sdk/providers/editly/backends/local.ts
@@ -1,12 +1,11 @@
 import { $ } from "bun";
 import type {
   FFmpegBackend,
+  FFmpegInput,
   FFmpegRunOptions,
   FFmpegRunResult,
   VideoInfo,
 } from "./types";
-
-const FFMPEG_COMMON_ARGS = ["-hide_banner", "-loglevel", "error"];
 
 export class LocalBackend implements FFmpegBackend {
   readonly name = "local";
@@ -39,13 +38,43 @@ export class LocalBackend implements FFmpegBackend {
     };
   }
 
+  private buildInputArgs(inputs: FFmpegInput[]): string[] {
+    const args: string[] = [];
+    for (const input of inputs) {
+      if (typeof input === "string") {
+        args.push("-i", input);
+      } else if ("raw" in input) {
+        args.push(...input.raw.split(" "));
+      } else {
+        if (input.options) args.push(...input.options);
+        args.push("-i", input.path);
+      }
+    }
+    return args;
+  }
+
   async run(options: FFmpegRunOptions): Promise<FFmpegRunResult> {
-    const { args, outputPath, verbose } = options;
+    const {
+      inputs,
+      filterComplex,
+      videoFilter,
+      outputArgs = [],
+      outputPath,
+      verbose,
+    } = options;
+
+    const inputArgs = this.buildInputArgs(inputs);
 
     const ffmpegArgs = [
-      ...FFMPEG_COMMON_ARGS.slice(0, 2),
+      "-hide_banner",
+      "-loglevel",
       verbose ? "info" : "error",
-      ...args,
+      ...inputArgs,
+      ...(filterComplex ? ["-filter_complex", filterComplex] : []),
+      ...(videoFilter ? ["-vf", videoFilter] : []),
+      ...outputArgs,
+      "-y",
+      outputPath,
     ];
 
     if (verbose) {

--- a/src/ai-sdk/providers/editly/backends/types.ts
+++ b/src/ai-sdk/providers/editly/backends/types.ts
@@ -11,13 +11,33 @@ import type { VideoInfo } from "../types";
 export type { VideoInfo };
 
 /**
- * FFmpeg execution options
+ * Represents an input to ffmpeg - can be a simple path/URL or structured with options
+ */
+export type FFmpegInput =
+  | string
+  | {
+      /** Path or URL to the input file */
+      path: string;
+      /** Options to apply BEFORE the -i flag (e.g. -ss 5 for seeking) */
+      options?: string[];
+    }
+  | {
+      /** Raw ffmpeg args that don't use -i (e.g. "-f lavfi -i color=black") */
+      raw: string;
+    };
+
+/**
+ * FFmpeg execution options - new interface where backend builds -i flags
  */
 export interface FFmpegRunOptions {
-  /** ffmpeg arguments (without the 'ffmpeg' command itself) */
-  args: string[];
-  /** List of input file paths (local or URLs) */
-  inputs: string[];
+  /** Inputs - backend builds -i flags from these */
+  inputs: FFmpegInput[];
+  /** Filter complex string (uses input indices like [0:v], [1:a]) */
+  filterComplex?: string;
+  /** Video filter string for single-input operations */
+  videoFilter?: string;
+  /** Arguments after inputs but before output (codec, map, etc) */
+  outputArgs?: string[];
   /** Output file path */
   outputPath: string;
   /** Enable verbose logging */

--- a/src/ai-sdk/providers/editly/rendi/index.ts
+++ b/src/ai-sdk/providers/editly/rendi/index.ts
@@ -1,5 +1,6 @@
 import type {
   FFmpegBackend,
+  FFmpegInput,
   FFmpegRunOptions,
   FFmpegRunResult,
   VideoInfo,
@@ -103,49 +104,80 @@ export class RendiBackend implements FFmpegBackend {
     throw new Error("Rendi ffprobe timed out");
   }
 
-  async run(options: FFmpegRunOptions): Promise<FFmpegRunResult> {
-    const { args, inputs, outputPath, verbose } = options;
+  private getInputPath(input: FFmpegInput): string {
+    if (typeof input === "string") return input;
+    if ("raw" in input) throw new Error("raw inputs not supported in Rendi");
+    return input.path;
+  }
 
-    const uniqueInputs = [...new Set(inputs)];
-    const inputUrls = uniqueInputs.map((input) => this.ensureUrl(input));
+  async run(options: FFmpegRunOptions): Promise<FFmpegRunResult> {
+    const {
+      inputs,
+      filterComplex,
+      videoFilter,
+      outputArgs = [],
+      outputPath,
+      verbose,
+    } = options;
 
     const inputFiles: Record<string, string> = {};
     const pathToPlaceholder = new Map<string, string>();
 
-    for (let i = 0; i < uniqueInputs.length; i++) {
+    for (let i = 0; i < inputs.length; i++) {
+      const input = inputs[i]!;
+      const path = this.getInputPath(input);
+      const url = this.ensureUrl(path);
       const placeholder = `in_${i + 1}`;
-      inputFiles[placeholder] = inputUrls[i]!;
-      pathToPlaceholder.set(uniqueInputs[i]!, `{{${placeholder}}}`);
+      inputFiles[placeholder] = url;
+      pathToPlaceholder.set(path, `{{${placeholder}}}`);
     }
 
-    const commandArgs = args.map((arg) => {
-      if (arg === outputPath) {
-        return "{{out_1}}";
-      }
-      const placeholder = pathToPlaceholder.get(arg);
-      if (placeholder) {
-        return placeholder;
-      }
-      let result = arg;
+    const replaceWithPlaceholders = (str: string): string => {
+      let result = str;
       for (const [url, ph] of pathToPlaceholder) {
         if (result.includes(url)) {
           result = result.replaceAll(url, ph);
         }
       }
       return result;
-    });
+    };
 
-    const filteredArgs = this.stripInternalFlags(commandArgs);
-    const ffmpegCommand = this.buildCommandString(filteredArgs);
+    const inputArgs: string[] = [];
+    for (let i = 0; i < inputs.length; i++) {
+      const input = inputs[i]!;
+      if (typeof input !== "string" && "options" in input && input.options) {
+        inputArgs.push(...input.options);
+      }
+      inputArgs.push("-i", `{{in_${i + 1}}}`);
+    }
 
+    const filterArgs: string[] = [];
+    if (filterComplex) {
+      filterArgs.push(
+        "-filter_complex",
+        replaceWithPlaceholders(filterComplex),
+      );
+    }
+    if (videoFilter) {
+      filterArgs.push("-vf", replaceWithPlaceholders(videoFilter));
+    }
+
+    const processedOutputArgs = outputArgs
+      .filter((arg) => arg !== "-y")
+      .map((arg) => replaceWithPlaceholders(arg));
+
+    const commandParts = [
+      ...inputArgs,
+      ...filterArgs,
+      ...processedOutputArgs,
+      "{{out_1}}",
+    ];
+    const ffmpegCommand = this.buildCommandString(commandParts);
     const outputFilename = outputPath?.split("/").pop() ?? "output.mp4";
-    const finalCommand = ffmpegCommand.includes("{{out_1}}")
-      ? ffmpegCommand
-      : ffmpegCommand.replace(/[^\s]+\.\w+$/, "{{out_1}}");
 
     if (verbose) {
       console.log("[rendi] input_files:", inputFiles);
-      console.log("[rendi] ffmpeg_command:", finalCommand);
+      console.log("[rendi] ffmpeg_command:", ffmpegCommand);
     }
 
     const submitResponse = await fetch(`${RENDI_API_BASE}/run-ffmpeg-command`, {
@@ -157,7 +189,7 @@ export class RendiBackend implements FFmpegBackend {
       body: JSON.stringify({
         input_files: inputFiles,
         output_files: { out_1: outputFilename },
-        ffmpeg_command: finalCommand,
+        ffmpeg_command: ffmpegCommand,
         max_command_run_seconds: DEFAULT_MAX_COMMAND_SECONDS,
       }),
     });
@@ -226,29 +258,6 @@ export class RendiBackend implements FFmpegBackend {
       return input;
     }
     throw new Error(`Rendi backend requires URLs, got local path: ${input}`);
-  }
-
-  private stripInternalFlags(args: string[]): string[] {
-    const filtered: string[] = [];
-    let skipNext = false;
-
-    for (const arg of args) {
-      if (skipNext) {
-        skipNext = false;
-        continue;
-      }
-
-      if (arg === "-hide_banner") continue;
-      if (arg === "-y") continue;
-      if (arg === "-loglevel") {
-        skipNext = true;
-        continue;
-      }
-
-      filtered.push(arg);
-    }
-
-    return filtered;
   }
 
   private buildCommandString(args: string[]): string {

--- a/src/ai-sdk/providers/editly/rendi/rendi.test.ts
+++ b/src/ai-sdk/providers/editly/rendi/rendi.test.ts
@@ -19,21 +19,10 @@ describe.skipIf(!hasRendiKey)("rendi backend", () => {
     const backend = createRendiBackend();
 
     const result = await backend.run({
-      args: [
-        "-i",
-        "https://storage.rendi.dev/sample/big_buck_bunny_720p_5sec_intro.mp4",
-        "-t",
-        "2",
-        "-c:v",
-        "libx264",
-        "-preset",
-        "ultrafast",
-        "-y",
-        "output.mp4",
-      ],
       inputs: [
         "https://storage.rendi.dev/sample/big_buck_bunny_720p_5sec_intro.mp4",
       ],
+      outputArgs: ["-t", "2", "-c:v", "libx264", "-preset", "ultrafast"],
       outputPath: "output.mp4",
       verbose: true,
     });

--- a/src/react/renderers/burn-captions.ts
+++ b/src/react/renderers/burn-captions.ts
@@ -84,21 +84,9 @@ export async function burnCaptions(
   const escapedAssPath = assInput.replace(/\\/g, "\\\\").replace(/:/g, "\\:");
 
   const result = await backend.run({
-    args: [
-      "-i",
-      videoInput,
-      "-vf",
-      `subtitles=${escapedAssPath}`,
-      "-crf",
-      "18",
-      "-preset",
-      "fast",
-      "-c:a",
-      "copy",
-      "-y",
-      outputPath,
-    ],
     inputs: [videoInput, assInput],
+    videoFilter: `subtitles=${escapedAssPath}`,
+    outputArgs: ["-crf", "18", "-preset", "fast", "-c:a", "copy"],
     outputPath,
     verbose,
   });


### PR DESCRIPTION
## Summary

- Refactors FFmpeg backend interface to eliminate redundant input passing
- Backends now build `-i` flags internally from structured `FFmpegInput` type
- Simplifies caller code in editly and burnCaptions

## Changes

- **types.ts**: Added `FFmpegInput` type (string | path+options | raw), updated `FFmpegRunOptions` with `filterComplex`, `videoFilter`, `outputArgs`
- **local.ts**: Added `buildInputArgs()` method that generates `-i` flags from inputs
- **rendi/index.ts**: Simplified to use new interface, removed `stripInternalFlags()` (no longer needed)
- **editly/index.ts**: Updated to use `filterComplex` and `outputArgs` instead of raw args
- **burn-captions.ts**: Updated to use `videoFilter` instead of building raw args

## Before/After

```ts
// Before - inputs passed twice, error-prone
backend.run({
  args: ["-i", video, "-vf", `subtitles=${ass}`, ...],
  inputs: [video, ass],  // redundant!
  outputPath: "out.mp4"
});

// After - clean, no redundancy
backend.run({
  inputs: [video, ass],
  videoFilter: `subtitles=${ass}`,
  outputArgs: ["-crf", "18"],
  outputPath: "out.mp4"
});
```

## Testing

- `bun test src/react/react.test.ts` - 14/14 ✅
- `bun test src/ai-sdk/providers/editly/editly.test.ts` - 39/40 ✅ (1 flaky timeout unrelated)