### PR TITLE
fix: upload generated files to storage on first render

### DIFF
--- a/src/react/renderers/context.ts
+++ b/src/react/renderers/context.ts
@@ -3,6 +3,7 @@ import type { CacheStorage } from "../../ai-sdk/cache";
 import type { File } from "../../ai-sdk/file";
 import type { generateVideo } from "../../ai-sdk/generate-video";
 import type { FFmpegBackend } from "../../ai-sdk/providers/editly/backends";
+import type { StorageProvider } from "../../ai-sdk/storage/types";
 import type { DefaultModels } from "../types";
 import type { ProgressTracker } from "./progress";
 
@@ -11,6 +12,7 @@ export interface RenderContext {
   height: number;
   fps: number;
   cache?: CacheStorage;
+  storage?: StorageProvider;
   generateImage: typeof generateImage;
   generateVideo: typeof generateVideo;
   tempFiles: string[];

--- a/src/react/renderers/image.ts
+++ b/src/react/renderers/image.ts
@@ -108,6 +108,10 @@ export async function renderImage(
       prompt: promptText,
     });
 
+    if (!file.url && ctx.storage) {
+      await file.upload(ctx.storage);
+    }
+
     ctx.generatedFiles.push(file);
 
     return file;

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -153,6 +153,7 @@ export async function renderRoot(
     height: props.height ?? 1080,
     fps: props.fps ?? 30,
     cache: cacheStorage,
+    storage: options.storage,
     generateImage: wrapGenerateImage,
     generateVideo: wrapGenerateVideo,
     tempFiles,

--- a/src/react/renderers/video.ts
+++ b/src/react/renderers/video.ts
@@ -161,6 +161,10 @@ export async function renderVideo(
       prompt: promptText,
     });
 
+    if (!file.url && ctx.storage) {
+      await file.upload(ctx.storage);
+    }
+
     ctx.generatedFiles.push(file);
 
     return file;


### PR DESCRIPTION
## Summary

- Generated image/video files had `url: null` on first render (cache miss) because `renderImage`/`renderVideo` never uploaded them to storage
- `options.storage` was accepted by `render()` but silently dropped — never passed to `RenderContext`
- Now threads `storage` through to context and calls `file.upload(ctx.storage)` right after file creation when no URL exists

## Root cause

The FAL provider downloads image bytes and discards the original URL (to conform to vercel ai sdk's `GeneratedFile` interface which has no `url` field). The renderers then create `File.fromGenerated()` and cast to `{ url?: string }` to read a URL that doesn't exist — silently getting `undefined` → `null`.

The cache layer uploads to R2 on `set()` but returns the **original** result object without backfilling the URL. So only on cache **hit** (second render) do URLs appear.

## Changes

- `context.ts` — add `storage?: StorageProvider` to `RenderContext`
- `render.ts` — pass `options.storage` to context
- `image.ts` / `video.ts` — upload file if no URL and storage available

## Test plan

- [ ] first render of image-only pipeline → all `files[].url` should be non-null
- [ ] first render of video pipeline → same
- [ ] second render (cache hit) → URLs still work, no double upload (`file.upload()` is a no-op when URL exists)

Fixes vargHQ/render#32

🤖 Generated with [Claude Code](https://claude.com/claude-code)