### PR TITLE
feat: add nano-banana-2, qwen-image-2, recraft-v4-pro, and reve image models

### DIFF
--- a/src/ai-sdk/providers/fal.ts
+++ b/src/ai-sdk/providers/fal.ts
@@ -175,9 +175,20 @@ const IMAGE_MODELS: Record<string, string> = {
   "recraft-v3": "fal-ai/recraft/v3/text-to-image",
   "nano-banana-pro": "fal-ai/nano-banana-pro",
   "nano-banana-pro/edit": "fal-ai/nano-banana-pro/edit",
+  "nano-banana-2": "fal-ai/nano-banana-2/edit",
+  "nano-banana-2/edit": "fal-ai/nano-banana-2/edit",
   "seedream-v4.5/edit": "fal-ai/bytedance/seedream/v4.5/edit",
+  // Qwen Image 2 - text-to-image and image-to-image editing (standard + pro)
+  "qwen-image-2": "fal-ai/qwen-image-2/text-to-image",
+  "qwen-image-2/edit": "fal-ai/qwen-image-2/edit",
+  "qwen-image-2-pro": "fal-ai/qwen-image-2/pro/text-to-image",
+  "qwen-image-2-pro/edit": "fal-ai/qwen-image-2/pro/edit",
   // Qwen Image Edit 2511 Multiple Angles - camera angle adjustment
   "qwen-angles": "fal-ai/qwen-image-edit-2511-multiple-angles",
+  // Recraft V4 Pro - text-to-image
+  "recraft-v4-pro": "fal-ai/recraft/v4/pro/text-to-image",
+  // Reve - image editing
+  "reve/edit": "fal-ai/reve/edit",
 };
 
 // Models that use image_size instead of aspect_ratio
@@ -186,10 +197,18 @@ const IMAGE_SIZE_MODELS = new Set([
   "flux-dev",
   "flux-pro",
   "seedream-v4.5/edit",
+  "qwen-image-2",
+  "qwen-image-2/edit",
+  "qwen-image-2-pro",
+  "qwen-image-2-pro/edit",
+  "recraft-v4-pro",
 ]);
 
 // Qwen Angles model - image-to-image with camera angle adjustment
 const QWEN_ANGLES_MODEL = "qwen-angles";
+
+// Models that use singular image_url instead of image_urls array
+const SINGULAR_IMAGE_URL_MODELS = new Set(["reve/edit"]);
 
 // Map aspect ratio to image_size for Qwen Angles (base dimension 1024)
 const ASPECT_RATIO_TO_QWEN_SIZE: Record<
@@ -848,7 +867,13 @@ class FalImageModel implements ImageModelV3 {
         modelId: this.modelId,
         fileHashes,
       });
