### PR TITLE
feat(fal): persist queue request IDs to recover from timeouts

### DIFF
--- a/src/ai-sdk/providers/fal.ts
+++ b/src/ai-sdk/providers/fal.ts
@@ -22,6 +22,11 @@ interface PendingRequest {
 
 const pendingStorage = fileCache({ dir: ".cache/fal-pending" });
 
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const FAL_TIMEOUT_MS = process.env.FAL_TIMEOUT_MS
+  ? Number.parseInt(process.env.FAL_TIMEOUT_MS, 10)
+  : DEFAULT_TIMEOUT_MS;
+
 const VIDEO_MODELS: Record<string, { t2v: string; i2v: string }> = {
   // Kling v2.6 - latest with native audio generation
   "kling-v2.6": {
@@ -239,6 +244,7 @@ async function executeWithQueueRecovery<T>(
         await fal.queue.subscribeToStatus(pending.endpoint, {
           requestId: pending.request_id,
           logs,
+          timeout: FAL_TIMEOUT_MS,
           onQueueUpdate,
         });
         const result = await fal.queue.result(pending.endpoint, {
@@ -277,6 +283,7 @@ async function executeWithQueueRecovery<T>(
     await fal.queue.subscribeToStatus(endpoint, {
       requestId: request_id,
       logs,
+      timeout: FAL_TIMEOUT_MS,
       onQueueUpdate,
     });
 


### PR DESCRIPTION
## Summary

Use fal queue API to persist request IDs so we can recover from client-side timeouts.

## Problem

When a fal generation times out client-side, the server job often continues and completes. We pay for the generation but lose the result because `fal.subscribe()` hides the request_id.

## Solution

Use fal's queue API instead of `fal.subscribe()`:

```typescript
// Before: request_id is hidden, lost on timeout
await fal.subscribe(endpoint, { input });

// After: request_id saved, recoverable
const { request_id } = await fal.queue.submit(endpoint, { input });
// save request_id to .cache/fal-pending/
await fal.queue.subscribeToStatus(endpoint, { requestId: request_id });
const result = await fal.queue.result(endpoint, { requestId: request_id });
```

## How it works

1. Compute pending key from `hash(endpoint + input)` 
2. Check `.cache/fal-pending/` for existing request with same hash
3. If found + completed → fetch result, delete pending entry
4. If found + in progress → resume waiting
5. If not found → submit to queue, save request_id, wait
6. On timeout → request_id stays saved for next run

## Output

```
📋 queued job abc12345... (recoverable on timeout)
⚠ job abc12345... saved for recovery on next run  # on timeout

# next run:
⚡ recovered completed job from queue (abc12345...)  # if done
⏳ resuming pending job (abc12345...) - status: IN_PROGRESS  # if still running
```

## Design decision

Fal provider manages its own file-based pending storage rather than passing cache through providerOptions - cleaner abstraction, no leaky dependencies on render context.

Closes #92