### PR TITLE
fix: unify ElevenLabs voice defaults and fix naming discrepancies

### DIFF
--- a/src/ai-sdk/providers/elevenlabs.ts
+++ b/src/ai-sdk/providers/elevenlabs.ts
@@ -14,7 +14,8 @@ import type { MusicModelV3, MusicModelV3CallOptions } from "../music-model";
 const VOICES: Record<string, string> = {
   rachel: "21m00Tcm4TlvDq8ikWAM",
   domi: "AZnzlk1XvdvUeBnXmlld",
-  bella: "EXAVITQu4vr4xnSDxMaL",
+  sarah: "EXAVITQu4vr4xnSDxMaL",
+  bella: "EXAVITQu4vr4xnSDxMaL", // alias — ElevenLabs calls this voice "Sarah"
   antoni: "ErXwobaYiN019PkySvjV",
   elli: "MF3mGyEYCl7XYWbV9V6O",
   josh: "TxGEqnHWrfWFTfGW9XjX",

--- a/src/core/schema/shared.ts
+++ b/src/core/schema/shared.ts
@@ -25,9 +25,12 @@ export type Resolution = z.infer<typeof resolutionSchema>;
 export const voiceNameSchema = z.enum([
   "rachel",
   "domi",
-  "bella",
+  "sarah",
+  "bella", // alias for sarah
   "antoni",
+  "elli",
   "josh",
+  "arnold",
   "adam",
   "sam",
 ]);

--- a/src/providers/elevenlabs.ts
+++ b/src/providers/elevenlabs.ts
@@ -190,7 +190,8 @@ export class ElevenLabsProvider extends BaseProvider {
 export const VOICES = {
   RACHEL: "21m00Tcm4TlvDq8ikWAM",
   DOMI: "AZnzlk1XvdvUeBnXmlld",
-  BELLA: "EXAVITQu4vr4xnSDxMaL",
+  SARAH: "EXAVITQu4vr4xnSDxMaL",
+  BELLA: "EXAVITQu4vr4xnSDxMaL", // alias — ElevenLabs calls this voice "Sarah"
   ANTONI: "ErXwobaYiN019PkySvjV",
   ELLI: "MF3mGyEYCl7XYWbV9V6O",
   JOSH: "TxGEqnHWrfWFTfGW9XjX",

--- a/src/react/renderers/speech.ts
+++ b/src/react/renderers/speech.ts
@@ -30,7 +30,7 @@ export async function renderSpeech(
   const { audio } = await generateSpeech({
     model,
     text,
-    voice: props.voice ?? "adam",
+    voice: props.voice ?? "rachel",
     cacheKey,
   } as Parameters<typeof generateSpeech>[0]);
 


### PR DESCRIPTION
## Summary
- Changes default voice in `<Speech>` renderer from `adam` to `rachel` to match all other defaults
- Adds `sarah` as primary name for voice ID `EXAVITQu4vr4xnSDxMaL` (matching ElevenLabs' actual name), keeps `bella` as backward-compatible alias
- Adds missing `elli` and `arnold` to `voiceNameSchema` Zod enum

## Context
The SDK had three inconsistencies in its ElevenLabs voice configuration:

1. **Default voice mismatch**: `<Speech>` defaulted to `adam` while SDK provider, gateway, CLI action, and voice action all defaulted to `rachel`
2. **Naming discrepancy**: Voice ID `EXAVITQu4vr4xnSDxMaL` was called `bella` in the SDK but `sarah` in the landing page (and by ElevenLabs itself)
3. **Schema gaps**: `elli` and `arnold` existed in voice ID maps but were missing from the Zod `voiceNameSchema`, preventing type-safe usage

## Files changed
- `src/react/renderers/speech.ts` — default voice `adam` → `rachel`
- `src/ai-sdk/providers/elevenlabs.ts` — add `sarah` as primary, keep `bella` as alias
- `src/providers/elevenlabs.ts` — same for core provider VOICES constant
- `src/core/schema/shared.ts` — add `sarah`, `elli`, `arnold` to voiceNameSchema

## Part of
ElevenLabs plan-limit refactor (Phase 3). See also:
- Gateway: vargHQ/gateway — `feature/elevenlabs-voice-registry`