### PR TITLE
feat(fal): add Qwen Image Edit 2511 Multiple Angles support

### DIFF
--- a/examples/grok-imagine-test.tsx
+++ b/examples/grok-imagine-test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Grok Imagine Video Test Example
+ *
+ * Run with: bun run examples/grok-imagine-test.tsx
+ *
+ * Tests all three Grok Imagine Video endpoints:
+ * 1. Text-to-Video
+ * 2. Image-to-Video
+ * 3. Edit Video
+ */
+
+import { fal } from "@fal-ai/client";
+import { falProvider } from "../src/providers/fal";
+
+// Configure fal client
+const apiKey = process.env.FAL_API_KEY ?? process.env.FAL_KEY;
+if (!apiKey) {
+  console.error("Error: FAL_API_KEY or FAL_KEY environment variable required");
+  process.exit(1);
+}
+fal.config({ credentials: apiKey });
+
+async function testTextToVideo() {
+  console.log("\n=== Testing Grok Text-to-Video ===\n");
+
+  const result = await falProvider.grokTextToVideo({
+    prompt:
+      "A majestic eagle soaring through clouds at sunset, cinematic lighting, slow motion",
+    duration: 6,
+    aspectRatio: "16:9",
+    resolution: "720p",
+  });
+
+  const data = result.data as { video?: { url?: string; duration?: number } };
+  console.log("Text-to-Video Result:");
+  console.log("  Video URL:", data?.video?.url);
+  console.log("  Duration:", data?.video?.duration);
+
+  return data?.video?.url;
+}
+
+async function testImageToVideo(imageUrl: string) {
+  console.log("\n=== Testing Grok Image-to-Video ===\n");
+
+  const result = await falProvider.grokImageToVideo({
+    prompt:
+      "The subject slowly turns their head and smiles, gentle wind blowing their hair",
+    imageUrl,
+    duration: 6,
+    aspectRatio: "auto",
+    resolution: "720p",
+  });
+
+  const data = result.data as { video?: { url?: string; duration?: number } };
+  console.log("Image-to-Video Result:");
+  console.log("  Video URL:", data?.video?.url);
+  console.log("  Duration:", data?.video?.duration);
+
+  return data?.video?.url;
+}
+
+async function testEditVideo(videoUrl: string) {
+  console.log("\n=== Testing Grok Edit Video ===\n");
+
+  const result = await falProvider.grokEditVideo({
+    prompt: "Add a vintage film grain effect and warm color grading",
+    videoUrl,
+    resolution: "auto",
+  });
+
+  const data = result.data as { video?: { url?: string; duration?: number } };
+  console.log("Edit Video Result:");
+  console.log("  Video URL:", data?.video?.url);
+  console.log("  Duration:", data?.video?.duration);
+
+  return data?.video?.url;
+}
+
+// Main execution
+async function main() {
+  const args = process.argv.slice(2);
+  const mode = args[0] || "t2v";
+
+  console.log("Grok Imagine Video Test");
+  console.log("=======================");
+  console.log(`Mode: ${mode}`);
+
+  try {
+    switch (mode) {
+      case "t2v":
+      case "text-to-video": {
+        await testTextToVideo();
+        break;
+      }
+
+      case "i2v":
+      case "image-to-video": {
+        const imageUrl =
+          args[1] ||
+          "https://v3b.fal.media/files/b/0a8b90e0/BFLE9VDlZqsryU-UA3BoD_image_004.png";
+        await testImageToVideo(imageUrl);
+        break;
+      }
+
+      case "edit":
+      case "edit-video": {
+        const videoUrl =
+          args[1] ||
+          "https://v3b.fal.media/files/b/0a8b9112/V5Z_NIPE3ppMDWivNo6_q_video_019.mp4";
+        await testEditVideo(videoUrl);
+        break;
+      }
+
+      case "all": {
+        // Run all tests in sequence
+        const t2vUrl = await testTextToVideo();
+
+        // Use a sample image for i2v test
+        const sampleImage =
+          "https://v3b.fal.media/files/b/0a8b90e0/BFLE9VDlZqsryU-UA3BoD_image_004.png";
+        await testImageToVideo(sampleImage);
+
+        // Use the t2v result for edit test if available
+        if (t2vUrl) {
+          await testEditVideo(t2vUrl);
+        }
+        break;
+      }
+
+      default:
+        console.log(`
+Usage: bun run examples/grok-imagine-test.tsx [mode] [url]
+
+Modes:
+  t2v, text-to-video    Generate video from text prompt
+  i2v, image-to-video   Generate video from image (provide image URL)
+  edit, edit-video      Edit existing video (provide video URL)
+  all                   Run all tests
+
+Examples:
+  bun run examples/grok-imagine-test.tsx t2v
+  bun run examples/grok-imagine-test.tsx i2v https://example.com/image.png
+  bun run examples/grok-imagine-test.tsx edit https://example.com/video.mp4
+  bun run examples/grok-imagine-test.tsx all
+`);
+    }
+
+    console.log("\nTest completed successfully!");
+  } catch (error) {
+    console.error("\nTest failed:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/definitions/actions/index.ts
+++ b/src/definitions/actions/index.ts
@@ -54,6 +54,12 @@ export {
 export type { GenerateMusicOptions, MusicResult } from "./music";
 // Music generation
 export { definition as music, generateMusic } from "./music";
+export type { QwenAnglesInput, QwenAnglesOutput } from "./qwen-angles";
+// Qwen Image Edit 2511 Multiple Angles
+export {
+  definition as qwenAngles,
+  qwenAngles as qwenAnglesImage,
+} from "./qwen-angles";
 export type { LipsyncOptions, LipsyncResult, Wav2LipOptions } from "./sync";
 // Lip sync
 export {
@@ -96,6 +102,7 @@ import {
 import { definition as grokEditDefinition } from "./grok-edit";
 import { definition as imageDefinition } from "./image";
 import { definition as musicDefinition } from "./music";
+import { definition as qwenAnglesDefinition } from "./qwen-angles";
 import { definition as syncDefinition } from "./sync";
 import { definition as transcribeDefinition } from "./transcribe";
 import { definition as uploadDefinition } from "./upload";
@@ -111,6 +118,7 @@ export const allActions = [
   syncDefinition,
   captionsDefinition,
   grokEditDefinition,
+  qwenAnglesDefinition,
   trimDefinition,
   cutDefinition,
   mergeDefinition,

--- a/src/definitions/actions/qwen-angles.ts
+++ b/src/definitions/actions/qwen-angles.ts
@@ -1,0 +1,218 @@
+/**
+ * Qwen Image Edit 2511 Multiple Angles action
+ * Generates same scene from different camera angles (azimuth/elevation)
+ */
+
+import { z } from "zod";
+import { filePathSchema } from "../../core/schema/shared";
+import type { ActionDefinition, ZodSchema } from "../../core/schema/types";
+import { falProvider } from "../../providers/fal";
+
+// Input schema with Zod
+const qwenAnglesInputSchema = z.object({
+  image: filePathSchema.describe("Input image to adjust camera angle for"),
+  horizontalAngle: z
+    .number()
+    .min(0)
+    .max(360)
+    .default(0)
+    .describe(
+      "Horizontal rotation angle in degrees. 0=front, 90=right side, 180=back, 270=left side, 360=front",
+    ),
+  verticalAngle: z
+    .number()
+    .min(-30)
+    .max(90)
+    .default(0)
+    .describe(
+      "Vertical camera angle in degrees. -30=looking up, 0=eye-level, 30=elevated, 60=high-angle, 90=bird's-eye",
+    ),
+  zoom: z
+    .number()
+    .min(0)
+    .max(10)
+    .default(5)
+    .describe(
+      "Camera zoom/distance. 0=wide shot (far), 5=medium shot (normal), 10=close-up (very close)",
+    ),
+  prompt: z
+    .string()
+    .optional()
+    .describe(
+      "Additional text to append to the automatically generated prompt",
+    ),
+  loraScale: z
+    .number()
+    .min(0)
+    .max(4)
+    .default(1)
+    .describe("Strength of the camera control effect"),
+  guidanceScale: z
+    .number()
+    .min(1)
+    .max(20)
+    .default(4.5)
+    .describe("CFG (Classifier Free Guidance) scale"),
+  numInferenceSteps: z
+    .number()
+    .min(1)
+    .max(50)
+    .default(28)
+    .describe("Number of inference steps"),
+  negativePrompt: z
+    .string()
+    .default("")
+    .describe("Negative prompt for the generation"),
+  seed: z.number().optional().describe("Random seed for reproducibility"),
+  outputFormat: z
+    .enum(["png", "jpeg", "webp"])
+    .default("png")
+    .describe("Output image format"),
+  numImages: z
+    .number()
+    .min(1)
+    .max(4)
+    .default(1)
+    .describe("Number of images to generate"),
+});
+
+// Output schema with Zod
+const qwenAnglesOutputSchema = z.object({
+  imageUrl: z.string(),
+  images: z.array(z.object({ url: z.string() })).optional(),
+  seed: z.number().optional(),
+  prompt: z.string().optional(),
+});
+
+// Schema object for the definition
+const schema: ZodSchema<
+  typeof qwenAnglesInputSchema,
+  typeof qwenAnglesOutputSchema
+> = {
+  input: qwenAnglesInputSchema,
+  output: qwenAnglesOutputSchema,
+};
+
+export const definition: ActionDefinition<typeof schema> = {
+  type: "action",
+  name: "qwen-angles",
+  description:
+    "Adjust camera angle of an image using Qwen Image Edit 2511 Multiple Angles",
+  schema,
+  routes: [
+    {
+      target: "fal-ai/qwen-image-edit-2511-multiple-angles",
+      priority: 10,
+    },
+  ],
+  execute: async (inputs) => {
+    const {
+      image,
+      horizontalAngle,
+      verticalAngle,
+      zoom,
+      prompt,
+      loraScale,
+      guidanceScale,
+      numInferenceSteps,
+      negativePrompt,
+      seed,
+      outputFormat,
+      numImages,
+    } = inputs;
+
+    console.log("[action/qwen-angles] adjusting camera angle");
+
+    const result = await falProvider.qwenMultipleAngles({
+      imageUrl: image,
+      horizontalAngle,
+      verticalAngle,
+      zoom,
+      additionalPrompt: prompt,
+      loraScale,
+      guidanceScale,
+      numInferenceSteps,
+      negativePrompt,
+      seed,
+      outputFormat,
+      numImages,
+    });
+
+    const data = result.data as {
+      images?: Array<{ url: string }>;
+      seed?: number;
+      prompt?: string;
+    };
+
+    const images = data?.images;
+    if (!images || images.length === 0) {
+      throw new Error("No images in result");
+    }
+
+    return {
+      imageUrl: images[0]!.url,
+      images,
+      seed: data?.seed,
+      prompt: data?.prompt,
+    };
+  },
+};
+
+// Re-export types for convenience
+export type QwenAnglesInput = z.infer<typeof qwenAnglesInputSchema>;
+export type QwenAnglesOutput = z.infer<typeof qwenAnglesOutputSchema>;
+
+// Convenience function
+export async function qwenAngles(
+  imageUrl: string,
+  options: {
+    horizontalAngle?: number;
+    verticalAngle?: number;
+    zoom?: number;
+    prompt?: string;
+    loraScale?: number;
+    guidanceScale?: number;
+    numInferenceSteps?: number;
+    negativePrompt?: string;
+    seed?: number;
+    outputFormat?: "png" | "jpeg" | "webp";
+    numImages?: number;
+  } = {},
+): Promise<QwenAnglesOutput> {
+  console.log("[qwen-angles] adjusting camera angle");
+
+  const result = await falProvider.qwenMultipleAngles({
+    imageUrl,
+    horizontalAngle: options.horizontalAngle,
+    verticalAngle: options.verticalAngle,
+    zoom: options.zoom,
+    additionalPrompt: options.prompt,
+    loraScale: options.loraScale,
+    guidanceScale: options.guidanceScale,
+    numInferenceSteps: options.numInferenceSteps,
+    negativePrompt: options.negativePrompt,
+    seed: options.seed,
+    outputFormat: options.outputFormat,
+    numImages: options.numImages,
+  });
+
+  const data = result.data as {
+    images?: Array<{ url: string }>;
+    seed?: number;
+    prompt?: string;
+  };
+
+  const images = data?.images;
+  if (!images || images.length === 0) {
+    throw new Error("No images in result");
+  }
+
+  return {
+    imageUrl: images[0]!.url,
+    images,
+    seed: data?.seed,
+    prompt: data?.prompt,
+  };
+}
+
+export default definition;

--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -502,6 +502,69 @@ export class FalProvider extends BaseProvider {
     console.log("[fal] completed!");
     return result;
   }
+
+  // ============================================================================
+  // Qwen Image Edit 2511 Multiple Angles
+  // ============================================================================
+
+  /**
+   * Adjust camera angle of an image using Qwen Image Edit 2511 Multiple Angles
+   * Generates same scene from different angles (azimuth/elevation)
+   */
+  async qwenMultipleAngles(args: {
+    imageUrl: string;
+    horizontalAngle?: number;
+    verticalAngle?: number;
+    zoom?: number;
+    additionalPrompt?: string;
+    loraScale?: number;
+    imageSize?: string | { width: number; height: number };
+    guidanceScale?: number;
+    numInferenceSteps?: number;
+    acceleration?: "none" | "regular";
+    negativePrompt?: string;
+    seed?: number;
+    outputFormat?: "png" | "jpeg" | "webp";
+    numImages?: number;
+  }) {
+    const modelId = "fal-ai/qwen-image-edit-2511-multiple-angles";
+
+    console.log(`[fal] starting qwen multiple angles: ${modelId}`);
+
+    const imageUrl = await ensureUrl(args.imageUrl, (buffer) =>
+      this.uploadFile(buffer),
+    );
+
+    const result = await fal.subscribe(modelId, {
+      input: {
+        image_urls: [imageUrl],
+        horizontal_angle: args.horizontalAngle ?? 0,
+        vertical_angle: args.verticalAngle ?? 0,
+        zoom: args.zoom ?? 5,
+        additional_prompt: args.additionalPrompt,
+        lora_scale: args.loraScale ?? 1,
+        image_size: args.imageSize,
+        guidance_scale: args.guidanceScale ?? 4.5,
+        num_inference_steps: args.numInferenceSteps ?? 28,
+        acceleration: args.acceleration ?? "regular",
+        negative_prompt: args.negativePrompt ?? "",
+        seed: args.seed,
+        output_format: args.outputFormat ?? "png",
+        num_images: args.numImages ?? 1,
+      },
+      logs: true,
+      onQueueUpdate: (update) => {
+        if (update.status === "IN_PROGRESS") {
+          console.log(
+            `[fal] ${update.logs?.map((l) => l.message).join(" ") || "processing..."}`,
+          );
+        }
+      },
+    });
+
+    console.log("[fal] completed!");
+    return result;
+  }
 }
 
 // Export singleton instance

--- a/src/react/examples/qwen-angles-test.tsx
+++ b/src/react/examples/qwen-angles-test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Qwen Image Edit 2511 Multiple Angles Test
+ *
+ * Demonstrates camera angle adjustment using Qwen model.
+ * Generates the same scene from different perspectives (azimuth/elevation).
+ *
+ * Run with: bun run src/cli/index.ts render src/react/examples/qwen-angles-test.tsx
+ */
+
+import { fal } from "../../ai-sdk/providers/fal";
+import { Clip, Image, Render } from "..";
+
+// Source image - replace with your own image URL or local path
+const sourceImage =
+  "https://v3b.fal.media/files/b/0a8973cb/qUbVwDCcMlvX4drBGYB1H.png";
+
+export default (
+  <Render width={1024} height={1024}>
+    {/* Original image - front view */}
+    <Clip duration={2}>
+      <Image src={sourceImage} resize="cover" />
+    </Clip>
+
+    {/* Right side view (90 degrees horizontal) */}
+    <Clip duration={2}>
+      <Image
+        prompt={{ text: "", images: [sourceImage] }}
+        model={fal.imageModel("qwen-angles")}
+        aspectRatio="1:1"
+        providerOptions={{
+          fal: {
+            horizontal_angle: 90,
+            vertical_angle: 0,
+            zoom: 5,
+          },
+        }}
+      />
+    </Clip>
+
+    {/* Bird's eye view (60 degrees vertical) */}
+    <Clip duration={2}>
+      <Image
+        prompt={{ text: "", images: [sourceImage] }}
+        model={fal.imageModel("qwen-angles")}
+        aspectRatio="1:1"
+        providerOptions={{
+          fal: {
+            horizontal_angle: 0,
+            vertical_angle: 60,
+            zoom: 5,
+          },
+        }}
+      />
+    </Clip>
+
+    {/* Close-up from 45 degree angle */}
+    <Clip duration={2}>
+      <Image
+        prompt={{ text: "", images: [sourceImage] }}
+        model={fal.imageModel("qwen-angles")}
+        aspectRatio="1:1"
+        providerOptions={{
+          fal: {
+            horizontal_angle: 45,
+            vertical_angle: 30,
+            zoom: 8,
+          },
+        }}
+      />
+    </Clip>
+  </Render>
+);


### PR DESCRIPTION
## Summary

Adds support for **Qwen Image Edit 2511 Multiple Angles** model via fal.ai. This model generates the same scene from different camera angles (azimuth/elevation) using a LoRA-based approach.

### Changes

- **AI-SDK fal provider** (`src/ai-sdk/providers/fal.ts`):
  - Add `qwen-angles` model to `IMAGE_MODELS`
  - Handle `additional_prompt` instead of `prompt` for qwen-angles
  - Convert `aspectRatio` to `image_size` dimensions (1024 base)
  - Use `"regular"` acceleration (not `"high"`)

- **Internal fal provider** (`src/providers/fal.ts`):
  - Add `qwenMultipleAngles()` method with full parameter support

- **CLI action** (`src/definitions/actions/qwen-angles.ts`):
  - Full action definition with Zod schemas
  - Parameters: `horizontalAngle`, `verticalAngle`, `zoom`, `loraScale`, etc.

- **React example** (`src/react/examples/qwen-angles-test.tsx`):
  - Demonstrates camera angle adjustment from multiple perspectives

### Usage

**CLI:**
```bash
varg run qwen-angles --image media/photo.png --horizontalAngle 90 --verticalAngle 30
```

**AI-SDK:**
```ts
import { fal } from "@varg/ai-sdk";
import { generateImage } from "ai";

const result = await generateImage({
  model: fal.image("qwen-angles"),
  aspectRatio: "1:1",
  files: [{ type: "url", url: "https://example.com/image.png" }],
  providerOptions: {
    fal: {
      horizontal_angle: 90,
      vertical_angle: 30,
      zoom: 5,
    },
  },
});
```

### Parameters

| Parameter | Range | Default | Description |
|-----------|-------|---------|-------------|
| `horizontal_angle` | 0-360 | 0 | 0°=front, 90°=right, 180°=back, 270°=left |
| `vertical_angle` | -30 to 90 | 0 | -30°=looking up, 0°=eye-level, 90°=bird's-eye |
| `zoom` | 0-10 | 5 | 0=wide shot, 5=medium, 10=close-up |
| `lora_scale` | 0-4 | 1 | Strength of camera control effect |