### PR TITLE
feat(packshot): support video backgrounds

### DIFF
--- a/src/react/renderers/packshot.ts
+++ b/src/react/renderers/packshot.ts
@@ -11,11 +11,13 @@ import type {
   PositionObject,
   SizeValue,
   TitleLayer,
+  VideoLayer,
 } from "../../ai-sdk/providers/editly/types";
 import type { PackshotProps, VargElement } from "../types";
 import type { RenderContext } from "./context";
 import { renderImage } from "./image";
 import { createBlinkingButton } from "./packshot/blinking-button";
+import { renderVideo } from "./video";
 
 /**
  * Resolve an FFmpegOutput to a string path/URL via the backend.
@@ -118,8 +120,23 @@ export async function renderPackshot(
         type: "fill-color" as const,
         color: props.background,
       });
+    } else if (props.background.type === "video") {
+      const bgFile = await renderVideo(
+        props.background as VargElement<"video">,
+        ctx,
+      );
+      const bgPath = await ctx.backend.resolvePath(bgFile);
+      const videoLayer: VideoLayer = {
+        type: "video",
+        path: bgPath,
+        resizeMode: "cover",
+      };
+      layers.push(videoLayer);
     } else {
-      const bgFile = await renderImage(props.background, ctx);
+      const bgFile = await renderImage(
+        props.background as VargElement<"image">,
+        ctx,
+      );
       const bgPath = await ctx.backend.resolvePath(bgFile);
       layers.push({
         type: "image" as const,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -207,7 +207,16 @@ export interface SwipeProps extends BaseProps {
 }
 
 export interface PackshotProps extends BaseProps {
-  background?: VargElement<"image"> | string;
+  /**
+   * Packshot background.
+   *
+   * - `string` — treated as a solid fill color (e.g. `"#000000"`).
+   * - `VargElement<"image">` — a generated or static image, rendered and
+   *   used as a full-bleed cover background.
+   * - `VargElement<"video">` — a generated or static video, rendered and
+   *   used as a looping full-bleed cover background.
+   */
+  background?: VargElement<"image"> | VargElement<"video"> | string;
   logo?: string;
   /**
    * Logo position on screen.


### PR DESCRIPTION
## Summary

- Add `VargElement<"video">` to the `PackshotProps.background` type, alongside the existing `VargElement<"image">` and `string` (fill color) options
- Video elements are rendered via `renderVideo()` and passed to editly as a `VideoLayer` with `resizeMode: "cover"`, matching the existing image background behaviour
- Add JSDoc to the `background` prop documenting all three variants

## Usage

```tsx
const vid = Video({ src: "path/to/clip.mp4" });
// or generated:
const vid = Video({ prompt: { text: "...", images: [img] }, model, duration: 5 });

<Packshot
  background={vid}
  logo="logo.png"
  cta="TRY IT NOW"
  blinkCta={true}
  duration={5}
/>
```

## Changes

- `src/react/types.ts` — expand `background` union type + JSDoc
- `src/react/renderers/packshot.ts` — import `renderVideo`, add video branch in background resolution