### PR TITLE
fix: route sliceAudio through FFmpegBackend for cloud/Rendi support

### DIFF
--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -221,6 +221,10 @@ async function sliceSegments(
  *
  * Adds a small safety padding (50ms) to capture any trailing silence
  * that exists in the original audio beyond the segment boundary.
+ *
+ * Routes through the FFmpegBackend when available (local or cloud/Rendi),
+ * falling back to a direct local `ffmpeg` shell command only when no
+ * backend exists (top-level `await` outside render()).
  */
 const SLICE_PADDING_S = 0.05; // 50ms safety padding
 
@@ -234,18 +238,45 @@ async function sliceAudio(
   const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const outPath = `/tmp/varg-segment-${suffix}.mp3`;
 
-  const inputPath = ctx?.backend
-    ? await ctx.backend.resolvePath(file)
-    : await file.toTempFile();
+  if (ctx?.backend) {
+    // Use the backend abstraction (works for both local ffmpeg and cloud/Rendi).
+    // -ss goes in input options (before -i for fast seek).
+    const result = await ctx.backend.run({
+      inputs: [{ path: file, options: ["-ss", String(start)] }],
+      outputArgs: [
+        "-t",
+        String(duration),
+        "-acodec",
+        "libmp3lame",
+        "-q:a",
+        "2",
+      ],
+      outputPath: outPath,
+    });
 
-  // -ss before -i for fast seek, then re-encode for sample-accurate cut
+    // Rendi returns a URL, local backend returns a file path.
+    if (result.output.type === "url") {
+      const response = await fetch(result.output.url);
+      return new Uint8Array(await response.arrayBuffer());
+    }
+    const sliced = await Bun.file(result.output.path).arrayBuffer();
+    try {
+      await Bun.file(result.output.path).delete?.();
+    } catch {
+      /* ignore cleanup errors */
+    }
+    return new Uint8Array(sliced);
+  }
+
+  // Fallback: no backend (top-level `await` outside render()) — use local ffmpeg directly.
+  const inputPath = await file.toTempFile();
   await $`ffmpeg -y -ss ${start} -i ${inputPath} -t ${duration} -acodec libmp3lame -q:a 2 ${outPath}`.quiet();
 
   const sliced = await Bun.file(outPath).arrayBuffer();
   try {
     await Bun.file(outPath).delete?.();
   } catch {
-    /* ignore */
+    /* ignore cleanup errors */
   }
   return new Uint8Array(sliced);
 }


### PR DESCRIPTION
## Problem

`sliceAudio()` always used a local `ffmpeg` shell command (`$\`ffmpeg ...\``) regardless of the active backend. In the render service Docker container, `ffmpeg` is not installed — only `libvips-dev` is. This caused `Speech({ children: [...] })` with segments to fail with `command not found: ffmpeg` when submitted to the cloud render service.

The failure happens in two places:
1. **Validation phase** (route.ts) — `await tsxToElement(code)` fully executes user code including `await Speech(...)`, hitting the missing ffmpeg
2. **Worker phase** — even with Rendi backend in the ResolveContext, `sliceAudio` bypassed it

## Fix

`sliceAudio()` now routes through the `FFmpegBackend` abstraction when a `ResolveContext` is available:

- Uses `backend.run()` with `-ss` in input options and codec args in outputArgs
- Handles both Rendi output (URL → fetch bytes) and local output (file path → read bytes)
- Falls back to direct local `ffmpeg` only when no backend exists (top-level `await` outside `render()`)

The command shape maps exactly to the original:
```
ffmpeg -y -ss <start> -i <input> -t <duration> -acodec libmp3lame -q:a 2 <output>
```

## Testing

- `tsc --noEmit` clean
- 20 speech module tests pass
- Rendi `run()` interface verified: input options go before `-i`, outputArgs after inputs