-      input.image_urls = await pMap(files, fileToUrl, { concurrency: 2 });
+      const imageUrls = await pMap(files, fileToUrl, { concurrency: 2 });
+      // Reve uses singular image_url instead of image_urls array
+      if (SINGULAR_IMAGE_URL_MODELS.has(this.modelId)) {
+        input.image_url = imageUrls[0];
+      } else {
+        input.image_urls = imageUrls;
+      }
     }
 
     if (isQwenAngles && !input.image_urls) {

--- a/src/definitions/models/index.ts
+++ b/src/definitions/models/index.ts
@@ -6,8 +6,12 @@ export { definition as elevenlabsTts } from "./elevenlabs";
 export { definition as flux } from "./flux";
 export { definition as kling } from "./kling";
 export { definition as llama } from "./llama";
+export { definition as nanoBanana2 } from "./nano-banana-2";
 export { definition as nanoBananaPro } from "./nano-banana-pro";
 export { definition as omnihuman } from "./omnihuman";
+export { definition as qwenImage2 } from "./qwen-image-2";
+export { definition as recraftV4 } from "./recraft-v4";
+export { definition as reve } from "./reve";
 export { definition as sonauto } from "./sonauto";
 export { definition as soul } from "./soul";
 export { definition as veedFabric } from "./veed-fabric";
@@ -19,8 +23,12 @@ import { definition as elevenlabsDefinition } from "./elevenlabs";
 import { definition as fluxDefinition } from "./flux";
 import { definition as klingDefinition } from "./kling";
 import { definition as llamaDefinition } from "./llama";
+import { definition as nanoBanana2Definition } from "./nano-banana-2";
 import { definition as nanoBananaProDefinition } from "./nano-banana-pro";
 import { definition as omnihumanDefinition } from "./omnihuman";
+import { definition as qwenImage2Definition } from "./qwen-image-2";
+import { definition as recraftV4Definition } from "./recraft-v4";
+import { definition as reveDefinition } from "./reve";
 import { definition as sonautoDefinition } from "./sonauto";
 import { definition as soulDefinition } from "./soul";
 import { definition as veedFabricDefinition } from "./veed-fabric";
@@ -31,6 +39,10 @@ export const allModels = [
   klingDefinition,
   fluxDefinition,
   nanoBananaProDefinition,
+  nanoBanana2Definition,
+  qwenImage2Definition,
+  recraftV4Definition,
+  reveDefinition,
   wanDefinition,
   omnihumanDefinition,
   veedFabricDefinition,

--- a/src/definitions/models/nano-banana-2.ts
+++ b/src/definitions/models/nano-banana-2.ts
@@ -1,0 +1,115 @@
+/**
+ * Nano Banana 2 image editing model (Google's next-gen image generation/editing)
+ * Edit-only model requiring image_urls input
+ */
+
+import { z } from "zod";
+import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+
+// Nano Banana 2 resolution options (includes 0.5K unlike nano-banana-pro)
+const nanoBanana2ResolutionSchema = z.enum(["0.5K", "1K", "2K", "4K"]);
+
+// Nano Banana 2 aspect ratio options (supports "auto" unlike nano-banana-pro)
+const nanoBanana2AspectRatioSchema = z.enum([
+  "auto",
+  "21:9",
+  "16:9",
+  "3:2",
+  "4:3",
+  "5:4",
+  "1:1",
+  "4:5",
+  "3:4",
+  "2:3",
+  "9:16",
+]);
+
+// Output format options
+const nanoBanana2OutputFormatSchema = z.enum(["png", "jpeg", "webp"]);
+
+// Safety tolerance level (string enum "1"-"6", unlike nano-banana-pro's semantic filter)
+const nanoBanana2SafetyToleranceSchema = z.enum(["1", "2", "3", "4", "5", "6"]);
+
+// Input schema with Zod
+const nanoBanana2InputSchema = z.object({
+  prompt: z.string().describe("Text description for image editing"),
+  image_urls: z
+    .array(z.string().url())
+    .describe(
+      "Input image URLs for image-to-image editing. Required for this model.",
+    ),
+  resolution: nanoBanana2ResolutionSchema
+    .default("1K")
+    .describe(
+      "Output resolution: 0.5K (512px), 1K (1024px), 2K (2048px), or 4K",
+    ),
+  aspect_ratio: nanoBanana2AspectRatioSchema
+    .default("auto")
+    .describe("Output aspect ratio. 'auto' preserves input aspect ratio."),
+  output_format: nanoBanana2OutputFormatSchema
+    .default("png")
+    .describe("Output image format"),
+  safety_tolerance: nanoBanana2SafetyToleranceSchema
+    .default("4")
+    .describe("Safety tolerance level: 1 (most strict) to 6 (least strict)"),
+  num_images: z
+    .number()
+    .int()
+    .min(1)
+    .max(4)
+    .default(1)
+    .describe("Number of images to generate (1-4)"),
+  seed: z
+    .number()
+    .int()
+    .optional()
+    .describe("Seed for the random number generator"),
+  limit_generations: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Limit generations from each round of prompting to 1. May affect quality.",
+    ),
+  enable_web_search: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Enable web search to use latest information for image generation",
+    ),
+});
+
+// Output schema with Zod
+const nanoBanana2OutputSchema = z.object({
+  images: z.array(
+    z.object({
+      url: z.string(),
+      file_name: z.string().optional(),
+      content_type: z.string().optional(),
+    }),
+  ),
+  description: z.string().optional(),
+});
+
+// Schema object for the definition
+const schema: ZodSchema<
+  typeof nanoBanana2InputSchema,
+  typeof nanoBanana2OutputSchema
+> = {
+  input: nanoBanana2InputSchema,
+  output: nanoBanana2OutputSchema,
+};
+
+export const definition: ModelDefinition<typeof schema> = {
+  type: "model",
+  name: "nano-banana-2",
+  description:
+    "Google Nano Banana 2 - next-gen image editing model. Requires image_urls for all operations.",
+  providers: ["fal"],
+  defaultProvider: "fal",
+  providerModels: {
+    fal: "fal-ai/nano-banana-2/edit",
+  },
+  schema,
+};
+
+export default definition;

