### PR TITLE
perf: use lazy File class for RenderResult.files

### DIFF
--- a/src/ai-sdk/file.ts
+++ b/src/ai-sdk/file.ts
@@ -1,11 +1,30 @@
 import type { ImageModelV3File } from "@ai-sdk/provider";
 import type { StorageProvider } from "./storage/types";
 
+/** Type of generated content */
+export type GeneratedFileType =
+  | "image"
+  | "video"
+  | "speech"
+  | "music"
+  | "captions";
+
+/** Metadata for AI-generated files */
+export interface FileMetadata {
+  /** Type of generated content */
+  type?: GeneratedFileType;
+  /** Model used to generate */
+  model?: string;
+  /** Original prompt used */
+  prompt?: string;
+}
+
 export class File {
   private _data: Uint8Array | null = null;
   private _url: string | null = null;
   private _mediaType: string;
   private _loader: (() => Promise<Uint8Array>) | null = null;
+  private _metadata: FileMetadata = {};
 
   private constructor(
     options:
@@ -125,6 +144,17 @@ export class File {
 
   get url(): string | null {
     return this._url;
+  }
+
+  /** Get file metadata (type, model, prompt) */
+  get metadata(): FileMetadata {
+    return this._metadata;
+  }
+
+  /** Set metadata and return this for chaining */
+  withMetadata(metadata: FileMetadata): this {
+    this._metadata = { ...this._metadata, ...metadata };
+    return this;
   }
 
   async data(): Promise<Uint8Array> {

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,4 +1,5 @@
 export type { CacheStorage } from "../ai-sdk/cache";
+export { File } from "../ai-sdk/file";
 export type { SizeValue } from "../ai-sdk/providers/editly/types";
 export { assets } from "./assets";
 export {
@@ -22,7 +23,7 @@ export { render, renderStream } from "./render";
 export type {
   CaptionsProps,
   ClipProps,
-  GeneratedFile,
+  FileMetadata,
   GeneratedFileType,
   ImageProps,
   MusicProps,

--- a/src/react/renderers/context.ts
+++ b/src/react/renderers/context.ts
@@ -3,7 +3,7 @@ import type { CacheStorage } from "../../ai-sdk/cache";
 import type { File } from "../../ai-sdk/file";
 import type { generateVideo } from "../../ai-sdk/generate-video";
 import type { FFmpegBackend } from "../../ai-sdk/providers/editly/backends";
-import type { DefaultModels, GeneratedFile } from "../types";
+import type { DefaultModels } from "../types";
 import type { ProgressTracker } from "./progress";
 
 export interface RenderContext {
@@ -18,5 +18,5 @@ export interface RenderContext {
   pendingFiles: Map<string, Promise<File>>;
   defaults?: DefaultModels;
   backend: FFmpegBackend;
-  generatedFiles: GeneratedFile[];
+  generatedFiles: File[];
 }

--- a/src/react/renderers/image.ts
+++ b/src/react/renderers/image.ts
@@ -1,7 +1,6 @@
 import type { generateImage } from "ai";
 import { File } from "../../ai-sdk/file";
 import type {
-  GeneratedFile,
   ImageInput,
   ImagePrompt,
   ImageProps,
@@ -96,24 +95,22 @@ export async function renderImage(
       throw new Error("Image generation returned no image data");
     }
 
-    const generatedFile: GeneratedFile = {
-      type: "image",
-      data: firstImage.uint8Array,
-      mediaType: "image/png",
-      url: (firstImage as { url?: string }).url,
-      model: modelId,
-      prompt:
-        typeof resolvedPrompt === "string"
-          ? resolvedPrompt
-          : resolvedPrompt.text,
-    };
-    ctx.generatedFiles.push(generatedFile);
+    const promptText =
+      typeof resolvedPrompt === "string" ? resolvedPrompt : resolvedPrompt.text;
 
-    return File.fromGenerated({
+    const file = File.fromGenerated({
       uint8Array: firstImage.uint8Array,
       mediaType: "image/png",
       url: (firstImage as { url?: string }).url,
+    }).withMetadata({
+      type: "image",
+      model: modelId,
+      prompt: promptText,
     });
+
+    ctx.generatedFiles.push(file);
+
+    return file;
   })();
 
   ctx.pendingFiles.set(cacheKeyStr, renderPromise);

--- a/src/react/renderers/music.ts
+++ b/src/react/renderers/music.ts
@@ -1,6 +1,6 @@
 import { File } from "../../ai-sdk/file";
 import { generateMusic } from "../../ai-sdk/generate-music";
-import type { GeneratedFile, MusicProps, VargElement } from "../types";
+import type { MusicProps, VargElement } from "../types";
 import type { RenderContext } from "./context";
 import { addTask, completeTask, startTask } from "./progress";
 
@@ -72,19 +72,17 @@ export async function renderMusic(
 
   const mediaType = audio.mediaType ?? "audio/mpeg";
 
-  const generatedFile: GeneratedFile = {
-    type: "music",
-    data: audio.uint8Array,
-    mediaType,
-    url: audio.url,
-    model: modelId,
-    prompt,
-  };
-  ctx.generatedFiles.push(generatedFile);
-
-  return File.fromGenerated({
+  const file = File.fromGenerated({
     uint8Array: audio.uint8Array,
     mediaType,
     url: audio.url,
+  }).withMetadata({
+    type: "music",
+    model: modelId,
+    prompt,
   });
+
+  ctx.generatedFiles.push(file);
+
+  return file;
 }

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -1,6 +1,6 @@
 import { generateImage, wrapImageModel } from "ai";
 import { type CacheStorage, withCache } from "../../ai-sdk/cache";
-import type { File } from "../../ai-sdk/file";
+import type { File, File as VargFile } from "../../ai-sdk/file";
 import { fileCache } from "../../ai-sdk/file-cache";
 import { generateVideo } from "../../ai-sdk/generate-video";
 import {
@@ -15,10 +15,8 @@ import type {
   Layer,
   VideoLayer,
 } from "../../ai-sdk/providers/editly/types";
-
 import type {
   ClipProps,
-  GeneratedFile,
   MusicProps,
   OverlayProps,
   RenderMode,
@@ -126,7 +124,7 @@ export async function renderRoot(
 
   const backend = options.backend ?? localBackend;
   const tempFiles: string[] = [];
-  const generatedFiles: GeneratedFile[] = [];
+  const generatedFiles: VargFile[] = [];
   const ctx: RenderContext = {
     width: props.width ?? 1920,
     height: props.height ?? 1080,

--- a/src/react/renderers/speech.ts
+++ b/src/react/renderers/speech.ts
@@ -1,6 +1,6 @@
 import { experimental_generateSpeech as generateSpeech } from "ai";
 import { File } from "../../ai-sdk/file";
-import type { GeneratedFile, SpeechProps, VargElement } from "../types";
+import type { SpeechProps, VargElement } from "../types";
 import type { RenderContext } from "./context";
 import { addTask, completeTask, startTask } from "./progress";
 import { computeCacheKey, getTextContent } from "./utils";
@@ -38,19 +38,17 @@ export async function renderSpeech(
 
   const mediaType = (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 
-  const generatedFile: GeneratedFile = {
-    type: "speech",
-    data: audio.uint8Array,
-    mediaType,
-    url: (audio as { url?: string }).url,
-    model: modelId,
-    prompt: text,
-  };
-  ctx.generatedFiles.push(generatedFile);
-
-  return File.fromGenerated({
+  const file = File.fromGenerated({
     uint8Array: audio.uint8Array,
     mediaType,
     url: (audio as { url?: string }).url,
+  }).withMetadata({
+    type: "speech",
+    model: modelId,
+    prompt: text,
   });
+
+  ctx.generatedFiles.push(file);
+
+  return file;
 }

--- a/src/react/renderers/video.ts
+++ b/src/react/renderers/video.ts
@@ -1,7 +1,6 @@
 import { File } from "../../ai-sdk/file";
 import type { generateVideo } from "../../ai-sdk/generate-video";
 import type {
-  GeneratedFile,
   ImageInput,
   VargElement,
   VideoPrompt,
@@ -152,21 +151,19 @@ export async function renderVideo(
     const promptText =
       typeof resolvedPrompt === "string" ? resolvedPrompt : resolvedPrompt.text;
 
-    const generatedFile: GeneratedFile = {
-      type: "video",
-      data: video.uint8Array,
-      mediaType,
-      url: (video as { url?: string }).url,
-      model: modelId,
-      prompt: promptText,
-    };
-    ctx.generatedFiles.push(generatedFile);
-
-    return File.fromGenerated({
+    const file = File.fromGenerated({
       uint8Array: video.uint8Array,
       mediaType,
       url: (video as { url?: string }).url,
+    }).withMetadata({
+      type: "video",
+      model: modelId,
+      prompt: promptText,
     });
+
+    ctx.generatedFiles.push(file);
+
+    return file;
   })();
 
   ctx.pendingFiles.set(cacheKeyStr, renderPromise);

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -276,33 +276,16 @@ export interface RenderOptions {
   storage?: StorageProvider;
 }
 
-export type GeneratedFileType =
-  | "image"
-  | "video"
-  | "speech"
-  | "music"
-  | "captions";
+// Re-export from file module for convenience
+export type { FileMetadata, GeneratedFileType } from "../ai-sdk/file";
 
-export interface GeneratedFile {
-  /** Type of generated content */
-  type: GeneratedFileType;
-  /** The generated file data */
-  data: Uint8Array;
-  /** Media type (mime type) */
-  mediaType: string;
-  /** Optional URL if uploaded/cached */
-  url?: string;
-  /** Model used to generate (if AI-generated) */
-  model?: string;
-  /** Original prompt used (if AI-generated) */
-  prompt?: string;
-}
+import type { File } from "../ai-sdk/file";
 
 export interface RenderResult {
   /** Final rendered video buffer */
   video: Uint8Array;
-  /** All intermediate files generated during rendering */
-  files: GeneratedFile[];
+  /** All intermediate files generated during rendering (lazy-loaded) */
+  files: File[];
 }
 
 export interface ElementPropsMap {


### PR DESCRIPTION
## Summary

Changes `RenderResult.files` from `GeneratedFile[]` (eager `Uint8Array`) to `File[]` (lazy loading).

## Problem

PR #108 added intermediate file tracking, but stored raw `Uint8Array` in memory for all generated assets. For complex renders with 10+ assets, this wastes 200MB+ RAM — especially problematic since files are often already uploaded to R2.

## Solution

- Use existing lazy `File` class instead of `GeneratedFile`
- `.url` returns cached URL immediately (0 RAM)
- `.data()` loads bytes only when explicitly needed
- Add `FileMetadata` interface with `type`, `model`, `prompt`
- Add `withMetadata()` method to `File` for chaining

## Usage

```ts
const result = await render(<Render>...</Render>);

// Access URLs without loading data into RAM
for (const file of result.files) {
  console.log(file.url);           // immediate, 0 RAM
  console.log(file.metadata.type); // 'image' | 'video' | 'music' | 'speech'
  
  // Only load data if needed
  const data = await file.data();  // loads on demand
}
```

## Breaking Change

`result.files[].data` → `await result.files[].data()`
`result.files[].type` → `result.files[].metadata.type`

Closes #113