### PR TITLE
fix: resolve biome lint warnings

### DIFF
--- a/launch-videos/06-kawaii-fruits.tsx
+++ b/launch-videos/06-kawaii-fruits.tsx
@@ -65,12 +65,12 @@ export default (
     />
 
     {/* Scene 1-4: Each character waves individually */}
-    {CHARACTERS.map((char, i) => (
-      <Clip key={char.name} duration={2.5}>
+    {characterImages.map((charImage, i) => (
+      <Clip key={CHARACTERS[i]?.name ?? i} duration={2.5}>
         <Video
           prompt={{
             text: "character waves hello enthusiastically, bounces up and down slightly, eyes squint with joy, tiny feet wiggle",
-            images: [characterImages[i]!],
+            images: [charImage],
           }}
           model={fal.videoModel("kling-v2.5")}
           duration={5}

--- a/launch-videos/07-ugc-weight-loss.tsx
+++ b/launch-videos/07-ugc-weight-loss.tsx
@@ -96,8 +96,8 @@ const voiceover = Speech({
 // === MUSIC ===
 const MUSIC_PROMPT =
   "upbeat motivational pop, inspiring transformation music, energetic but not overwhelming, modern fitness vibe";
-const MUSIC_DURATION = 15;
-const MUSIC_VOLUME = 0.15; // Low volume so voiceover is clear
+const _MUSIC_DURATION = 15;
+const _MUSIC_VOLUME = 0.15; // Low volume so voiceover is clear
 
 // === CAPTIONS SETTINGS ===
 const CAPTIONS_STYLE = "tiktok";

--- a/skills/varg-video-generation/scripts/setup.ts
+++ b/skills/varg-video-generation/scripts/setup.ts
@@ -9,14 +9,8 @@
  *   bun scripts/setup.ts
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const COLORS = {
   reset: "\x1b[0m",
@@ -228,7 +222,7 @@ Get your free API key at: ${COLORS.cyan}https://fal.ai/dashboard/keys${COLORS.re
   }
 
   if (added) {
-    writeFileSync(gitignorePath, gitignoreContent.trim() + "\n");
+    writeFileSync(gitignorePath, `${gitignoreContent.trim()}\n`);
     log.success("Updated .gitignore");
   } else {
     log.info(".gitignore already configured");

--- a/src/ai-sdk/cache.ts
+++ b/src/ai-sdk/cache.ts
@@ -43,7 +43,7 @@ function parseTTL(ttl: number | string | undefined): number | undefined {
   const match = ttl.match(/^(\d+)(s|m|h|d)$/);
   if (!match) return undefined;
 
-  const value = Number.parseInt(match[1]!, 10);
+  const value = Number.parseInt(match[1] ?? "0", 10);
   const unit = match[2];
 
   switch (unit) {

--- a/src/ai-sdk/examples/google-image.ts
+++ b/src/ai-sdk/examples/google-image.ts
@@ -22,8 +22,8 @@ async function main() {
       await Bun.write("output/google-mountain.png", images[0].uint8Array);
       console.log("   saved to output/google-mountain.png");
     }
-  } catch (error: any) {
-    console.error("   error:", error.message || error);
+  } catch (error) {
+    console.error("   error:", error instanceof Error ? error.message : error);
   }
 
   console.log("\n2. image-to-image with nano-banana-pro/edit...");
@@ -52,8 +52,8 @@ async function main() {
       );
       console.log("   saved to output/google-mountain-sunset.png");
     }
-  } catch (error: any) {
-    console.error("   error:", error.message || error);
+  } catch (error) {
+    console.error("   error:", error instanceof Error ? error.message : error);
   }
 
   console.log("\ndone!");

--- a/src/ai-sdk/examples/higgsfield-image.ts
+++ b/src/ai-sdk/examples/higgsfield-image.ts
@@ -15,8 +15,10 @@ async function main() {
     aspectRatio: "1:1",
   });
 
-  console.log(`image generated: ${images[0]!.uint8Array.byteLength} bytes`);
-  await Bun.write("output/higgsfield-default.png", images[0]!.uint8Array);
+  const firstImage = images[0];
+  if (!firstImage) throw new Error("No image generated");
+  console.log(`image generated: ${firstImage.uint8Array.byteLength} bytes`);
+  await Bun.write("output/higgsfield-default.png", firstImage.uint8Array);
 
   console.log("\ngenerating with model settings...");
   const { images: styledImages } = await generateImage({
@@ -28,10 +30,12 @@ async function main() {
     aspectRatio: "16:9",
   });
 
-  console.log(`styled image: ${styledImages[0]!.uint8Array.byteLength} bytes`);
+  const firstStyledImage = styledImages[0];
+  if (!firstStyledImage) throw new Error("No styled image generated");
+  console.log(`styled image: ${firstStyledImage.uint8Array.byteLength} bytes`);
   await Bun.write(
     "output/higgsfield-cinematic.png",
-    styledImages[0]!.uint8Array,
+    firstStyledImage.uint8Array,
   );
 
   console.log("\ngenerating with provider defaults...");
@@ -47,12 +51,14 @@ async function main() {
     aspectRatio: "4:3",
   });
 
+  const firstEnhancedImage = enhancedImages[0];
+  if (!firstEnhancedImage) throw new Error("No enhanced image generated");
   console.log(
-    `enhanced image: ${enhancedImages[0]!.uint8Array.byteLength} bytes`,
+    `enhanced image: ${firstEnhancedImage.uint8Array.byteLength} bytes`,
   );
   await Bun.write(
     "output/higgsfield-enhanced.png",
-    enhancedImages[0]!.uint8Array,
+    firstEnhancedImage.uint8Array,
   );
 
   console.log("\ndone!");

--- a/src/ai-sdk/examples/replicate-bg-removal.ts
+++ b/src/ai-sdk/examples/replicate-bg-removal.ts
@@ -14,10 +14,12 @@ async function main() {
     n: 1,
   });
 
-  console.log(`source image: ${sourceImages[0]!.uint8Array.byteLength} bytes`);
-  await Bun.write("output/bg-removal-source.png", sourceImages[0]!.uint8Array);
+  const firstSourceImage = sourceImages[0];
+  if (!firstSourceImage) throw new Error("No source image generated");
+  console.log(`source image: ${firstSourceImage.uint8Array.byteLength} bytes`);
+  await Bun.write("output/bg-removal-source.png", firstSourceImage.uint8Array);
 
-  const sourceFile = File.from(sourceImages[0]!);
+  const sourceFile = File.from(firstSourceImage);
 
   console.log("\nremoving background...");
   const { images: processedImages } = await generateImage({
@@ -27,12 +29,14 @@ async function main() {
     },
   });
 
+  const firstProcessedImage = processedImages[0];
+  if (!firstProcessedImage) throw new Error("No processed image generated");
   console.log(
-    `processed image: ${processedImages[0]!.uint8Array.byteLength} bytes`,
+    `processed image: ${firstProcessedImage.uint8Array.byteLength} bytes`,
   );
   await Bun.write(
     "output/bg-removal-result.png",
-    processedImages[0]!.uint8Array,
+    firstProcessedImage.uint8Array,
   );
 
   console.log("\nusing alternative model...");
@@ -43,8 +47,10 @@ async function main() {
     },
   });
 
-  console.log(`alt result: ${altImages[0]!.uint8Array.byteLength} bytes`);
-  await Bun.write("output/bg-removal-alt.png", altImages[0]!.uint8Array);
+  const firstAltImage = altImages[0];
+  if (!firstAltImage) throw new Error("No alt image generated");
+  console.log(`alt result: ${firstAltImage.uint8Array.byteLength} bytes`);
+  await Bun.write("output/bg-removal-alt.png", firstAltImage.uint8Array);
 
   console.log("\ndone!");
 }

--- a/src/ai-sdk/examples/talking-lion.ts
+++ b/src/ai-sdk/examples/talking-lion.ts
@@ -26,7 +26,9 @@ Whether you're building social content or creative apps, Varg has got you covere
     }),
   ]);
 