--- a/src/definitions/models/qwen-image-2.ts
+++ b/src/definitions/models/qwen-image-2.ts
@@ -1,0 +1,113 @@
+/**
+ * Qwen Image 2 generation and editing model
+ * Next-generation unified generation-and-editing model from Alibaba
+ * Supports both text-to-image and image-to-image editing
+ * Available in standard and pro tiers
+ */
+
+import { z } from "zod";
+import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+
+// Image size can be an enum string or an object with width/height
+const qwenImage2ImageSizeSchema = z.union([
+  z.enum([
+    "square_hd",
+    "square",
+    "landscape_4_3",
+    "landscape_16_9",
+    "portrait_4_3",
+    "portrait_16_9",
+  ]),
+  z.object({
+    width: z.number().int().min(512).max(2048),
+    height: z.number().int().min(512).max(2048),
+  }),
+]);
+
+// Output format options
+const qwenImage2OutputFormatSchema = z.enum(["png", "jpeg", "webp"]);
+
+// Input schema with Zod
+const qwenImage2InputSchema = z.object({
+  prompt: z
+    .string()
+    .describe(
+      "Text description for generation or editing. Supports Chinese and English.",
+    ),
+  negative_prompt: z
+    .string()
+    .default("")
+    .describe("Content to avoid in the generated image. Max 500 characters."),
+  image_size: qwenImage2ImageSizeSchema
+    .optional()
+    .describe(
+      "Output image size. Can be an enum (e.g. 'square_hd') or {width, height} object. Pixels must be between 512x512 and 2048x2048.",
+    ),
+  image_urls: z
+    .array(z.string().url())
+    .optional()
+    .describe(
+      "Reference images for editing (1-6 images). Order matters: reference as 'image 1', 'image 2' in prompt. Required for /edit endpoints.",
+    ),
+  enable_prompt_expansion: z
+    .boolean()
+    .default(true)
+    .describe("Enable LLM prompt optimization for better results"),
+  seed: z
+    .number()
+    .int()
+    .min(0)
+    .max(2147483647)
+    .optional()
+    .describe("Random seed for reproducibility"),
+  enable_safety_checker: z
+    .boolean()
+    .default(true)
+    .describe("Enable content moderation for input and output"),
+  num_images: z
+    .number()
+    .int()
+    .min(1)
+    .max(6)
+    .default(1)
+    .describe("Number of images to generate (1-4 for t2i, 1-6 for edit)"),
+  output_format: qwenImage2OutputFormatSchema
+    .default("png")
+    .describe("Output image format"),
+});
+
+// Output schema with Zod
+const qwenImage2OutputSchema = z.object({
+  images: z.array(
+    z.object({
+      url: z.string(),
+      file_name: z.string().optional(),
+      content_type: z.string().optional(),
+    }),
+  ),
+  seed: z.number().int().optional(),
+});
+
+// Schema object for the definition
+const schema: ZodSchema<
+  typeof qwenImage2InputSchema,
+  typeof qwenImage2OutputSchema
+> = {
+  input: qwenImage2InputSchema,
+  output: qwenImage2OutputSchema,
+};
+
+export const definition: ModelDefinition<typeof schema> = {
+  type: "model",
+  name: "qwen-image-2",
+  description:
+    "Qwen Image 2.0 - next-gen unified generation-and-editing model. Supports text-to-image and image-to-image editing in standard and pro tiers.",
+  providers: ["fal"],
+  defaultProvider: "fal",
+  providerModels: {
+    fal: "fal-ai/qwen-image-2/text-to-image",
+  },
+  schema,
+};
+
+export default definition;

