### PR TITLE
feat: add Kling 3.0 (O3) video model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ replicate.imageModel("owner/model-name")
 
 | model | provider | capabilities |
 |-------|----------|--------------|
+| kling-v3 | fal | text-to-video, image-to-video (O3 Pro, latest) |
+| kling-v3-standard | fal | text-to-video, image-to-video (O3 Standard, cheaper) |
+| kling-v2.6 | fal | text-to-video, image-to-video |
 | kling-v2.5 | fal | text-to-video, image-to-video |
 | kling-v2.1 | fal | text-to-video, image-to-video |
 | wan-2.5 | fal | image-to-video, good for characters |

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -741,7 +741,7 @@ createVideoAd();
 | model type | models |
 |---|---|
 | `imageModel` | `nano-banana-pro`, `nano-banana-pro/edit` |
-| `videoModel` | `kling-v2.5`, `kling-v2.5-pro` |
+| `videoModel` | `kling-v3`, `kling-v3-standard`, `kling-v2.6`, `kling-v2.5` |
 | `lipsyncModel` | `sync-v2-pro` |
 
 ### higgsfield

--- a/src/definitions/models/kling.ts
+++ b/src/definitions/models/kling.ts
@@ -47,7 +47,7 @@ export const definition: ModelDefinition<typeof schema> = {
   providers: ["fal", "replicate"],
   defaultProvider: "fal",
   providerModels: {
-    fal: "fal-ai/kling-video/v2.5-turbo/pro",
+    fal: "fal-ai/kling-video/o3/pro",
     replicate: "fofr/kling-v1.5",
   },
   schema,

--- a/src/react/renderers/progress.ts
+++ b/src/react/renderers/progress.ts
@@ -26,6 +26,8 @@ export const MODEL_TIME_ESTIMATES: Record<string, number> = {
   ideogram: 8,
   // video models
   kling: 180,
+  "kling-v3": 180,
+  "kling-v3-standard": 120,
   "kling-v2": 180,
   "kling-v2.5": 180,
   "kling-v2.6": 180,


### PR DESCRIPTION
## Summary

- Add `kling-v3` (O3 Pro) and `kling-v3-standard` (O3 Standard) video models via fal.ai
- Upgrade default `kling` model to O3 Pro
- O3 supports string duration 3-15s, end images, and native audio generation (same API shape as v2.6)

## Endpoints added

| SDK Model ID | text-to-video | image-to-video |
|---|---|---|
| `kling-v3` | `fal-ai/kling-video/o3/pro/text-to-video` | `fal-ai/kling-video/o3/pro/image-to-video` |
| `kling-v3-standard` | `fal-ai/kling-video/o3/standard/text-to-video` | `fal-ai/kling-video/o3/standard/image-to-video` |

## Files changed

- `src/ai-sdk/providers/fal.ts` — Add model entries + extend v2.6 code path to cover v3
- `src/definitions/models/kling.ts` — Default `kling` now points to O3 Pro
- `src/react/renderers/progress.ts` — Time estimates for new models
- `docs/sdk.md` / `README.md` — Model tables updated

## Not included (follow-up)

- **reference-to-video** endpoint (`o3/pro/reference-to-video`, `o3/standard/reference-to-video`) — new mode with elements/character references, needs custom handling
- **motion control** for O3 (not yet available on fal.ai)

## Testing

- All 66 unit tests pass
- Pre-existing TS error in `garry-tan-varg.tsx` on main (unrelated)