-  const image = File.from(imageResult.images[0]!);
+  const firstImage = imageResult.images[0];
+  if (!firstImage) throw new Error("No image generated");
+  const image = File.from(firstImage);
   const audio = File.from(speechResult.audio);
 
   console.log(`image: ${(await image.data()).byteLength} bytes`);

--- a/src/ai-sdk/examples/video-generation.ts
+++ b/src/ai-sdk/examples/video-generation.ts
@@ -20,7 +20,9 @@ async function main() {
   });
 
   console.log("animating image to video...");
-  const image = File.from(images[0]!);
+  const firstImage = images[0];
+  if (!firstImage) throw new Error("No image generated");
+  const image = File.from(firstImage);
   const { video: animatedVideo } = await generateVideo({
     model: fal.videoModel("wan-2.5"),
     prompt: {

--- a/src/ai-sdk/examples/workflow-animated-girl.ts
+++ b/src/ai-sdk/examples/workflow-animated-girl.ts
@@ -30,7 +30,9 @@ Don't forget to like and subscribe for more content like this!`;
     cacheKey: ["animated-girl", "portrait"],
   });
 
-  const imageData = images[0]!.uint8Array;
+  const firstImage = images[0];
+  if (!firstImage) throw new Error("No image generated");
+  const imageData = firstImage.uint8Array;
   await Bun.write("output/workflow-girl-image.png", imageData);
   console.log("saved: output/workflow-girl-image.png");
 

--- a/src/ai-sdk/examples/workflow-before-after.ts
+++ b/src/ai-sdk/examples/workflow-before-after.ts
@@ -24,7 +24,9 @@ async function main() {
     cacheKey: ["before-after", "before-image"],
   });
 
