### PR TITLE
feat: add varg provider for vargai/ai + remove hardcoded test key

### DIFF
--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -1,3 +1,5 @@
+// Re-export Vercel AI SDK media generation functions for convenience
+export { experimental_generateSpeech, generateImage } from "ai";
 export {
   type CacheStorage,
   clearCache,
@@ -99,6 +101,11 @@ export {
   createTogetherProvider,
   together,
 } from "./providers/together";
+export {
+  createVarg,
+  type VargProvider,
+  varg,
+} from "./providers/varg";
 export {
   falStorage,
   limitedRetryUpload,

--- a/src/ai-sdk/providers/varg.ts
+++ b/src/ai-sdk/providers/varg.ts
@@ -1,0 +1,404 @@
+import {
+  type EmbeddingModelV3,
+  type ImageModelV3,
+  type ImageModelV3CallOptions,
+  type LanguageModelV3,
+  NoSuchModelError,
+  type ProviderV3,
+  type SharedV3Warning,
+  type SpeechModelV3,
+  type SpeechModelV3CallOptions,
+} from "@ai-sdk/provider";
+import type { MusicModelV3, MusicModelV3CallOptions } from "../music-model";
+import type { VideoModelV3, VideoModelV3CallOptions } from "../video-model";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface VargProviderSettings {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface VargProvider extends ProviderV3 {
+  videoModel(modelId: string): VideoModelV3;
+  imageModel(modelId: string): ImageModelV3;
+  speechModel(modelId: string): SpeechModelV3;
+  musicModel(modelId: string): MusicModelV3;
+}
+
+// ---------------------------------------------------------------------------
+// Internal HTTP helpers
+// ---------------------------------------------------------------------------
+
+class VargAPIError extends Error {
+  constructor(
+    message: string,
+    public statusCode?: number,
+  ) {
+    super(message);
+    this.name = "VargAPIError";
+  }
+}
+
+function resolveConfig(settings: VargProviderSettings = {}) {
+  const apiKey = settings.apiKey ?? process.env.VARG_API_KEY ?? "";
+  const baseUrl = settings.baseUrl ?? "https://api.varg.ai/v1";
+  return { apiKey, baseUrl };
+}
+
+function getHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+async function submitJob(
+  baseUrl: string,
+  apiKey: string,
+  capability: "video" | "image" | "speech" | "music",
+  params: Record<string, unknown>,
+) {
+  const response = await fetch(`${baseUrl}/${capability}`, {
+    method: "POST",
+    headers: getHeaders(apiKey),
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    const raw = (await response.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    const errorData = ((raw?.error ?? raw) || {}) as { message?: string };
+    const msg = errorData?.message ?? `gateway returned ${response.status}`;
+    throw new VargAPIError(msg, response.status);
+  }
+
+  return (await response.json()) as {
+    job_id: string;
+    status: string;
+    output?: { url: string; media_type: string };
+  };
+}
+
+async function pollJob(
+  baseUrl: string,
+  apiKey: string,
+  jobId: string,
+  maxAttempts = 450,
+  intervalMs = 2000,
+) {
+  for (let i = 0; i < maxAttempts; i++) {
+    const res = await fetch(`${baseUrl}/jobs/${jobId}`, {
+      headers: getHeaders(apiKey),
+    });
+    if (!res.ok) {
+      throw new VargAPIError(
+        `failed to poll job ${jobId}: ${res.status}`,
+        res.status,
+      );
+    }
+    const job = (await res.json()) as {
+      job_id: string;
+      status: string;
+      output?: { url: string; media_type: string };
+      error?: string;
+    };
+    if (
+      job.status === "completed" ||
+      job.status === "failed" ||
+      job.status === "cancelled"
+    ) {
+      return job;
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new VargAPIError(`job ${jobId} did not complete within timeout`);
+}
+
+async function executeJob(
+  baseUrl: string,
+  apiKey: string,
+  capability: "video" | "image" | "speech" | "music",
+  params: Record<string, unknown>,
+): Promise<{ data: Uint8Array; mediaType: string; jobId: string }> {
+  const job = await submitJob(baseUrl, apiKey, capability, params);
+
+  // Completed synchronously (cache hit)
+  if (job.status === "completed" && job.output?.url) {
+    const res = await fetch(job.output.url);
+    if (!res.ok)
+      throw new VargAPIError(
+        `failed to download from ${job.output.url}: ${res.status}`,
+      );
+    return {
+      data: new Uint8Array(await res.arrayBuffer()),
+      mediaType: job.output.media_type,
+      jobId: job.job_id,
+    };
+  }
+
+  // Poll until done
+  const completed = await pollJob(baseUrl, apiKey, job.job_id);
+  if (completed.status === "failed") {
+    throw new VargAPIError(
+      `job ${completed.job_id} failed: ${completed.error || "unknown"}`,
+    );
+  }
+  if (!completed.output) {
+    throw new VargAPIError(`${capability} completed but no output`);
+  }
+
+  const res = await fetch(completed.output.url);
+  if (!res.ok) {
+    throw new VargAPIError(
+      `failed to download from ${completed.output.url}: ${res.status}`,
+    );
+  }
+  return {
+    data: new Uint8Array(await res.arrayBuffer()),
+    mediaType: completed.output.media_type,
+    jobId: job.job_id,
+  };
+}
+
+async function uploadFile(
+  baseUrl: string,
+  apiKey: string,
+  blob: Blob,
+  mediaType: string,
+): Promise<{ url: string }> {
+  const res = await fetch(`${baseUrl}/files`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": mediaType,
+    },
+    body: blob,
+  });
+  if (!res.ok) {
+    throw new VargAPIError(`file upload failed: ${res.status}`, res.status);
+  }
+  return (await res.json()) as { url: string };
+}
+
+// ---------------------------------------------------------------------------
+// Model implementations
+// ---------------------------------------------------------------------------
+
+class VargVideoModel implements VideoModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "varg";
+  readonly modelId: string;
+  readonly maxVideosPerCall = 1;
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor(modelId: string, baseUrl: string, apiKey: string) {
+    this.modelId = modelId;
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+  }
+
+  async doGenerate(options: VideoModelV3CallOptions) {
+    const warnings: SharedV3Warning[] = [];
+    const params: Record<string, unknown> = {
+      model: this.modelId,
+      prompt: options.prompt,
+    };
+    if (options.duration) params.duration = options.duration;
+    if (options.aspectRatio) params.aspect_ratio = options.aspectRatio;
+
+    if (options.files?.length) {
+      const fileUrls: { url: string }[] = [];
+      for (const f of options.files) {
+        if (f.type === "url") {
+          fileUrls.push({ url: (f as { type: "url"; url: string }).url });
+        } else if (f.type === "file") {
+          const fd = f as { type: "file"; data: Uint8Array; mediaType: string };
+          const uploaded = await uploadFile(
+            this.baseUrl,
+            this.apiKey,
+            new Blob([fd.data], { type: fd.mediaType }),
+            fd.mediaType,
+          );
+          fileUrls.push({ url: uploaded.url });
+        }
+      }
+      if (fileUrls.length) params.files = fileUrls;
+    }
+
+    if (options.providerOptions?.varg) {
+      params.provider_options = options.providerOptions.varg;
+    }
+
+    const result = await executeJob(this.baseUrl, this.apiKey, "video", params);
+    return {
+      videos: [result.data],
+      warnings,
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+    };
+  }
+}
+
+class VargImageModel implements ImageModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "varg";
+  readonly modelId: string;
+  readonly maxImagesPerCall = 1;
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor(modelId: string, baseUrl: string, apiKey: string) {
+    this.modelId = modelId;
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+  }
+
+  async doGenerate(options: ImageModelV3CallOptions) {
+    const warnings: SharedV3Warning[] = [];
+    const params: Record<string, unknown> = {
+      model: this.modelId,
+      prompt: options.prompt,
+    };
+    if (options.aspectRatio) params.aspect_ratio = options.aspectRatio;
+
+    if (options.files?.length) {
+      const fileUrls: { url: string }[] = [];
+      for (const f of options.files) {
+        if (f.type === "url") {
+          fileUrls.push({ url: (f as { type: "url"; url: string }).url });
+        } else if (f.type === "file") {
+          const fd = f as { type: "file"; data: Uint8Array; mediaType: string };
+          const uploaded = await uploadFile(
+            this.baseUrl,
+            this.apiKey,
+            new Blob([fd.data], { type: fd.mediaType }),
+            fd.mediaType,
+          );
+          fileUrls.push({ url: uploaded.url });
+        }
+      }
+      if (fileUrls.length) params.files = fileUrls;
+    }
+
+    if (options.providerOptions?.varg) {
+      params.provider_options = options.providerOptions.varg;
+    }
+
+    const result = await executeJob(this.baseUrl, this.apiKey, "image", params);
+    return {
+      images: [result.data],
+      warnings,
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+    };
+  }
+}
+
+class VargSpeechModel implements SpeechModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "varg";
+  readonly modelId: string;
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor(modelId: string, baseUrl: string, apiKey: string) {
+    this.modelId = modelId;
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+  }
+
+  async doGenerate(options: SpeechModelV3CallOptions) {
+    const warnings: SharedV3Warning[] = [];
+    const params: Record<string, unknown> = {
+      model: this.modelId,
+      text: options.text,
+    };
+    if (options.voice) params.voice = options.voice;
+
+    const result = await executeJob(
+      this.baseUrl,
+      this.apiKey,
+      "speech",
+      params,
+    );
+    return {
+      audio: result.data,
+      warnings,
+      response: { timestamp: new Date(), modelId: this.modelId },
+    };
+  }
+}
+
+class VargMusicModel implements MusicModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "varg";
+  readonly modelId: string;
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor(modelId: string, baseUrl: string, apiKey: string) {
+    this.modelId = modelId;
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+  }
+
+  async doGenerate(options: MusicModelV3CallOptions) {
+    const warnings: SharedV3Warning[] = [];
+    const params: Record<string, unknown> = {
+      model: this.modelId,
+      prompt: options.prompt,
+    };
+    if (options.duration) params.duration = options.duration;
+    if (options.providerOptions?.varg) {
+      params.provider_options = options.providerOptions.varg;
+    }
+
+    const result = await executeJob(this.baseUrl, this.apiKey, "music", params);
+    return {
+      audio: result.data,
+      warnings,
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory + singleton
+// ---------------------------------------------------------------------------
+
+export function createVarg(settings: VargProviderSettings = {}): VargProvider {
+  const { apiKey, baseUrl } = resolveConfig(settings);
+
+  return {
+    specificationVersion: "v3",
+    videoModel: (modelId) => new VargVideoModel(modelId, baseUrl, apiKey),
+    imageModel: (modelId) => new VargImageModel(modelId, baseUrl, apiKey),
+    speechModel: (modelId) => new VargSpeechModel(modelId, baseUrl, apiKey),
+    musicModel: (modelId) => new VargMusicModel(modelId, baseUrl, apiKey),
+    languageModel(modelId: string): LanguageModelV3 {
+      throw new NoSuchModelError({ modelId, modelType: "languageModel" });
+    },
+    embeddingModel(modelId: string): EmbeddingModelV3 {
+      throw new NoSuchModelError({ modelId, modelType: "embeddingModel" });
+    },
+  };
+}
+
+const varg_provider = createVarg();
+export { varg_provider as varg };

--- a/test-upload-binary.ts
+++ b/test-upload-binary.ts
@@ -1,0 +1,107 @@
+/**
+ * Test: upload a binary file to gateway and verify it's not corrupted.
+ * Tests the exact path: render → POST /v1/files → R2 → download → verify
+ *
+ * Usage:
+ *   bun run test-upload-binary.ts
+ */
+
+// Minimal valid PNG with bytes > 0x7F that would be corrupted by UTF-8 text conversion
+const PNG_HEADER = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02,
+  0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44,
+  0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00,
+  0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+const GATEWAY_URL =
+  process.env.GATEWAY_URL || "https://varg-gateway.fly.dev/v1";
+const API_KEY = process.env.VARG_API_KEY;
+if (!API_KEY) {
+  console.error("VARG_API_KEY env var is required.");
+  process.exit(1);
+}
+
+console.log(`Gateway: ${GATEWAY_URL}`);
+console.log(`PNG data: ${PNG_HEADER.length} bytes`);
+console.log(`First byte: 0x${PNG_HEADER[0]!.toString(16)} (should be 0x89)\n`);
+
+// Step 1: Upload binary file (same as VargClient.uploadFile)
+console.log("--- Step 1: Upload to gateway POST /v1/files ---");
+const blob = new Blob([PNG_HEADER], { type: "image/png" });
+
+const uploadRes = await fetch(`${GATEWAY_URL}/files`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${API_KEY}`,
+    "Content-Type": "image/png",
+  },
+  body: blob,
+});
+
+const uploadBody = (await uploadRes.json()) as {
+  url?: string;
+  size?: number;
+  error?: string;
+  message?: string;
+};
+console.log(`  HTTP ${uploadRes.status}`);
+console.log(`  ${JSON.stringify(uploadBody)}\n`);
+
+if (!uploadBody.url) {
+  console.error("Upload failed — no URL returned");
+  process.exit(1);
+}
+
+// Step 2: Download and verify
+console.log("--- Step 2: Download and verify ---");
+const downloadRes = await fetch(uploadBody.url);
+const downloadedBuffer = await downloadRes.arrayBuffer();
+const downloaded = new Uint8Array(downloadedBuffer);
+
+console.log(
+  `  Downloaded: ${downloaded.length} bytes (expected ${PNG_HEADER.length})`,
+);
+console.log(
+  `  First 3 bytes: ${Array.from(downloaded.slice(0, 3))
+    .map((b) => "0x" + b.toString(16).padStart(2, "0"))
+    .join(" ")}`,
+);
+console.log(`  Expected:      0x89 0x50 0x4e`);
+
+// Byte-by-byte comparison
+let corrupted = false;
+const corruptions: string[] = [];
+for (let i = 0; i < Math.max(PNG_HEADER.length, downloaded.length); i++) {
+  const orig = PNG_HEADER[i];
+  const dl = downloaded[i];
+  if (orig !== dl) {
+    corruptions.push(
+      `  byte[${i}]: original=0x${(orig ?? 0).toString(16).padStart(2, "0")} downloaded=0x${(dl ?? 0).toString(16).padStart(2, "0")}`,
+    );
+    corrupted = true;
+  }
+}
+
+if (corrupted) {
+  console.log(`\n  CORRUPTED — ${corruptions.length} byte mismatches:`);
+  for (const c of corruptions.slice(0, 10)) console.log(c);
+  if (corruptions.length > 10)
+    console.log(`  ... and ${corruptions.length - 10} more`);
+
+  const first3hex = Array.from(downloaded.slice(0, 3))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join(" ");
+  if (first3hex === "ef bf bd") {
+    console.log("\n  Pattern: 0x89 → EF BF BD (UTF-8 replacement character)");
+    console.log(
+      "  ROOT CAUSE: binary data was decoded as UTF-8 text somewhere in the upload pipeline",
+    );
+  }
+} else {
+  console.log("\n  FILE INTEGRITY OK — no corruption");
+}
+
+console.log("\n--- Done ---");


### PR DESCRIPTION
## Summary

- Add self-contained `varg` provider (`src/ai-sdk/providers/varg.ts`) implementing `ProviderV3` with video, image, speech, and music models
- Export `varg` singleton, `createVarg` factory, and `VargProvider` type from `vargai/ai`
- Re-export `generateImage` and `experimental_generateSpeech` from Vercel AI SDK for single-import DX
- Remove hardcoded `varg_test_key_12345` fallback from `test-upload-binary.ts`

## Usage

```ts
import { varg, generateImage } from "vargai/ai";

const result = await generateImage({
  model: varg.imageModel("flux-schnell"),
  prompt: "a cute robot waving hello",
});
```

## Tested
- Import resolution verified via Bun
- Model instantiation verified (video, image, speech, music + NoSuchModelError for language/embedding)
- End-to-end image generation via gateway confirmed working

## Related PRs
- vargHQ/gateway — adds `varg` singleton to `@vargai/gateway`
- vargHQ/render — removes hardcoded test keys from test scripts