### PR TITLE
fix: prevent text layer overlap during clip transitions

### DIFF
--- a/src/ai-sdk/providers/editly/index.ts
+++ b/src/ai-sdk/providers/editly/index.ts
@@ -419,6 +419,8 @@ interface TimedTextLayer {
   layer: TextLayer;
   startTime: number;
   duration: number;
+  transitionInDuration: number;
+  transitionOutDuration: number;
 }
 
 function collectTextLayers(clips: ProcessedClip[]): TimedTextLayer[] {
@@ -429,12 +431,19 @@ function collectTextLayers(clips: ProcessedClip[]): TimedTextLayer[] {
     const clip = clips[i];
     if (!clip) continue;
 
+    const transitionInDuration =
+      i > 0 ? (clips[i - 1]?.transition.duration ?? 0) : 0;
+    const transitionOutDuration =
+      i < clips.length - 1 ? clip.transition.duration : 0;
+
     for (const layer of clip.layers) {
       if (layer && isTextOverlayLayer(layer)) {
         textLayers.push({
           layer: layer as TextLayer,
           startTime: currentTime,
           duration: clip.duration,
+          transitionInDuration,
+          transitionOutDuration,
         });
       }
     }
@@ -845,13 +854,23 @@ export async function editly(config: EditlyConfig): Promise<EditlyResult> {
       const timedLayer = textLayers[i];
       if (!timedLayer) continue;
 
-      const { layer, startTime, duration } = timedLayer;
+      const {
+        layer,
+        startTime,
+        duration,
+        transitionInDuration,
+        transitionOutDuration,
+      } = timedLayer;
       const outputLabel = `vwithtext${i}`;
+
+      // Shrink text visibility to avoid overlap during transitions
+      const effectiveStart = startTime + transitionInDuration;
+      const effectiveStop = startTime + duration - transitionOutDuration;
 
       const timedLayerWithEnable = {
         ...layer,
-        start: layer.start ?? startTime,
-        stop: layer.stop ?? startTime + duration,
+        start: layer.start != null ? layer.start + startTime : effectiveStart,
+        stop: layer.stop != null ? layer.stop + startTime : effectiveStop,
       };
 
       if (layer.type === "title") {


### PR DESCRIPTION
## Summary

- Text overlay layers (title, subtitle, news-title, slide-in-text) now account for transition durations when calculating their visibility window
- Previously, adjacent titles overlapped during xfade transitions because each text layer's `enable` expression used the full clip duration
- The fix shrinks each text layer's visible time range by starting after the incoming transition and ending before the outgoing transition

## Problem

When using `fadeblack` (or any xfade) transitions between clips, text layers from adjacent clips would overlap during the transition period. For example with a 0.8s fadeblack:

- Clip 1 title: `enable='between(t,0,5)'`
- Clip 2 title: `enable='between(t,4.2,9.2)'`
- **Overlap at t=4.2-5.0**: both titles visible simultaneously

## Fix

`collectTextLayers()` now tracks incoming/outgoing transition durations per clip. The enable timing is adjusted to:

- `effectiveStart = startTime + transitionInDuration`
- `effectiveStop = startTime + duration - transitionOutDuration`

After fix:
- Clip 1 title: `enable='between(t,0,4.2)'`
- Clip 2 title: `enable='between(t,5,8.4)'`
- **No overlap**: titles disappear before transitions begin

## Changed files

- `src/ai-sdk/providers/editly/index.ts`