### PR TITLE
feat: support custom CacheStorage for serverless environments

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,3 +1,4 @@
+export type { CacheStorage } from "../ai-sdk/cache";
 export type { SizeValue } from "../ai-sdk/providers/editly/types";
 export { assets } from "./assets";
 export {

--- a/src/react/renderers/context.ts
+++ b/src/react/renderers/context.ts
@@ -1,5 +1,5 @@
 import type { generateImage } from "ai";
-import type { fileCache } from "../../ai-sdk/file-cache";
+import type { CacheStorage } from "../../ai-sdk/cache";
 import type { generateVideo } from "../../ai-sdk/generate-video";
 import type { DefaultModels } from "../types";
 import type { ProgressTracker } from "./progress";
@@ -8,7 +8,7 @@ export interface RenderContext {
   width: number;
   height: number;
   fps: number;
-  cache?: ReturnType<typeof fileCache>;
+  cache?: CacheStorage;
   generateImage: typeof generateImage;
   generateVideo: typeof generateVideo;
   tempFiles: string[];

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -1,5 +1,6 @@
 import type { ImageModelV3, SpeechModelV3 } from "@ai-sdk/provider";
 import type { FFmpegBackend } from "@/ai-sdk/providers/editly/backends";
+import type { CacheStorage } from "../ai-sdk/cache";
 import type { MusicModelV3 } from "../ai-sdk/music-model";
 import type {
   CropPosition,
@@ -256,7 +257,7 @@ export interface DefaultModels {
 
 export interface RenderOptions {
   output?: string;
-  cache?: string;
+  cache?: string | CacheStorage;
   quiet?: boolean;
   verbose?: boolean;
   mode?: RenderMode;


### PR DESCRIPTION
## Summary

- Adds support for passing a `CacheStorage` instance directly to `render()` instead of just a directory path
- Enables Redis/Upstash caching in serverless environments (Vercel, AWS Lambda) where filesystem is ephemeral
- Exports `CacheStorage` type from `vargai/react` for convenience

## Usage

```ts
import { render, type CacheStorage } from 'vargai/react'
import { Redis } from '@upstash/redis'

const redis = new Redis({ url: '...', token: '...' })

const redisCache: CacheStorage = {
  async get(key) {
    return redis.get(key)
  },
  async set(key, value, ttl) {
    await redis.set(key, JSON.stringify(value), { ex: ttl ? ttl / 1000 : undefined })
  },
  async delete(key) {
    await redis.del(key)
  }
}

await render(<Render>...</Render>, {
  cache: redisCache,  // custom cache for serverless
})
```

Closes #79