-  const beforeImage = beforeImages[0]!.uint8Array;
+  const firstBeforeImage = beforeImages[0];
+  if (!firstBeforeImage) throw new Error("No before image generated");
+  const beforeImage = firstBeforeImage.uint8Array;
   await Bun.write("output/workflow-before-image.png", beforeImage);
   console.log("saved: output/workflow-before-image.png");
 
@@ -37,7 +39,9 @@ async function main() {
     cacheKey: ["before-after", "after-image"],
   });
 
-  const afterImage = afterImages[0]!.uint8Array;
+  const firstAfterImage = afterImages[0];
+  if (!firstAfterImage) throw new Error("No after image generated");
+  const afterImage = firstAfterImage.uint8Array;
   await Bun.write("output/workflow-after-image.png", afterImage);
   console.log("saved: output/workflow-after-image.png");
 

--- a/src/ai-sdk/examples/workflow-character-grid.ts
+++ b/src/ai-sdk/examples/workflow-character-grid.ts
@@ -71,7 +71,9 @@ async function main() {
         n: 1,
         cacheKey: ["character-grid", name],
       });
-      const data = images[0]!.uint8Array;
+      const firstImage = images[0];
+      if (!firstImage) throw new Error(`No image generated for ${name}`);
+      const data = firstImage.uint8Array;
       await Bun.write(`output/character-${i}-${name.toLowerCase()}.png`, data);
       return {
         name,

--- a/src/ai-sdk/examples/workflow-slideshow.ts
+++ b/src/ai-sdk/examples/workflow-slideshow.ts
@@ -46,7 +46,9 @@ And ending with this amazing view.`;
         n: 1,
         cacheKey: ["slideshow", "scene", i],
       });
-      const data = images[0]!.uint8Array;
+      const firstImage = images[0];
+      if (!firstImage) throw new Error(`No image generated for scene ${i}`);
+      const data = firstImage.uint8Array;
       await Bun.write(`output/workflow-scene-${i}.png`, data);
       return `output/workflow-scene-${i}.png`;
     }),
@@ -62,7 +64,9 @@ And ending with this amazing view.`;
     cacheKey: ["slideshow", "talking-head"],
   });
 
-  const talkingImage = talkingImages[0]!.uint8Array;
+  const firstTalkingImage = talkingImages[0];
+  if (!firstTalkingImage) throw new Error("No talking head image generated");
+  const talkingImage = firstTalkingImage.uint8Array;
   await Bun.write("output/workflow-talking-head.png", talkingImage);
 
   console.log("\nstep 3: generating voiceover...");
