### PR TITLE
fix: make vargai/ai importable in webpack/next.js environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "sharp": "^0.34.5",
     "zod": "^4.2.1"
   },
+  "sideEffects": false,
   "version": "0.4.0-alpha51",
   "exports": {
     ".": "./src/index.ts",
@@ -80,6 +81,7 @@
     "./studio": "./src/studio/index.ts",
     "./jsx-runtime": "./src/react/runtime/jsx-runtime.ts",
     "./jsx-dev-runtime": "./src/react/runtime/jsx-dev-runtime.ts",
-    "./editly": "./src/ai-sdk/providers/editly/index.ts"
+    "./editly": "./src/ai-sdk/providers/editly/index.ts",
+    "./file": "./src/ai-sdk/file.ts"
   }
 }

--- a/src/ai-sdk/middleware/placeholder.ts
+++ b/src/ai-sdk/middleware/placeholder.ts
@@ -1,7 +1,6 @@
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { $ } from "bun";
 
 export interface PlaceholderOptions {
   type: "image" | "video" | "audio";
@@ -81,6 +80,8 @@ export async function generatePlaceholder(
     tmpdir(),
     `placeholder_${Date.now()}_${Math.random().toString(36).slice(2)}.${ext}`,
   );
+
+  const { $ } = await import("bun");
 
   try {
     if (type === "audio") {


### PR DESCRIPTION
## Summary

Fixes #117 — `import { File } from 'vargai/ai'` fails in Next.js/webpack with `Module not found: Can't resolve 'bun'`.

## Changes

- **Dynamic bun import in placeholder middleware** — moved `import { $ } from "bun"` from static top-level to `await import("bun")` inside `generatePlaceholder()`. This is the only callsite that caused webpack module resolution to fail, since it's a static import of a bun-only module that gets pulled in through the barrel export.
- **`sideEffects: false`** in package.json — enables webpack/next.js to tree-shake unused exports from the `vargai/ai` barrel, so importing just `File` no longer pulls in middleware.
- **`./file` export path** — dedicated entry point (`import { File } from "vargai/file"`) as an escape hatch for consumers who want zero barrel risk.

## What this doesn't change

`File.fromPath()` and `toTempFile()` still use `Bun.file()` / `Bun.write()` — these are runtime globals, not static imports, so they don't break webpack module resolution.