### PR TITLE
feat(react): return intermediate files from render

### DIFF
--- a/src/react/examples/character-video.tsx
+++ b/src/react/examples/character-video.tsx
@@ -80,7 +80,7 @@ async function main() {
     cache: ".cache/ai",
   });
 
-  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log(`\ndone! ${buffer.video.byteLength} bytes`);
   console.log("output: output/react-madi.mp4");
 }
 

--- a/src/react/examples/grid.tsx
+++ b/src/react/examples/grid.tsx
@@ -46,7 +46,7 @@ async function main() {
     cache: ".cache/ai",
   });
 
-  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log(`\ndone! ${buffer.video.byteLength} bytes`);
   console.log("output: output/react-grid.mp4");
 }
 

--- a/src/react/examples/quickstart-test.tsx
+++ b/src/react/examples/quickstart-test.tsx
@@ -77,7 +77,7 @@ async function main() {
 
     console.log("\n=== SUCCESS ===");
     console.log(
-      `Output: output/quickstart-test.mp4 (${(buffer.byteLength / 1024 / 1024).toFixed(2)} MB)`,
+      `Output: output/quickstart-test.mp4 (${(buffer.video.byteLength / 1024 / 1024).toFixed(2)} MB)`,
     );
     console.log("\nYour setup is working! You can now:");
     console.log("1. Try the templates in .claude/skills/video-generation.md");

--- a/src/react/examples/split.tsx
+++ b/src/react/examples/split.tsx
@@ -34,7 +34,7 @@ async function main() {
     cache: ".cache/ai",
   });
 
-  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log(`\ndone! ${buffer.video.byteLength} bytes`);
   console.log("output: output/react-split.mp4");
 }
 

--- a/src/react/examples/video-grid.tsx
+++ b/src/react/examples/video-grid.tsx
@@ -39,7 +39,7 @@ async function main() {
     cache: ".cache/ai",
   });
 
-  console.log(`\ndone! ${buffer.byteLength} bytes`);
+  console.log(`\ndone! ${buffer.video.byteLength} bytes`);
   console.log("output: output/react-video-grid.mp4");
 }
 

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -22,6 +22,8 @@ export { render, renderStream } from "./render";
 export type {
   CaptionsProps,
   ClipProps,
+  GeneratedFile,
+  GeneratedFileType,
   ImageProps,
   MusicProps,
   OverlayProps,
@@ -29,6 +31,7 @@ export type {
   PositionProps,
   RenderOptions,
   RenderProps,
+  RenderResult,
   SliderProps,
   SpeechProps,
   SplitProps,

--- a/src/react/react.test.ts
+++ b/src/react/react.test.ts
@@ -235,8 +235,9 @@ describe("layout renderers", () => {
     });
 
     const result = await render(root, { output: outPath, quiet: true });
-    expect(result).toBeInstanceOf(Uint8Array);
-    expect(result.length).toBeGreaterThan(0);
+    expect(result.video).toBeInstanceOf(Uint8Array);
+    expect(result.video.length).toBeGreaterThan(0);
+    expect(result.files).toBeInstanceOf(Array);
     expect(existsSync(outPath)).toBe(true);
     unlinkSync(outPath);
   });
@@ -264,7 +265,8 @@ describe("layout renderers", () => {
       });
 
       const result = await render(root, { output: outPath, quiet: true });
-      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.video).toBeInstanceOf(Uint8Array);
+      expect(result.files).toBeInstanceOf(Array);
       expect(existsSync(outPath)).toBe(true);
       unlinkSync(outPath);
     },
@@ -295,7 +297,8 @@ describe("layout renderers", () => {
       });
 
       const result = await render(root, { output: outPath, quiet: true });
-      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.video).toBeInstanceOf(Uint8Array);
+      expect(result.files).toBeInstanceOf(Array);
       expect(existsSync(outPath)).toBe(true);
       unlinkSync(outPath);
     },
@@ -326,7 +329,8 @@ describe("layout renderers", () => {
     });
 
     const result = await render(root, { output: outPath, quiet: true });
-    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.video).toBeInstanceOf(Uint8Array);
+    expect(result.files).toBeInstanceOf(Array);
     expect(existsSync(outPath)).toBe(true);
     unlinkSync(outPath);
   });
@@ -350,7 +354,8 @@ describe("layout renderers", () => {
       });
 
       const result = await render(root, { output: outPath, quiet: true });
-      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.video).toBeInstanceOf(Uint8Array);
+      expect(result.files).toBeInstanceOf(Array);
       expect(existsSync(outPath)).toBe(true);
       unlinkSync(outPath);
     },
@@ -384,8 +389,9 @@ describe("layout renderers", () => {
     });
 
     const result = await render(root, { output: outPath, quiet: true });