@@ -121,7 +125,7 @@ And ending with this amazing view.`;
   await Bun.write("output/workflow-slideshow.srt", srtContent);
 
   console.log("\nstep 7: creating slideshow with pip...");
-  const clips = sceneImages.map((imagePath, i) => ({
+  const clips = sceneImages.map((imagePath, _i) => ({
     duration: 2,
     layers: [
       { type: "image" as const, path: imagePath },

--- a/src/ai-sdk/file.ts
+++ b/src/ai-sdk/file.ts
@@ -159,8 +159,8 @@ export class File {
   async base64(): Promise<string> {
     const data = await this.arrayBuffer();
     let binary = "";
-    for (let i = 0; i < data.byteLength; i++) {
-      binary += String.fromCharCode(data[i]!);
+    for (const byte of data) {
+      binary += String.fromCharCode(byte);
     }
     return btoa(binary);
   }

--- a/src/ai-sdk/generate-element.ts
+++ b/src/ai-sdk/generate-element.ts
@@ -24,8 +24,8 @@ export function scene(
 
   for (let i = 0; i < strings.length; i++) {
     text += strings[i];
-    if (i < elements.length) {
-      const el = elements[i]!;
+    const el = elements[i];
+    if (el) {
       const count = el.images.length;
 
       if (count === 1) {

--- a/src/ai-sdk/generate-video.ts
+++ b/src/ai-sdk/generate-video.ts
@@ -59,9 +59,8 @@ class DefaultGeneratedVideo implements GeneratedVideo {
 
   get base64(): string {
     let binary = "";
-    const bytes = this._data;
-    for (let i = 0; i < bytes.byteLength; i++) {
-      binary += String.fromCharCode(bytes[i]!);
+    for (const byte of this._data) {
+      binary += String.fromCharCode(byte);
     }
     return btoa(binary);
   }
@@ -158,7 +157,7 @@ export async function generateVideo(
   }
 
   return {
-    video: videos[0]!,
+    video: videos[0] as GeneratedVideo,
     videos,
     warnings,
   };

--- a/src/ai-sdk/middleware/placeholder.ts
+++ b/src/ai-sdk/middleware/placeholder.ts
@@ -35,9 +35,9 @@ function hslToHex(hsl: string): string {
   const match = hsl.match(/hsl\((\d+),(\d+)%,(\d+)%\)/);
   if (!match) return "333333";
 
-  const h = Number.parseInt(match[1]!) / 360;
-  const s = Number.parseInt(match[2]!) / 100;
-  const l = Number.parseInt(match[3]!) / 100;
+  const h = Number.parseInt(match[1] ?? "0", 10) / 360;
+  const s = Number.parseInt(match[2] ?? "0", 10) / 100;
+  const l = Number.parseInt(match[3] ?? "0", 10) / 100;
 
   const hue2rgb = (p: number, q: number, t: number) => {
     if (t < 0) t += 1;

--- a/src/ai-sdk/middleware/wrap-image-model.ts
+++ b/src/ai-sdk/middleware/wrap-image-model.ts
@@ -1,8 +1,4 @@
-import type {
-  ImageModelV3,
-  ImageModelV3CallOptions,
-  ImageModelV3Middleware,
-} from "@ai-sdk/provider";
+import type { ImageModelV3, ImageModelV3Middleware } from "@ai-sdk/provider";
 import { wrapImageModel } from "ai";
 import { generatePlaceholder } from "./placeholder";
 import type { RenderMode } from "./wrap-video-model";

--- a/src/ai-sdk/providers/editly/index.ts
+++ b/src/ai-sdk/providers/editly/index.ts
@@ -161,7 +161,7 @@ function isTextOverlayLayer(layer: Layer): boolean {
 
 function buildBaseClipFilter(
   clip: ProcessedClip,
-  clipIndex: number,
+  _clipIndex: number,
   width: number,
   height: number,
   inputOffset: number,
@@ -416,8 +416,7 @@ function buildAudioFilter(
   let inputIdx = videoInputCount;
 
   if (videoSourceAudio && videoSourceAudio.length > 0) {
-    for (let i = 0; i < videoSourceAudio.length; i++) {
-      const src = videoSourceAudio[i]!;
+    for (const [i, src] of videoSourceAudio.entries()) {
       const { inputIndex, startTime, duration, cutFrom, mixVolume } = src;
 
       const shouldInclude =
@@ -460,8 +459,7 @@ function buildAudioFilter(
     inputIdx++;
   }
 
-  for (let i = 0; i < audioTracks.length; i++) {
-    const track = audioTracks[i]!;
+  for (const [i, track] of audioTracks.entries()) {
     audioInputs.push(track.path);
     const label = `atrk${i}`;
 
@@ -483,8 +481,7 @@ function buildAudioFilter(
     inputIdx++;
   }
 
-  for (let i = 0; i < clipAudioLayers.length; i++) {
-    const { layer, clipStartTime } = clipAudioLayers[i]!;
+  for (const [i, { layer, clipStartTime }] of clipAudioLayers.entries()) {
     audioInputs.push(layer.path);
     const label = `aclip${i}`;
 

--- a/src/ai-sdk/providers/editly/layers.ts
+++ b/src/ai-sdk/providers/editly/layers.ts
@@ -37,7 +37,6 @@ function getCropPositionExpr(position: CropPosition | undefined): {
       return { x: "(iw-ow)/2", y: "ih-oh" };
     case "bottom-right":
       return { x: "iw-ow", y: "ih-oh" };
-    case "center":
     default:
       return { x: "(iw-ow)/2", y: "(ih-oh)/2" };
   }

--- a/src/ai-sdk/providers/editly/rendi/index.ts
+++ b/src/ai-sdk/providers/editly/rendi/index.ts
@@ -123,8 +123,7 @@ export class RendiBackend implements FFmpegBackend {
     const inputFiles: Record<string, string> = {};
     const pathToPlaceholder = new Map<string, string>();
 
-    for (let i = 0; i < inputs.length; i++) {
-      const input = inputs[i]!;
+    for (const [i, input] of inputs.entries()) {
       const path = this.getInputPath(input);
       const url = this.ensureUrl(path);
       const placeholder = `in_${i + 1}`;
@@ -146,8 +145,7 @@ export class RendiBackend implements FFmpegBackend {
     };
 
     const inputArgs: string[] = [];
-    for (let i = 0; i < inputs.length; i++) {
-      const input = inputs[i]!;
+    for (const [i, input] of inputs.entries()) {
       if (typeof input !== "string" && "options" in input && input.options) {
         inputArgs.push(...input.options);
       }

--- a/src/ai-sdk/providers/fal.ts
+++ b/src/ai-sdk/providers/fal.ts
@@ -365,7 +365,7 @@ class FalVideoModel implements VideoModelV3 {
     } = options;
     const warnings: SharedV3Warning[] = [];
 
-    const hasVideoInput = files?.some((f) =>
+    const _hasVideoInput = files?.some((f) =>
       getMediaType(f)?.startsWith("video/"),
     );
     const hasImageInput = files?.some((f) =>
@@ -491,12 +491,14 @@ class FalVideoModel implements VideoModelV3 {
         const imageFiles = files.filter((f) =>
           getMediaType(f)?.startsWith("image/"),
         );
-        if (imageFiles.length > 0) {
+        const firstImage = imageFiles[0];
+        if (firstImage) {
           // First image is start image
-          input.image_url = await fileToUrl(imageFiles[0]!);
+          input.image_url = await fileToUrl(firstImage);
           // Second image (if provided) is end image for Kling v2.6 and LTX-2
-          if ((isKlingV26 || isLtx2) && imageFiles.length > 1) {
-            input.end_image_url = await fileToUrl(imageFiles[1]!);
+          const secondImage = imageFiles[1];
+          if ((isKlingV26 || isLtx2) && secondImage) {
+            input.end_image_url = await fileToUrl(secondImage);
           }
         }
       } else if (!isLtx2) {
@@ -788,7 +790,8 @@ class FalImageModel implements ImageModelV3 {
 
     const imageBuffers = await Promise.all(
       images.map(async (img) => {
-        const response = await fetch(img.url!, { signal: abortSignal });
+        if (!img.url) throw new Error("Image URL is missing");
+        const response = await fetch(img.url, { signal: abortSignal });
         return new Uint8Array(await response.arrayBuffer());
       }),
     );

--- a/src/cli/commands/frame.tsx
+++ b/src/cli/commands/frame.tsx
@@ -385,7 +385,7 @@ export const frameCmd = defineCommand({
       process.exit(1);
     }
 
-    const renderProps = component.props as RenderProps;
+    const _renderProps = component.props as RenderProps;
     const frames = extractFrames(component);
 
     if (frames.length === 0) {

--- a/src/cli/commands/init.tsx
+++ b/src/cli/commands/init.tsx
@@ -532,7 +532,7 @@ Get your free API key at: ${COLORS.cyan}https://fal.ai/dashboard/keys${COLORS.re
     }
 
     if (added) {
-      writeFileSync(gitignorePath, gitignoreContent.trim() + "\n");
+      writeFileSync(gitignorePath, `${gitignoreContent.trim()}\n`);
       log.success("Updated .gitignore");
     } else {
       log.info(".gitignore already configured");

--- a/src/cli/commands/storyboard.tsx
+++ b/src/cli/commands/storyboard.tsx
@@ -470,12 +470,12 @@ function generateHtml(storyboard: Storyboard, sourceFile: string): string {
       el.imageDataUrl ||
       (el.src && !isLocalFilePath(el.src) ? el.src : undefined);
 
-    if (hasSrcWithPreview) {
+    if (hasSrcWithPreview && el.src) {
       const shortPath =
-        el.src!.length > 50 ? `${el.src!.slice(0, 50)}...` : el.src!;
+        el.src.length > 50 ? `${el.src.slice(0, 50)}...` : el.src;
       const isUrl =
-        el.src!.startsWith("http://") || el.src!.startsWith("https://");
-      const escapedSrc = escapeAttr(el.src!);
+        el.src.startsWith("http://") || el.src.startsWith("https://");
+      const escapedSrc = escapeAttr(el.src);
       const previewImgSrc = previewSrc ? escapeAttr(previewSrc) : undefined;
       return `
       <div class="tree-node" style="--depth: ${depth}">
