### PR TITLE
docs: add cache policy rule for AI assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,3 +123,13 @@ bun --hot ./index.ts
 ```
 
 For more information, read the Bun API docs in `node_modules/bun-types/docs/**.md`.
+
+## Cache Policy
+
+**NEVER clear or delete the user's cache**, even when debugging.
+
+- Video/image generation costs real money ($0.05–$0.50+ per generation) and takes 60–180 seconds
+- The cache is the user's asset — treat it as production data, not disposable debug state
+- If you need to regenerate, modify the prompt slightly or use a different cache key
+- If cache must be cleared, always ask the user explicitly first
+- Suggest `--no-cache` flag for one-off re-renders instead of deleting cached files


### PR DESCRIPTION
## Summary

Adds a **Cache Policy** section to CLAUDE.md instructing AI assistants to never clear or delete user cache during debugging.

## Changes

- Added cache policy rules to CLAUDE.md:
  - Never delete cached generations (they cost $0.05–$0.50+ each)
  - Suggest alternatives: `--no-cache` flag, modified prompts, or asking the user
  - Treat cache as production data, not disposable debug state

Closes #46