### PR TITLE
fix: default Grid/Split resize to 'cover' instead of 'contain'

### DIFF
--- a/src/react/examples/split-math-teacher.tsx
+++ b/src/react/examples/split-math-teacher.tsx
@@ -1,0 +1,74 @@
+/**
+ * Split layout example: math teacher with vertical split.
+ *
+ * Demonstrates that Split fills each region by default (resize="cover")
+ * — no black bars even when child aspect ratios differ from the split region.
+ */
+import { elevenlabs } from "../../ai-sdk/providers/elevenlabs";
+import { fal } from "../../ai-sdk/providers/fal";
+import { Clip, Image, Music, Render, render, Split, Title, Video } from "..";
+
+async function main() {
+  console.log("creating math teacher split screen...\n");
+
+  const mathImage = Image({
+    prompt:
+      "whiteboard with math problem: 2x + 5 = 13, solve for x, clean handwriting, chalk white on dark board, 8k",
+    model: fal.imageModel("nano-banana-pro"),
+    aspectRatio: "9:16",
+  });
+
+  const instructorImage = Image({
+    prompt:
+      "male math teacher in his 30s, friendly expression, standing in front of whiteboard, wearing blue button-up shirt, classroom setting, confident pose, professional, 8k photorealistic",
+    model: fal.imageModel("nano-banana-pro"),
+    aspectRatio: "9:16",
+  });
+
+  const mathVideo = Video({
+    prompt: {
+      text: "animated solution: equation appears, numbers highlight, arrow points to step 1: subtract 5 from both sides showing 2x = 8, step 2: divide by 2 showing x = 4, final answer glows",
+      images: [mathImage],
+    },
+    model: fal.videoModel("kling-v2.5"),
+    duration: 5,
+  });
+
+  const instructorVideo = Video({
+    prompt: {
+      text: "teacher gestures while speaking, points to side with hand, nods, explains with confident expression, hand movements match explanation",
+      images: [instructorImage],
+    },
+    model: fal.videoModel("kling-v2.5"),
+    duration: 5,
+  });
+
+  const video = (
+    <Render width={2160} height={1920}>
+      <Clip duration={5}>
+        <Split direction="vertical">{[mathVideo, instructorVideo]}</Split>
+        <Music
+          prompt="light upbeat educational background music, cheerful classroom vibe"
+          model={elevenlabs.musicModel()}
+          volume={0.2}
+          duration={5}
+        />
+        <Title position="top" color="#ffffff">
+          Solving Linear Equations
+        </Title>
+      </Clip>
+    </Render>
+  );
+
+  console.log("video tree:", JSON.stringify(video, null, 2));
+
+  const buffer = await render(video, {
+    output: "output/split-math-teacher.mp4",
+    cache: ".cache/ai",
+  });
+
+  console.log(`\ndone! ${buffer.video.byteLength} bytes`);
+  console.log("output: output/split-math-teacher.mp4");
+}
+
+main().catch(console.error);

--- a/src/react/layouts/grid.tsx
+++ b/src/react/layouts/grid.tsx
@@ -5,7 +5,7 @@ export const Grid = ({
   columns,
   rows,
   children,
-  resize = "contain",
+  resize = "cover",
 }: {
   columns?: number;
   rows?: number;

--- a/src/react/layouts/layouts.test.ts
+++ b/src/react/layouts/layouts.test.ts
@@ -232,11 +232,11 @@ describe("Grid", () => {
     expect(result[3]?.props.top).toBe("50%");
   });
 
-  test("defaults resize to contain", () => {
+  test("defaults resize to cover", () => {
     const children = [Video({ src: "a.mp4" })] as VargElement[];
     const result = asArray(Grid({ columns: 1, children }));
 
-    expect(result[0]?.props.resize).toBe("contain");
+    expect(result[0]?.props.resize).toBe("cover");
   });
 
   test("child resize overrides grid default", () => {


### PR DESCRIPTION
## Summary

- Changed `Grid` default `resize` from `"contain"` to `"cover"` so Split/Grid children fill their regions completely instead of showing black bars (letterboxing)
- Added `split-math-teacher.tsx` example demonstrating vertical split with 9:16 videos in a square canvas — no black bars

Resolves #152