### PR TITLE
feat(fal): add Grok Imagine Video support (xAI)

### DIFF
--- a/src/definitions/actions/grok-edit.ts
+++ b/src/definitions/actions/grok-edit.ts
@@ -1,0 +1,133 @@
+/**
+ * Grok Imagine Video Edit action
+ * Edit videos using xAI's Grok Imagine Video model
+ */
+
+import { z } from "zod";
+import { filePathSchema } from "../../core/schema/shared";
+import type { ActionDefinition, ZodSchema } from "../../core/schema/types";
+import { falProvider } from "../../providers/fal";
+
+// Resolution enum matching the API spec
+const grokEditResolutionSchema = z
+  .enum(["auto", "480p", "720p"])
+  .default("auto")
+  .describe("Resolution of the output video");
+
+// Input schema with Zod
+const grokEditInputSchema = z.object({
+  prompt: z.string().describe("Text description of the desired edit"),
+  video: filePathSchema.describe(
+    "Input video to edit (will be resized to max 854x480 and truncated to 8 seconds)",
+  ),
+  resolution: grokEditResolutionSchema,
+});
+
+// Output schema with Zod
+const grokEditOutputSchema = z.object({
+  videoUrl: z.string(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  duration: z.number().optional(),
+  fps: z.number().optional(),
+});
+
+// Schema object for the definition
+const schema: ZodSchema<
+  typeof grokEditInputSchema,
+  typeof grokEditOutputSchema
+> = {
+  input: grokEditInputSchema,
+  output: grokEditOutputSchema,
+};
+
+export const definition: ActionDefinition<typeof schema> = {
+  type: "action",
+  name: "grok-edit",
+  description: "Edit video using xAI's Grok Imagine Video",
+  schema,
+  routes: [
+    {
+      target: "xai/grok-imagine-video/edit-video",
+      priority: 10,
+    },
+  ],
+  execute: async (inputs) => {
+    const { prompt, video, resolution } = inputs;
+
+    console.log("[action/grok-edit] editing video with Grok Imagine");
+
+    const result = await falProvider.grokEditVideo({
+      prompt,
+      videoUrl: video,
+      resolution,
+    });
+
+    const data = result.data as {
+      video?: {
+        url?: string;
+        width?: number;
+        height?: number;
+        duration?: number;
+        fps?: number;
+      };
+    };
+
+    const videoUrl = data?.video?.url;
+    if (!videoUrl) {
+      throw new Error("No video URL in result");
+    }
+
+    return {
+      videoUrl,
+      width: data.video?.width,
+      height: data.video?.height,
+      duration: data.video?.duration,
+      fps: data.video?.fps,
+    };
+  },
+};
+
+// Re-export types for convenience
+export type GrokEditInput = z.infer<typeof grokEditInputSchema>;
+export type GrokEditOutput = z.infer<typeof grokEditOutputSchema>;
+
+// Convenience function
+export async function grokEditVideo(
+  prompt: string,
+  videoUrl: string,
+  options: { resolution?: "auto" | "480p" | "720p" } = {},
+): Promise<GrokEditOutput> {
+  console.log("[grok-edit] editing video");
+
+  const result = await falProvider.grokEditVideo({
+    prompt,
+    videoUrl,
+    resolution: options.resolution,
+  });
+
+  const data = result.data as {
+    video?: {
+      url?: string;
+      width?: number;
+      height?: number;
+      duration?: number;
+      fps?: number;
+    };
+  };
+
+  const url = data?.video?.url;
+  if (!url) {
+    throw new Error("No video URL in result");
+  }
+
+  return {
+    videoUrl: url,
+    width: data.video?.width,
+    height: data.video?.height,
+    duration: data.video?.duration,
+    fps: data.video?.fps,
+  };
+}
+
+export default definition;

--- a/src/definitions/actions/index.ts
+++ b/src/definitions/actions/index.ts
@@ -38,6 +38,12 @@ export {
   trim,
   trimDefinition,
 } from "./edit";
+export type { GrokEditInput, GrokEditOutput } from "./grok-edit";
+// Grok Imagine Video Edit
+export {
+  definition as grokEdit,
+  grokEditVideo,
+} from "./grok-edit";
 export type { ImageGenerationResult } from "./image";
 // Image generation
 export {
@@ -87,6 +93,7 @@ import {
   transitionDefinition,
   trimDefinition,
 } from "./edit";
+import { definition as grokEditDefinition } from "./grok-edit";
 import { definition as imageDefinition } from "./image";
 import { definition as musicDefinition } from "./music";
 import { definition as syncDefinition } from "./sync";
@@ -103,6 +110,7 @@ export const allActions = [
   musicDefinition,
   syncDefinition,
   captionsDefinition,
+  grokEditDefinition,
   trimDefinition,
   cutDefinition,
   mergeDefinition,

--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -374,6 +374,134 @@ export class FalProvider extends BaseProvider {
     console.log("[fal] completed!");
     return result;
   }
+
+  // ============================================================================
+  // Grok Imagine Video methods (xAI)
+  // ============================================================================
+
+  /**
+   * Generate video from text using Grok Imagine Video
+   * Supports 1-15 second videos at 480p or 720p resolution
+   */
+  async grokTextToVideo(args: {
+    prompt: string;
+    duration?: number;
+    aspectRatio?: "16:9" | "4:3" | "3:2" | "1:1" | "2:3" | "3:4" | "9:16";
+    resolution?: "480p" | "720p";
+  }) {
+    const modelId = "xai/grok-imagine-video/text-to-video";
+
+    console.log(`[fal] starting grok text-to-video: ${modelId}`);
+    console.log(`[fal] prompt: ${args.prompt}`);
+
+    const result = await fal.subscribe(modelId, {
+      input: {
+        prompt: args.prompt,
+        duration: args.duration ?? 6,
+        aspect_ratio: args.aspectRatio ?? "16:9",
+        resolution: args.resolution ?? "720p",
+      },
+      logs: true,
+      onQueueUpdate: (update) => {
+        if (update.status === "IN_PROGRESS") {
+          console.log(
+            `[fal] ${update.logs?.map((l) => l.message).join(" ") || "processing..."}`,
+          );
+        }
+      },
+    });
+
+    console.log("[fal] completed!");
+    return result;
+  }
+
+  /**
+   * Generate video from image using Grok Imagine Video
+   * Supports 1-15 second videos at 480p or 720p resolution
+   */
+  async grokImageToVideo(args: {
+    prompt: string;
+    imageUrl: string;
+    duration?: number;
+    aspectRatio?:
+      | "auto"
+      | "16:9"
+      | "4:3"
+      | "3:2"
+      | "1:1"
+      | "2:3"
+      | "3:4"
+      | "9:16";
+    resolution?: "480p" | "720p";
+  }) {
+    const modelId = "xai/grok-imagine-video/image-to-video";
+
+    console.log(`[fal] starting grok image-to-video: ${modelId}`);
+    console.log(`[fal] prompt: ${args.prompt}`);
+
+    const imageUrl = await ensureUrl(args.imageUrl, (buffer) =>
+      this.uploadFile(buffer),
+    );
+
+    const result = await fal.subscribe(modelId, {
+      input: {
+        prompt: args.prompt,
+        image_url: imageUrl,
+        duration: args.duration ?? 6,
+        aspect_ratio: args.aspectRatio ?? "auto",
+        resolution: args.resolution ?? "720p",
+      },
+      logs: true,
+      onQueueUpdate: (update) => {
+        if (update.status === "IN_PROGRESS") {
+          console.log(
+            `[fal] ${update.logs?.map((l) => l.message).join(" ") || "processing..."}`,
+          );
+        }
+      },
+    });
+
+    console.log("[fal] completed!");
+    return result;
+  }
+
+  /**
+   * Edit video using Grok Imagine Video
+   * Video will be resized to max 854x480 and truncated to 8 seconds
+   */
+  async grokEditVideo(args: {
+    prompt: string;
+    videoUrl: string;
+    resolution?: "auto" | "480p" | "720p";
+  }) {
+    const modelId = "xai/grok-imagine-video/edit-video";
+
+    console.log(`[fal] starting grok edit-video: ${modelId}`);
+    console.log(`[fal] prompt: ${args.prompt}`);
+
+    const videoUrl = await ensureUrl(args.videoUrl, (buffer) =>
+      this.uploadFile(buffer),
+    );
+
+    const result = await fal.subscribe(modelId, {
+      input: {
+        prompt: args.prompt,
+        video_url: videoUrl,
+        resolution: args.resolution ?? "auto",
+      },
+      logs: true,
+      onQueueUpdate: (update) => {
+        if (update.status === "IN_PROGRESS") {
+          console.log(
+            `[fal] ${update.logs?.map((l) => l.message).join(" ") || "processing..."}`,
+          );
+        }
+      },
+    });
+
+    console.log("[fal] completed!");
+    return result;
+  }
 }
 
 // Export singleton instance


### PR DESCRIPTION
## Summary
- Add xAI's Grok Imagine Video model support to the fal provider
- Support text-to-video, image-to-video, and video editing modes
- Add `grok-edit` action for CLI video editing

## Changes
- **AI-SDK provider** (`src/ai-sdk/providers/fal.ts`):
  - Add `grok-imagine` model for t2v/i2v (1-15s duration, 480p/720p)
  - Add `grok-imagine-edit` model for video-to-video editing
  - Handle Grok-specific parameters (duration, resolution)

- **Grok Edit action** (`src/definitions/actions/grok-edit.ts`):
  - New CLI action: `bun run src/cli/index.ts run grok-edit --prompt "..." --video input.mp4`
  - Resolution options: auto, 480p, 720p

## Usage

### AI-SDK
```ts
import { fal } from "@varg/ai-sdk";
import { generateVideo } from "ai";

// Text to video
const video = await generateVideo({
  model: fal.video("grok-imagine"),
  prompt: "A cat playing piano",
  duration: 6,
});

// Video editing
const edited = await generateVideo({
  model: fal.video("grok-imagine-edit"),
  prompt: "Add fireworks to the sky",
  files: [videoFile],
});
```

### CLI
```bash
bun run src/cli/index.ts run grok-edit --prompt "Make it rain" --video media/input.mp4
```