@@ -567,15 +567,12 @@ function generateHtml(storyboard: Storyboard, sourceFile: string): string {
           child.imageDataUrl ||
           (child.src && !isLocalFilePath(child.src) ? child.src : undefined);
 
-        if (hasSrcWithPreview) {
+        if (hasSrcWithPreview && child.src) {
           const shortPath =
-            child.src!.length > 60
-              ? `${child.src!.slice(0, 60)}...`
-              : child.src!;
+            child.src.length > 60 ? `${child.src.slice(0, 60)}...` : child.src;
           const isUrl =
-            child.src!.startsWith("http://") ||
-            child.src!.startsWith("https://");
-          const escapedSrc = escapeAttr(child.src!);
+            child.src.startsWith("http://") || child.src.startsWith("https://");
+          const escapedSrc = escapeAttr(child.src);
           const previewImgSrc = previewSrc ? escapeAttr(previewSrc) : undefined;
           return `
           <div class="timeline-nested">

--- a/src/definitions/actions/qwen-angles.ts
+++ b/src/definitions/actions/qwen-angles.ts
@@ -145,12 +145,13 @@ export const definition: ActionDefinition<typeof schema> = {
     };
 
     const images = data?.images;
-    if (!images || images.length === 0) {
+    const firstImage = images?.[0];
+    if (!images || !firstImage) {
       throw new Error("No images in result");
     }
 
     return {
-      imageUrl: images[0]!.url,
+      imageUrl: firstImage.url,
       images,
       seed: data?.seed,
       prompt: data?.prompt,
@@ -203,12 +204,13 @@ export async function qwenAngles(
   };
 
   const images = data?.images;
-  if (!images || images.length === 0) {
+  const firstImage = images?.[0];
+  if (!images || !firstImage) {
     throw new Error("No images in result");
   }
 
   return {
-    imageUrl: images[0]!.url,
+    imageUrl: firstImage.url,
     images,
     seed: data?.seed,
     prompt: data?.prompt,

--- a/src/react/renderers/cache.test.ts
+++ b/src/react/renderers/cache.test.ts
@@ -109,7 +109,7 @@ describe("render cache behavior", () => {
     const counters = { imageCalls: 0, videoCalls: 0 };
 
     const model = createVideoModel();
-    const imageModel = createImageModel();
+    const _imageModel = createImageModel();
 
     const base = Video({
       prompt: "walk forward",
@@ -146,7 +146,7 @@ describe("render cache behavior", () => {
     const cacheDir = makeTempDir();
     const counters = { imageCalls: 0, videoCalls: 0 };
 
-    const videoModel = createVideoModel();
+    const _videoModel = createVideoModel();
     const imageModel = createImageModel();
 
     const base = Image({

--- a/src/react/renderers/captions.ts
+++ b/src/react/renderers/captions.ts
@@ -291,7 +291,19 @@ export async function renderCaptions(
   }
 
   const styleName = props.style ?? "tiktok";
-  const baseStyle = STYLE_PRESETS[styleName] ?? STYLE_PRESETS.tiktok!;
+  const defaultStyle: SubtitleStyle = {
+    fontName: "Montserrat",
+    fontSize: 72,
+    primaryColor: "&HFFFFFF",
+    outlineColor: "&H000000",
+    backColor: "&H00000000",
+    bold: true,
+    outline: 4,
+    shadow: 0,
+    marginV: 480,
+    alignment: 2,
+  };
+  const baseStyle = STYLE_PRESETS[styleName] ?? defaultStyle;
 
   const alignment = props.position
     ? (POSITION_ALIGNMENT[props.position] ?? baseStyle.alignment)

--- a/src/react/renderers/packshot.ts
+++ b/src/react/renderers/packshot.ts
@@ -237,9 +237,6 @@ function mapCtaPosition(
     case "center-left":
     case "center-right":
       return "center";
-    case "bottom":
-    case "bottom-left":
-    case "bottom-right":
     default:
       return "bottom";
   }

--- a/src/react/renderers/packshot/blinking-button.ts
+++ b/src/react/renderers/packshot/blinking-button.ts
@@ -368,7 +368,6 @@ function getButtonYPosition(
       return Math.floor(videoHeight * 0.15);
     case "center":
       return Math.floor((videoHeight - buttonHeight) / 2);
-    case "bottom":
     default:
       return Math.floor(videoHeight * 0.78 - buttonHeight / 2);
   }

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -16,7 +16,6 @@ import type {
 } from "../../ai-sdk/providers/editly/types";
 
 import type {
-  CaptionsProps,
   ClipProps,
   MusicProps,
   OverlayProps,

--- a/src/react/renderers/slider.ts
+++ b/src/react/renderers/slider.ts
@@ -34,7 +34,9 @@ export async function renderSlider(
   }
 
   if (childPaths.length === 1) {
-    return childPaths[0]!;
+    const firstPath = childPaths[0];
+    if (!firstPath) throw new Error("No path found");
+    return firstPath;
   }
 
   const transitionName = direction === "horizontal" ? "slideleft" : "slideup";

--- a/src/react/renderers/split.ts
+++ b/src/react/renderers/split.ts
@@ -52,7 +52,9 @@ export async function renderSplit(
   }
 
   if (cells.length === 1) {
-    return cells[0]!.path;
+    const firstCell = cells[0];
+    if (!firstCell) throw new Error("No cell found");
+    return firstCell.path;
   }
 
   const numChildren = cells.length;

--- a/src/react/renderers/swipe.ts
+++ b/src/react/renderers/swipe.ts
@@ -40,7 +40,9 @@ export async function renderSwipe(
   }
 
   if (childPaths.length === 1) {
-    return childPaths[0]!;
+    const firstPath = childPaths[0];
+    if (!firstPath) throw new Error("No path found");
+    return firstPath;
   }
 
   const transitionName = SWIPE_TRANSITION_MAP[direction];

--- a/src/studio/step-renderer.ts
+++ b/src/studio/step-renderer.ts
@@ -255,7 +255,8 @@ export function getSessionStatus(session: StepSession): {
     completedStages: session.results.size,
     currentStageIndex: session.currentStageIndex,
     stages: session.extracted.order.map((id) => {
-      const stage = session.extracted.stages.find((s) => s.id === id)!;
+      const stage = session.extracted.stages.find((s) => s.id === id);
+      if (!stage) throw new Error(`Stage not found: ${id}`);
       return {
         id: stage.id,
         type: stage.type,


### PR DESCRIPTION
## Summary

- Replace non-null assertions (`!`) with proper guards or optional chaining
- Prefix unused variables with underscore or remove them  
- Replace `any` types with `unknown` and proper type checks
- Use `for..of` loops instead of index-based iteration where appropriate

Fixes 71 biome warnings (noNonNullAssertion, noUnusedVariables, noExplicitAny).