### PR TITLE
fix: use backend.resolvePath() for cloud input uploads

### DIFF
--- a/src/react/renderers/packshot/blinking-button.ts
+++ b/src/react/renderers/packshot/blinking-button.ts
@@ -4,7 +4,6 @@ import type {
   FFmpegBackend,
   FFmpegOutput,
 } from "../../../ai-sdk/providers/editly/backends/types";
-import { uploadBuffer } from "../../../providers/storage";
 
 export interface BlinkingButtonOptions {
   text: string;
@@ -107,18 +106,15 @@ function oscExpr(tv: string, P: number): string {
 }
 
 /**
- * Resolve a local file path to a URL for cloud backends.
+ * Resolve a local file path to a string path/URL via the backend.
  * Local backend: returns the path as-is.
- * Cloud backend: uploads the file and returns the URL.
+ * Cloud backend (Rendi): uploads via its StorageProvider and returns the URL.
  */
 async function resolvePathForBackend(
   localPath: string,
   backend: FFmpegBackend,
 ): Promise<string> {
-  if (backend.name === "local") return localPath;
-  const buffer = await Bun.file(localPath).arrayBuffer();
-  const key = `tmp/${Date.now()}-${localPath.split("/").pop()}`;
-  return uploadBuffer(buffer, key, "image/png");
+  return backend.resolvePath(localPath);
 }
 
 // ─── Main ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace global `uploadBuffer()` singleton with `backend.resolvePath()` in blinking-button, packshot, and burn-captions renderers
- The singleton used hardcoded `CLOUDFLARE_ACCESS_KEY_ID` env vars and bucket `m` / `s3.varg.ai`, which don't match the render service's R2 config (`CLOUDFLARE_R2_*` / `su.varg.ai`)
- `backend.resolvePath()` already handles both local (returns path as-is) and cloud (uploads via injected StorageProvider) — no new abstractions needed

## Root cause
Cloud render failed with `Credential access key has length 0` or Rendi 404s because blinking-button/packshot uploaded input PNGs to the wrong bucket via the global singleton instead of using the backend's storage provider.