-    expect(result).toBeInstanceOf(Uint8Array);
-    expect(result.length).toBeGreaterThan(0);
+    expect(result.video).toBeInstanceOf(Uint8Array);
+    expect(result.video.length).toBeGreaterThan(0);
+    expect(result.files).toBeInstanceOf(Array);
     expect(existsSync(outPath)).toBe(true);
     unlinkSync(outPath);
   });

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -1,10 +1,10 @@
 import { renderRoot } from "./renderers";
-import type { RenderOptions, VargElement } from "./types";
+import type { RenderOptions, RenderResult, VargElement } from "./types";
 
 export async function render(
   element: VargElement,
   options: RenderOptions = {},
-): Promise<Uint8Array> {
+): Promise<RenderResult> {
   if (element.type !== "render") {
     throw new Error("Root element must be <Render>");
   }
@@ -14,8 +14,8 @@ export async function render(
 
 export const renderStream = {
   async *stream(element: VargElement, options: RenderOptions = {}) {
-    yield { type: "start", progress: 0 };
+    yield { type: "start" as const, progress: 0 };
     const result = await render(element, options);
-    yield { type: "complete", progress: 100, result };
+    yield { type: "complete" as const, progress: 100, result };
   },
 };

--- a/src/react/renderers/cache.test.ts
+++ b/src/react/renderers/cache.test.ts
@@ -103,6 +103,7 @@ function createContext(
     tempFiles: [],
     pendingFiles: new Map<string, Promise<File>>(),
     backend: localBackend,
+    generatedFiles: [],
   };
 }
 

--- a/src/react/renderers/context.ts
+++ b/src/react/renderers/context.ts
@@ -3,7 +3,7 @@ import type { CacheStorage } from "../../ai-sdk/cache";
 import type { File } from "../../ai-sdk/file";
 import type { generateVideo } from "../../ai-sdk/generate-video";
 import type { FFmpegBackend } from "../../ai-sdk/providers/editly/backends";
-import type { DefaultModels } from "../types";
+import type { DefaultModels, GeneratedFile } from "../types";
 import type { ProgressTracker } from "./progress";
 
 export interface RenderContext {
@@ -18,4 +18,5 @@ export interface RenderContext {
   pendingFiles: Map<string, Promise<File>>;
   defaults?: DefaultModels;
   backend: FFmpegBackend;
+  generatedFiles: GeneratedFile[];
 }

--- a/src/react/renderers/image.ts
+++ b/src/react/renderers/image.ts
@@ -1,6 +1,7 @@
 import type { generateImage } from "ai";
 import { File } from "../../ai-sdk/file";
 import type {
+  GeneratedFile,
   ImageInput,
   ImagePrompt,
   ImageProps,
@@ -94,6 +95,19 @@ export async function renderImage(
     if (!firstImage?.uint8Array) {
       throw new Error("Image generation returned no image data");
     }
+
+    const generatedFile: GeneratedFile = {
+      type: "image",
+      data: firstImage.uint8Array,
+      mediaType: "image/png",
+      url: (firstImage as { url?: string }).url,
+      model: modelId,
+      prompt:
+        typeof resolvedPrompt === "string"
+          ? resolvedPrompt
+          : resolvedPrompt.text,
+    };
+    ctx.generatedFiles.push(generatedFile);
 
     return File.fromGenerated({
       uint8Array: firstImage.uint8Array,

--- a/src/react/renderers/music.ts
+++ b/src/react/renderers/music.ts
@@ -1,6 +1,6 @@
 import { File } from "../../ai-sdk/file";
 import { generateMusic } from "../../ai-sdk/generate-music";
-import type { MusicProps, VargElement } from "../types";
+import type { GeneratedFile, MusicProps, VargElement } from "../types";
 import type { RenderContext } from "./context";
 import { addTask, completeTask, startTask } from "./progress";
 
@@ -70,9 +70,21 @@ export async function renderMusic(
     if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
   }
 
+  const mediaType = audio.mediaType ?? "audio/mpeg";
+
+  const generatedFile: GeneratedFile = {
+    type: "music",
+    data: audio.uint8Array,
+    mediaType,
+    url: audio.url,
+    model: modelId,
+    prompt,
+  };
+  ctx.generatedFiles.push(generatedFile);
+
   return File.fromGenerated({
     uint8Array: audio.uint8Array,
-    mediaType: audio.mediaType ?? "audio/mpeg",
+    mediaType,
     url: audio.url,
   });
 }

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -18,11 +18,13 @@ import type {
 
 import type {
   ClipProps,
+  GeneratedFile,
   MusicProps,
   OverlayProps,
   RenderMode,
   RenderOptions,
   RenderProps,
+  RenderResult,
   SpeechProps,
   VargElement,
 } from "../types";
@@ -61,7 +63,7 @@ function resolveCacheStorage(
 export async function renderRoot(
   element: VargElement<"render">,
   options: RenderOptions,
-): Promise<Uint8Array> {
+): Promise<RenderResult> {
   const props = element.props as RenderProps;
   const progress = createProgressTracker(options.quiet ?? false);
 
@@ -124,6 +126,7 @@ export async function renderRoot(
 
   const backend = options.backend ?? localBackend;
   const tempFiles: string[] = [];
+  const generatedFiles: GeneratedFile[] = [];
   const ctx: RenderContext = {
     width: props.width ?? 1920,
     height: props.height ?? 1080,
@@ -136,6 +139,7 @@ export async function renderRoot(
     pendingFiles: new Map<string, Promise<File>>(),
     defaults: options.defaults,
     backend,
+    generatedFiles,
   };
 
   const clipElements: VargElement<"clip">[] = [];
@@ -376,5 +380,8 @@ export async function renderRoot(
     );
   }
 
-  return new Uint8Array(finalBuffer);
+  return {
+    video: new Uint8Array(finalBuffer),
+    files: generatedFiles,
+  };
 }

--- a/src/react/renderers/speech.ts
+++ b/src/react/renderers/speech.ts
@@ -1,6 +1,6 @@
 import { experimental_generateSpeech as generateSpeech } from "ai";
 import { File } from "../../ai-sdk/file";
-import type { SpeechProps, VargElement } from "../types";
+import type { GeneratedFile, SpeechProps, VargElement } from "../types";
 import type { RenderContext } from "./context";
 import { addTask, completeTask, startTask } from "./progress";
 import { computeCacheKey, getTextContent } from "./utils";
@@ -36,9 +36,21 @@ export async function renderSpeech(
 
   if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
 
+  const mediaType = (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
+
+  const generatedFile: GeneratedFile = {
+    type: "speech",
+    data: audio.uint8Array,
+    mediaType,
+    url: (audio as { url?: string }).url,
+    model: modelId,
+    prompt: text,
+  };
+  ctx.generatedFiles.push(generatedFile);
+
   return File.fromGenerated({
     uint8Array: audio.uint8Array,
-    mediaType: (audio as { mediaType?: string }).mediaType ?? "audio/mpeg",
+    mediaType,
     url: (audio as { url?: string }).url,
   });
 }

--- a/src/react/renderers/video.ts
+++ b/src/react/renderers/video.ts
@@ -1,6 +1,7 @@
 import { File } from "../../ai-sdk/file";
 import type { generateVideo } from "../../ai-sdk/generate-video";
 import type {
+  GeneratedFile,
   ImageInput,
   VargElement,
   VideoPrompt,
@@ -147,9 +148,23 @@ export async function renderVideo(
 
     if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
 
+    const mediaType = video.mimeType ?? "video/mp4";
+    const promptText =
+      typeof resolvedPrompt === "string" ? resolvedPrompt : resolvedPrompt.text;
+
+    const generatedFile: GeneratedFile = {
+      type: "video",
+      data: video.uint8Array,
+      mediaType,
+      url: (video as { url?: string }).url,
+      model: modelId,
+      prompt: promptText,
+    };
+    ctx.generatedFiles.push(generatedFile);
+
     return File.fromGenerated({
       uint8Array: video.uint8Array,
-      mediaType: video.mimeType ?? "video/mp4",
+      mediaType,
       url: (video as { url?: string }).url,
     });
   })();

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -276,6 +276,35 @@ export interface RenderOptions {
   storage?: StorageProvider;
 }
 
+export type GeneratedFileType =
+  | "image"
+  | "video"
+  | "speech"
+  | "music"
+  | "captions";
+
+export interface GeneratedFile {
+  /** Type of generated content */
+  type: GeneratedFileType;
+  /** The generated file data */
+  data: Uint8Array;
+  /** Media type (mime type) */
+  mediaType: string;
+  /** Optional URL if uploaded/cached */
+  url?: string;
+  /** Model used to generate (if AI-generated) */
+  model?: string;
+  /** Original prompt used (if AI-generated) */
+  prompt?: string;
+}
+
+export interface RenderResult {
+  /** Final rendered video buffer */
+  video: Uint8Array;
+  /** All intermediate files generated during rendering */
+  files: GeneratedFile[];
+}
+
 export interface ElementPropsMap {
   render: RenderProps;
   clip: ClipProps;

--- a/src/studio/step-renderer.ts
+++ b/src/studio/step-renderer.ts
@@ -53,6 +53,7 @@ export function createStepSession(
     progress: createProgressTracker(false),
     pendingFiles: new Map(),
     backend: localBackend,
+    generatedFiles: [],
   };
 
   const extracted = extractStages(rootElement);


### PR DESCRIPTION
## Summary

- `render()` now returns `RenderResult` containing both the final video and all intermediate generated files
- each `GeneratedFile` includes type, data, mediaType, url, model, and prompt
- enables users to access/save individual assets generated during rendering

## Breaking Change

`render()` return type changed from `Promise<Uint8Array>` to `Promise<RenderResult>`. access video via `result.video`.

## Usage

```tsx
const result = await render(<Render>...</Render>);

// final video
await Bun.write("output.mp4", result.video);

// intermediate files
for (const file of result.files) {
  console.log(`${file.type}: ${file.prompt}`);
}
```