--- a/src/definitions/models/recraft-v4.ts
+++ b/src/definitions/models/recraft-v4.ts
@@ -1,0 +1,94 @@
+/**
+ * Recraft V4 Pro image generation model
+ * Built for brand systems and production-ready workflows
+ * Text-to-image only
+ */
+
+import { z } from "zod";
+import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+
+// Image size can be an enum string or an object with width/height
+const recraftV4ImageSizeSchema = z.union([
+  z.enum([
+    "square_hd",
+    "square",
+    "landscape_4_3",
+    "landscape_16_9",
+    "portrait_4_3",
+    "portrait_16_9",
+  ]),
+  z.object({
+    width: z.number().int(),
+    height: z.number().int(),
+  }),
+]);
+
+// RGB color schema
+const rgbColorSchema = z.object({
+  r: z.number().int().min(0).max(255),
+  g: z.number().int().min(0).max(255),
+  b: z.number().int().min(0).max(255),
+});
+
+// Output format - Recraft V4 outputs webp by default
+const recraftV4OutputFormatSchema = z.enum(["png", "jpeg", "webp"]);
+
+// Input schema with Zod
+const recraftV4InputSchema = z.object({
+  prompt: z.string().describe("Text description for image generation"),
+  image_size: recraftV4ImageSizeSchema
+    .default("square_hd")
+    .describe(
+      "Output image size. Can be an enum (e.g. 'landscape_16_9') or {width, height} object.",
+    ),
+  colors: z
+    .array(rgbColorSchema)
+    .default([])
+    .describe("Array of preferable RGB colors for the generated image"),
+  background_color: rgbColorSchema
+    .optional()
+    .describe("Preferable background color of the generated image"),
+  enable_safety_checker: z
+    .boolean()
+    .default(true)
+    .describe("Enable content safety checker"),
+  output_format: recraftV4OutputFormatSchema
+    .optional()
+    .describe("Output image format"),
+});
+
+// Output schema with Zod
+const recraftV4OutputSchema = z.object({
+  images: z.array(
+    z.object({
+      url: z.string(),
+      file_name: z.string().optional(),
+      file_size: z.number().optional(),
+      content_type: z.string().optional(),
+    }),
+  ),
+});
+
+// Schema object for the definition
+const schema: ZodSchema<
+  typeof recraftV4InputSchema,
+  typeof recraftV4OutputSchema
+> = {
+  input: recraftV4InputSchema,
+  output: recraftV4OutputSchema,
+};
+
+export const definition: ModelDefinition<typeof schema> = {
+  type: "model",
+  name: "recraft-v4-pro",
+  description:
+    "Recraft V4 Pro - professional text-to-image model built for brand systems and production-ready workflows. Strong composition, refined lighting, realistic materials.",
+  providers: ["fal"],
+  defaultProvider: "fal",
+  providerModels: {
+    fal: "fal-ai/recraft/v4/pro/text-to-image",
+  },
+  schema,
+};
+
+export default definition;

