### PR TITLE
feat(title): add optional text outline (border) props

### DIFF
--- a/src/ai-sdk/providers/editly/layers.ts
+++ b/src/ai-sdk/providers/editly/layers.ts
@@ -642,9 +642,13 @@ export function getTitleFilter(
     ? `:fontfile='${escapeDrawText(layer.fontPath)}'`
     : "";
   const fontFamily = layer.fontFamily ? `:font='${layer.fontFamily}'` : "";
+  const border =
+    layer.outline != null
+      ? `:borderw=${layer.outline}:bordercolor=${layer.outlineColor ?? "black"}`
+      : "";
   const enable = getEnableExpr(layer.start, layer.stop, clipDuration ?? 9999);
 
-  return `[${baseLabel}]drawtext=text='${text}':fontsize=${fontSize}:fontcolor=${color}:x=${x}:y=${y}${fontFile}${fontFamily}${enable}`;
+  return `[${baseLabel}]drawtext=text='${text}':fontsize=${fontSize}:fontcolor=${color}:x=${x}:y=${y}${border}${fontFile}${fontFamily}${enable}`;
 }
 
 export function getSubtitleFilter(

--- a/src/ai-sdk/providers/editly/types.ts
+++ b/src/ai-sdk/providers/editly/types.ts
@@ -87,6 +87,8 @@ export interface TextLayer extends BaseLayer {
   textColor?: string;
   fontPath?: string;
   fontFamily?: string;
+  outline?: number;
+  outlineColor?: string;
 }
 
 /**

--- a/src/react/renderers/title.ts
+++ b/src/react/renderers/title.ts
@@ -11,6 +11,8 @@ export function renderTitle(element: VargElement<"title">): TitleLayer {
     text,
     textColor: props.color,
     position: props.position,
+    outline: props.outline,
+    outlineColor: props.outlineColor,
     start: props.start,
     stop: props.end,
   };

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -158,6 +158,8 @@ export interface TalkingHeadProps extends BaseProps {
 export interface TitleProps extends BaseProps {
   position?: Position;
   color?: string;
+  outline?: number;
+  outlineColor?: string;
   start?: number;
   end?: number;
   children?: string;


### PR DESCRIPTION
## Summary

- Add optional `outline` and `outlineColor` props to the `<Title>` component
- Maps to ffmpeg's `borderw` and `bordercolor` drawtext parameters for text readability over video

## Usage

```tsx
<Title position="center" color="#ffffff" outline={3} outlineColor="black">
  this changed my brain chemistry
</Title>
```

Both props are optional. When `outline` is not set, no border is rendered (backwards compatible). When `outline` is set but `outlineColor` is omitted, defaults to `"black"`.

## Changes

- `editly/types.ts` — Added `outline?: number` and `outlineColor?: string` to `TextLayer`
- `react/types.ts` — Added `outline?: number` and `outlineColor?: string` to `TitleProps`
- `react/renderers/title.ts` — Plumb new props through to editly layer
- `editly/layers.ts` — Apply `borderw`/`bordercolor` in `getTitleFilter()` when outline is set

Resolves #136