### PR TITLE
feat: support voice_id passthrough and relax voice schemas

### DIFF
--- a/src/ai-sdk/providers/elevenlabs.ts
+++ b/src/ai-sdk/providers/elevenlabs.ts
@@ -11,6 +11,14 @@ import {
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { MusicModelV3, MusicModelV3CallOptions } from "../music-model";
 
+/**
+ * Curated name → voice_id mapping for backward-compatible friendly names.
+ * These are convenience aliases only — any valid ElevenLabs voice_id can be
+ * passed directly as the `voice` parameter and it will be forwarded as-is.
+ *
+ * For the full catalog of 600+ voices, use voice_id strings directly or
+ * call the gateway's GET /v1/voices endpoint to browse/search.
+ */
 const VOICES: Record<string, string> = {
   rachel: "21m00Tcm4TlvDq8ikWAM",
   domi: "AZnzlk1XvdvUeBnXmlld",

--- a/src/core/schema/shared.ts
+++ b/src/core/schema/shared.ts
@@ -21,7 +21,15 @@ export type VideoDurationString = z.infer<typeof videoDurationStringSchema>;
 export const resolutionSchema = z.enum(["480p", "720p", "1080p"]);
 export type Resolution = z.infer<typeof resolutionSchema>;
 
-// ElevenLabs preset voices
+// Voice parameter: accepts any voice name or ElevenLabs voice_id string.
+// ElevenLabs has 1000+ voices — pass a voice_id directly for full catalog access.
+// Common names ("rachel", "adam", etc.) are resolved to voice_ids automatically.
+export const voiceSchema = z
+  .string()
+  .min(1, "Voice name or voice_id cannot be empty");
+export type Voice = z.infer<typeof voiceSchema>;
+
+/** @deprecated Use voiceSchema instead. Kept for backward compatibility. */
 export const voiceNameSchema = z.enum([
   "rachel",
   "domi",
@@ -35,6 +43,21 @@ export const voiceNameSchema = z.enum([
   "sam",
 ]);
 export type VoiceName = z.infer<typeof voiceNameSchema>;
+
+// Well-known voice names for quick reference in skills/prompts.
+// These are convenience aliases — any valid ElevenLabs voice_id also works.
+export const WELL_KNOWN_VOICE_NAMES = [
+  "rachel",
+  "domi",
+  "sarah",
+  "bella",
+  "antoni",
+  "elli",
+  "josh",
+  "arnold",
+  "adam",
+  "sam",
+] as const;
 
 // Simplified voice set (commonly used in skills)
 export const simpleVoiceSchema = z.enum(["rachel", "sam", "adam", "josh"]);

--- a/src/definitions/actions/voice.ts
+++ b/src/definitions/actions/voice.ts
@@ -4,15 +4,17 @@
  */
 
 import { z } from "zod";
-import { filePathSchema, voiceNameSchema } from "../../core/schema/shared";
+import { filePathSchema, voiceSchema } from "../../core/schema/shared";
 import type { ActionDefinition, ZodSchema } from "../../core/schema/types";
 import { elevenlabsProvider, VOICES } from "../../providers/elevenlabs";
 import { storageProvider } from "../../providers/storage";
 
-// Input schema with Zod
+// Input schema with Zod — accepts any voice name or ElevenLabs voice_id
 const voiceInputSchema = z.object({
   text: z.string().describe("Text to convert to speech"),
-  voice: voiceNameSchema.default("rachel").describe("Voice to use"),
+  voice: voiceSchema
+    .default("rachel")
+    .describe("Voice name or ElevenLabs voice_id"),
   output: filePathSchema.optional().describe("Output file path"),
 });
 
@@ -58,10 +60,11 @@ export interface VoiceResult {
   uploadUrl?: string;
 }
 
-// Voice name to ID mapping
+// Voice name to ID mapping. Unknown names pass through as voice_ids.
 const VOICE_MAP: Record<string, string> = {
   rachel: VOICES.RACHEL,
   domi: VOICES.DOMI,
+  sarah: VOICES.SARAH,
   bella: VOICES.BELLA,
   antoni: VOICES.ANTONI,
   elli: VOICES.ELLI,

--- a/src/providers/elevenlabs.ts
+++ b/src/providers/elevenlabs.ts
@@ -186,7 +186,11 @@ export class ElevenLabsProvider extends BaseProvider {
   }
 }
 
-// Popular voices
+/**
+ * Curated voice_id constants for common ElevenLabs voices.
+ * For the full catalog of 600+ voices, use voice_ids directly or
+ * call the gateway's GET /v1/voices endpoint to browse/search.
+ */
 export const VOICES = {
   RACHEL: "21m00Tcm4TlvDq8ikWAM",
   DOMI: "AZnzlk1XvdvUeBnXmlld",


### PR DESCRIPTION
## Summary

- **Add `voiceSchema`** (`z.string().min(1)`) alongside the deprecated `voiceNameSchema` enum — accepts any voice name or ElevenLabs voice_id
- **Add `WELL_KNOWN_VOICE_NAMES`** constant for reference/autocomplete
- **Fix missing "sarah"** in the voice action's `VOICE_MAP`
- **Add JSDoc** to VOICES constants noting voice_id passthrough support
- Any valid ElevenLabs voice_id can now be used directly as the `voice` parameter

## Related PRs

- Gateway: vargHQ/gateway#62
- App: vargHQ/app — `feature/voice-registry-v2`

## Backward Compatibility

- `voiceNameSchema` is preserved (marked `@deprecated`)
- Existing code using `voice: "adam"` continues to work
- `simpleVoiceSchema` is unchanged (used by skills)
- The VOICES constant map is unchanged