--- a/src/definitions/models/reve.ts
+++ b/src/definitions/models/reve.ts
@@ -1,0 +1,66 @@
+/**
+ * Reve image editing model
+ * Upload an existing image and transform it via a text prompt
+ * Edit-only model using singular image_url (not image_urls array)
+ */
+
+import { z } from "zod";
+import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+
+// Output format options
+const reveOutputFormatSchema = z.enum(["png", "jpeg", "webp"]);
+
+// Input schema with Zod
+const reveInputSchema = z.object({
+  prompt: z
+    .string()
+    .describe("Text description of how to edit the provided image"),
+  image_url: z
+    .string()
+    .url()
+    .describe(
+      "URL of the reference image to edit. Supports PNG, JPEG, WebP, AVIF, and HEIF formats.",
+    ),
+  num_images: z
+    .number()
+    .int()
+    .min(1)
+    .max(4)
+    .default(1)
+    .describe("Number of images to generate (1-4)"),
+  output_format: reveOutputFormatSchema
+    .default("png")
+    .describe("Output image format"),
+});
+
+// Output schema with Zod
+const reveOutputSchema = z.object({
+  images: z.array(
+    z.object({
+      url: z.string(),
+      file_name: z.string().optional(),
+      content_type: z.string().optional(),
+    }),
+  ),
+});
+
+// Schema object for the definition
+const schema: ZodSchema<typeof reveInputSchema, typeof reveOutputSchema> = {
+  input: reveInputSchema,
+  output: reveOutputSchema,
+};
+
+export const definition: ModelDefinition<typeof schema> = {
+  type: "model",
+  name: "reve",
+  description:
+    "Reve edit model - upload an existing image and transform it via a text prompt. Uses singular image_url input.",
+  providers: ["fal"],
+  defaultProvider: "fal",
+  providerModels: {
+    fal: "fal-ai/reve/edit",
+  },
+  schema,
+};
+
+export default definition;

--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -54,6 +54,23 @@ export class FalProvider extends BaseProvider {
         return "fal-ai/nano-banana-pro/edit";
       }
     }
+    // Nano Banana 2: always route to /edit endpoint (edit-only model)
+    if (model === "fal-ai/nano-banana-2") {
+      return "fal-ai/nano-banana-2/edit";
+    }
+    // Qwen Image 2: route to /edit endpoint when image_urls are provided
+    if (model === "fal-ai/qwen-image-2/text-to-image") {
+      const imageUrls = inputs.image_urls as string[] | undefined;
+      if (imageUrls && imageUrls.length > 0) {
+        return "fal-ai/qwen-image-2/edit";
+      }
+    }
+    if (model === "fal-ai/qwen-image-2/pro/text-to-image") {
+      const imageUrls = inputs.image_urls as string[] | undefined;
+      if (imageUrls && imageUrls.length > 0) {
+        return "fal-ai/qwen-image-2/pro/edit";
+      }
+    }
     return model;
   }
 


### PR DESCRIPTION
## Summary

- Add **nano-banana-2** (Google's next-gen image editing model) — edit-only, both `nano-banana-2` and `nano-banana-2/edit` aliases route to `fal-ai/nano-banana-2/edit`. New params: `safety_tolerance` (1-6), `resolution` incl. 0.5K, `limit_generations`, `enable_web_search`
- Add **qwen-image-2** (Alibaba's unified generation-and-editing model) — 4 variants: `qwen-image-2`, `qwen-image-2/edit`, `qwen-image-2-pro`, `qwen-image-2-pro/edit` with auto-routing from t2i to edit when `image_urls` provided. Uses `image_size` instead of `aspect_ratio`
- Add **recraft-v4-pro** (professional text-to-image for brand systems) — text-to-image only at `fal-ai/recraft/v4/pro/text-to-image`. Uses `image_size`, supports `colors` and `background_color` params
- Add **reve/edit** (image editing via text prompt) — uses singular `image_url` instead of `image_urls` array; added `SINGULAR_IMAGE_URL_MODELS` set for proper handling in FalImageModel

## Changes

### New files (4)
- `src/definitions/models/nano-banana-2.ts` — Zod schema + model definition
- `src/definitions/models/qwen-image-2.ts` — Zod schema + model definition
- `src/definitions/models/recraft-v4.ts` — Zod schema + model definition
- `src/definitions/models/reve.ts` — Zod schema + model definition

### Modified files (3)
- `src/definitions/models/index.ts` — register all 4 new models in exports + `allModels` array
- `src/providers/fal.ts` — add `resolveModelEndpoint()` routing for nano-banana-2 and qwen-image-2
- `src/ai-sdk/providers/fal.ts` — add `IMAGE_MODELS` entries, `IMAGE_SIZE_MODELS` for qwen/recraft, `SINGULAR_IMAGE_URL_MODELS` for reve, and image_url handling in `FalImageModel.doGenerate()`

## Testing

All 72 unit tests pass (`bun test`).