### PR TITLE
feat(ai-sdk): add Together provider and fal timing diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ REPLICATE_API_TOKEN=r8_xxx
 
 # apify (web scraping actors)
 APIFY_TOKEN=apify_api_xxx
+
+# decart ai (real-time & batch video/image)
+DECART_API_KEY=decart_xxx
+
+# together ai (fast flux-schnell, no queue)
+TOGETHER_API_KEY=together_xxx

--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -88,6 +88,10 @@ export {
   type ReplicateProviderSettings,
   replicate,
 } from "./providers/replicate";
+export {
+  createTogetherProvider,
+  together,
+} from "./providers/together";
 export type {
   VideoModelV3,
   VideoModelV3CallOptions,

--- a/src/ai-sdk/providers/fal.ts
+++ b/src/ai-sdk/providers/fal.ts
@@ -386,6 +386,8 @@ class FalImageModel implements ImageModelV3 {
     const input: Record<string, unknown> = {
       prompt,
       num_images: n ?? 1,
+      // Use high acceleration for faster queue processing on supported models (flux-schnell)
+      acceleration: "high",
       ...(providerOptions?.fal ?? {}),
     };
 
@@ -442,18 +444,36 @@ class FalImageModel implements ImageModelV3 {
 
     const finalEndpoint = this.resolveEndpoint();
 
-    // Debug: log the input being sent
-    if (IMAGE_SIZE_MODELS.has(this.modelId)) {
-      console.log(
-        "[fal-provider] seedream input:",
-        JSON.stringify(input, null, 2),
-      );
-    }
+    // Timing diagnostics
+    const t0 = Date.now();
+    let lastStatus = "";
+    const queueStartTime = t0;
+    let processingStartTime = 0;
 
     const result = await fal.subscribe(finalEndpoint, {
       input,
       logs: true,
+      onQueueUpdate: (status) => {
+        const elapsed = Date.now() - t0;
+        if (status.status !== lastStatus) {
+          if (status.status === "IN_PROGRESS" && !processingStartTime) {
+            processingStartTime = Date.now();
+            console.log(
+              `[fal-timing] ${this.modelId}: IN_QUEUE took ${processingStartTime - queueStartTime}ms`,
+            );
+          }
+          console.log(
+            `[fal-timing] ${this.modelId}: status=${status.status} at ${elapsed}ms`,
+          );
+          lastStatus = status.status;
+        }
+      },
     });
+
+    const subscribeTime = Date.now() - t0;
+    console.log(
+      `[fal-timing] ${this.modelId}: total subscribe took ${subscribeTime}ms`,
+    );
 
     const data = result.data as { images?: Array<{ url?: string }> };
     const images = data?.images ?? [];
@@ -462,11 +482,16 @@ class FalImageModel implements ImageModelV3 {
       throw new Error("No images in fal response");
     }
 
+    const t1 = Date.now();
     const imageBuffers = await Promise.all(
       images.map(async (img) => {
         const response = await fetch(img.url!, { signal: abortSignal });
         return new Uint8Array(await response.arrayBuffer());
       }),
+    );
+    const downloadTime = Date.now() - t1;
+    console.log(
+      `[fal-timing] ${this.modelId}: image download took ${downloadTime}ms`,
     );
 
     return {

--- a/src/ai-sdk/providers/together.ts
+++ b/src/ai-sdk/providers/together.ts
@@ -1,0 +1,191 @@
+import {
+  type ImageModelV3,
+  type ImageModelV3CallOptions,
+  NoSuchModelError,
+  type SharedV3Warning,
+} from "@ai-sdk/provider";
+
+const IMAGE_MODELS: Record<string, string> = {
+  "flux-schnell": "black-forest-labs/FLUX.1-schnell",
+  "flux-dev": "black-forest-labs/FLUX.1-dev",
+  "flux-pro": "black-forest-labs/FLUX.1-pro",
+  "flux-1.1-pro": "black-forest-labs/FLUX.1.1-pro",
+  "flux-kontext-pro": "black-forest-labs/FLUX.1-kontext-pro",
+  "flux-kontext-max": "black-forest-labs/FLUX.1-kontext-max",
+};
+
+// Aspect ratio to width/height mapping
+const ASPECT_RATIO_DIMENSIONS: Record<
+  string,
+  { width: number; height: number }
+> = {
+  "1:1": { width: 1024, height: 1024 },
+  "4:3": { width: 1024, height: 768 },
+  "3:4": { width: 768, height: 1024 },
+  "16:9": { width: 1344, height: 768 },
+  "9:16": { width: 768, height: 1344 },
+  "3:2": { width: 1024, height: 683 },
+  "2:3": { width: 683, height: 1024 },
+};
+
+interface TogetherProviderOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+class TogetherImageModel implements ImageModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "together";
+  readonly modelId: string;
+  readonly maxImagesPerCall = 4;
+
+  private apiKey: string;
+  private baseUrl: string;
+
+  constructor(modelId: string, options: TogetherProviderOptions = {}) {
+    this.modelId = modelId;
+    this.apiKey = options.apiKey ?? process.env.TOGETHER_API_KEY ?? "";
+    this.baseUrl = options.baseUrl ?? "https://api.together.xyz/v1";
+
+    if (!this.apiKey) {
+      throw new Error(
+        "Together API key is required. Set TOGETHER_API_KEY environment variable or pass apiKey option.",
+      );
+    }
+  }
+
+  async doGenerate(options: ImageModelV3CallOptions) {
+    const { prompt, n, size, aspectRatio, seed, providerOptions, abortSignal } =
+      options;
+    const warnings: SharedV3Warning[] = [];
+
+    // Resolve model endpoint
+    const model = IMAGE_MODELS[this.modelId] ?? this.modelId;
+
+    // Build request body
+    const body: Record<string, unknown> = {
+      model,
+      prompt,
+      n: n ?? 1,
+      steps: 4, // flux-schnell optimal steps
+      ...(providerOptions?.together ?? {}),
+    };
+
+    // Handle size
+    if (size) {
+      const [width, height] = size.split("x").map(Number);
+      body.width = width;
+      body.height = height;
+    } else if (aspectRatio) {
+      const dims = ASPECT_RATIO_DIMENSIONS[aspectRatio];
+      if (dims) {
+        body.width = dims.width;
+        body.height = dims.height;
+      } else {
+        warnings.push({
+          type: "unsupported",
+          feature: "aspectRatio",
+          details: `Aspect ratio "${aspectRatio}" not supported, using default 1024x1024`,
+        });
+        body.width = 1024;
+        body.height = 1024;
+      }
+    }
+
+    if (seed !== undefined) {
+      body.seed = seed;
+    }
+
+    // Timing diagnostics
+    const t0 = Date.now();
+
+    const response = await fetch(`${this.baseUrl}/images/generations`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abortSignal,
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Together API error: ${response.status} ${error}`);
+    }
+
+    const data = (await response.json()) as {
+      data: Array<{ url?: string; b64_json?: string }>;
+    };
+
+    const apiTime = Date.now() - t0;
+    console.log(
+      `[together-timing] ${this.modelId}: API call took ${apiTime}ms`,
+    );
+
+    const images = data.data ?? [];
+    if (images.length === 0) {
+      throw new Error("No images in Together response");
+    }
+
+    // Download images from URLs
+    const t1 = Date.now();
+    const imageBuffers = await Promise.all(
+      images.map(async (img) => {
+        if (img.b64_json) {
+          // Base64 response
+          return new Uint8Array(Buffer.from(img.b64_json, "base64"));
+        }
+        if (img.url) {
+          // URL response - download
+          const imgResponse = await fetch(img.url, { signal: abortSignal });
+          return new Uint8Array(await imgResponse.arrayBuffer());
+        }
+        throw new Error("Image has neither url nor b64_json");
+      }),
+    );
+    const downloadTime = Date.now() - t1;
+    console.log(
+      `[together-timing] ${this.modelId}: image download took ${downloadTime}ms`,
+    );
+    console.log(
+      `[together-timing] ${this.modelId}: TOTAL ${Date.now() - t0}ms`,
+    );
+
+    return {
+      images: imageBuffers,
+      warnings,
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+    };
+  }
+}
+
+interface TogetherProvider {
+  imageModel: (modelId: string) => ImageModelV3;
+}
+
+function createTogetherProvider(
+  options: TogetherProviderOptions = {},
+): TogetherProvider {
+  const imageModel = (modelId: string): ImageModelV3 => {
+    if (!IMAGE_MODELS[modelId] && !modelId.includes("/")) {
+      throw new NoSuchModelError({
+        modelId,
+        modelType: "imageModel",
+        message: `Unknown image model: ${modelId}. Available: ${Object.keys(IMAGE_MODELS).join(", ")}`,
+      });
+    }
+    return new TogetherImageModel(modelId, options);
+  };
+
+  return {
+    imageModel,
+  };
+}
+
+export const together = createTogetherProvider();
+export { createTogetherProvider };


### PR DESCRIPTION
## Summary

- Add Together AI provider for fast flux-schnell image generation (no queue delay)
- Add timing diagnostics to fal provider for performance monitoring
- Add `acceleration: "high"` to fal image generation for faster queue processing
- Add TOGETHER_API_KEY to .env.example

## Together Provider

The Together provider offers a faster alternative to fal for Flux models by using direct API calls without queue delays:

```ts
import { together } from "./src/ai-sdk";

const result = await together.imageModel("flux-schnell").doGenerate({
  prompt: "A beautiful sunset",
  aspectRatio: "16:9",
});
```

Available models:
- `flux-schnell` - Fast generation
- `flux-dev` - Development model
- `flux-pro` - Production quality
- `flux-1.1-pro` - Latest pro version
- `flux-kontext-pro` / `flux-kontext-max` - Context-aware models

## Fal Improvements

- Added timing logs to track queue wait time vs processing time
- Added `acceleration: "high"` for supported models to reduce queue time