### PR TITLE
fix: process all hoisted captions with per-clip timeline offsets

### DIFF
--- a/src/react/renderers/merge-ass.ts
+++ b/src/react/renderers/merge-ass.ts
@@ -80,9 +80,10 @@ export function mergeAssFiles(
 
     for (const styleLine of styleLines) {
       // Rename style: "Style: Default,..." -> "Style: Default_0,..."
+      // Use [^,]+ to handle style names that may contain spaces.
       const renamed = styleLine.replace(
-        /^Style:\s*(\S+?),/,
-        (_m, name: string) => `Style: ${name}${suffix},`,
+        /^Style:\s*([^,]+),/,
+        (_m, name: string) => `Style: ${name.trim()}${suffix},`,
       );
       allStyles.push(renamed);
     }

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -397,6 +397,14 @@ export async function renderRoot(
   const hoistedCaptionsResults: CaptionsResult[] = [];
   let mergedAssPath: string | undefined;
 
+  if (captionsResult && hoistedCaptions.length > 0) {
+    console.warn(
+      `\x1b[33m⚠ Found both a Render-level <Captions> and ${hoistedCaptions.length} clip-level <Captions>. ` +
+        "Clip-level captions will be ignored — move all <Captions> inside clips, " +
+        "or use a single <Captions> at the Render level.\x1b[0m",
+    );
+  }
+
   if (!captionsResult && hoistedCaptions.length > 0) {
     for (const { element: captionsElement, clipIndex } of hoistedCaptions) {
       const result = await renderCaptions(captionsElement, ctx);


### PR DESCRIPTION
## Summary

- **Bug**: When multiple `<Clip>` elements each have their own `<Captions src={speechN}>`, only the first clip's voiceover/captions were generated — the rest silently dropped
- **Root cause**: `hoistedCaptions[0]!` in `render.ts:235` picked only the first element; `captionsResult` was a scalar; audio was added at time 0:00 with no per-clip offset
- **Fix**: Process ALL hoisted captions, add each speech audio as an `audioTrack` with `start: clipStartOffset`, merge/shift ASS subtitle files so captions appear at the correct time

## Changes

### `src/react/renderers/render.ts`
- Hoisting now tracks `clipIndex` per caption (`{ element, clipIndex }[]` instead of flat array)
- Hoisted captions processing moved **after** clip timeline offsets are computed
- All hoisted captions rendered (not just `[0]`), each audio track gets `start` offset via editly's existing `adelay` support
- ASS files merged with time offsets or shifted for single-caption case
- `hasCaptions` and burn logic updated to use `finalAssPath` (Render-level OR merged hoisted)

### `src/react/renderers/merge-ass.ts` (new)
- `shiftAssTimestamps(assPath, offset)` — shifts all Dialogue timestamps in an ASS file
- `mergeAssFiles(segments, width, height)` — merges multiple ASS files with per-segment time offsets and renamed styles to avoid collisions

## Backward compatibility

- Render-level `<Captions>` (direct child of `<Render>`) works exactly as before
- Single hoisted caption from first clip (offset 0) produces identical output to before
- No user-facing API changes
- Same number of ffmpeg calls (2: editly + burn)

## Example

```tsx
<Render>
  <Music src="bg.mp3" />
  <Clip duration={8.5}>{vid1}<Captions src={speech1} style="tiktok" /></Clip>
  <Clip duration={8.2}>{vid2}<Captions src={speech2} style="tiktok" /></Clip>
  <Clip duration={8.8}>{vid3}<Captions src={speech3} style="tiktok" /></Clip>
  <Clip duration={8.3}>{vid4}<Captions src={speech4} style="tiktok" /></Clip>
</Render>
```

**Before**: Only speech1 generated, only clip 1 has captions  
**After**: All 4 speeches generated, all 4 subtitle tracks rendered at correct times