### PR TITLE
fix: export ELEVENLABS_DEFAULTS to prevent elevenlabs:undefined model IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "zod": "^4.2.1"
   },
   "sideEffects": false,
-  "version": "0.4.0-alpha64",
+  "version": "0.4.0-alpha66",
   "exports": {
     ".": "./src/index.ts",
     "./ai": "./src/ai-sdk/index.ts",

--- a/src/ai-sdk/file.ts
+++ b/src/ai-sdk/file.ts
@@ -268,6 +268,8 @@ export class File {
       "video/mp4": ".mp4",
       "video/webm": ".webm",
       "video/quicktime": ".mov",
+      "text/x-ssa": ".ass",
+      "application/x-subrip": ".srt",
     };
     return extMap[this._mediaType] ?? "";
   }
@@ -290,6 +292,9 @@ function inferMediaType(path: string): string {
     mp4: "video/mp4",
     webm: "video/webm",
     mov: "video/quicktime",
+    ass: "text/x-ssa",
+    ssa: "text/x-ssa",
+    srt: "application/x-subrip",
   };
   return mimeTypes[ext ?? ""] ?? "application/octet-stream";
 }

--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -64,6 +64,7 @@ export {
 } from "./providers/editly/rendi";
 export {
   createElevenLabs,
+  ELEVENLABS_DEFAULTS,
   type ElevenLabsProvider,
   elevenlabs,
   VOICES,

--- a/src/ai-sdk/providers/elevenlabs.ts
+++ b/src/ai-sdk/providers/elevenlabs.ts
@@ -168,6 +168,12 @@ export interface ElevenLabsProviderSettings {
   apiKey?: string;
 }
 
+/** Default model IDs used when callers omit the modelId argument. */
+export const ELEVENLABS_DEFAULTS = {
+  speechModel: "eleven_turbo_v2",
+  musicModel: "music_v1",
+} as const;
+
 export interface ElevenLabsProvider extends ProviderV3 {
   speechModel(modelId?: string): SpeechModelV3;
   musicModel(modelId?: string): MusicModelV3;
@@ -184,10 +190,10 @@ export function createElevenLabs(
 
   return {
     specificationVersion: "v3",
-    speechModel(modelId = "eleven_turbo_v2") {
+    speechModel(modelId = ELEVENLABS_DEFAULTS.speechModel) {
       return new ElevenLabsSpeechModel(modelId, client);
     },
-    musicModel(modelId = "music_v1") {
+    musicModel(modelId = ELEVENLABS_DEFAULTS.musicModel) {
       return new ElevenLabsMusicModel(modelId, client);
     },
     languageModel(modelId: string): LanguageModelV3 {


### PR DESCRIPTION
## Summary

- **Bug**: When template code calls `elevenlabs.musicModel()` or `elevenlabs.speechModel()` without arguments, the render service's `prefixedGateway` proxy produces `"elevenlabs:undefined"` as the model ID. This is because the proxy wraps the method with `(id: string) => gateway.musicModel(\`elevenlabs:${id}\`)` — no default parameter — so `id` is `undefined` when omitted.
- **Fix**: Export `ELEVENLABS_DEFAULTS` constants from the SDK (`speechModel: "eleven_turbo_v2"`, `musicModel: "music_v1"`) and use them both in `createElevenLabs()` and in the render proxy, keeping the source of truth in one place.
- Also adds `.ass`/`.ssa`/`.srt` MIME type mappings to `inferMediaType()` and `extensionFromMediaType()` for subtitle file uploads via rendi (from alpha65).

## Changes

- `src/ai-sdk/providers/elevenlabs.ts` — Add `ELEVENLABS_DEFAULTS` constant, use it in `createElevenLabs()` defaults
- `src/ai-sdk/index.ts` — Export `ELEVENLABS_DEFAULTS`
- `src/ai-sdk/file.ts` — Add subtitle MIME types
- `package.json` — Bump to `0.4.0-alpha66`

Published as `vargai@0.4.0-alpha66`.