### PR TITLE
feat: support <Overlay> inside <Clip> with start/end timing

### DIFF
--- a/src/ai-sdk/providers/editly/editly.test.ts
+++ b/src/ai-sdk/providers/editly/editly.test.ts
@@ -1409,4 +1409,114 @@ describe("editly", () => {
       }),
     ).rejects.toThrow("produced no video output");
   });
+
+  // Per-clip overlay tests (feature/per-clip-overlay)
+
+  test("clip-local video overlay with start/stop timing", async () => {
+    const outPath = "output/editly-test-clip-overlay-timing.mp4";
+    if (existsSync(outPath)) unlinkSync(outPath);
+
+    await editly({
+      outPath,
+      width: 1280,
+      height: 720,
+      fps: 30,
+      clips: [
+        {
+          duration: 4,
+          layers: [
+            { type: "fill-color", color: "#1a1a2e" },
+            {
+              type: "video",
+              path: VIDEO_1,
+              width: "30%",
+              height: "30%",
+              left: "68%",
+              top: "2%",
+              start: 1,
+              stop: 3,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(existsSync(outPath)).toBe(true);
+    const info = await ffprobe(outPath);
+    expect(info.duration).toBeCloseTo(4, 0);
+  });
+
+  test("clip-local image overlay with start/stop timing", async () => {
+    const outPath = "output/editly-test-clip-image-overlay-timing.mp4";
+    if (existsSync(outPath)) unlinkSync(outPath);
+
+    await editly({
+      outPath,
+      width: 1280,
+      height: 720,
+      fps: 30,
+      clips: [
+        {
+          duration: 4,
+          layers: [
+            { type: "fill-color", color: "#1a1a2e" },
+            {
+              type: "image-overlay",
+              path: IMAGE_SQUARE,
+              position: "top-right",
+              width: "20%",
+              start: 1,
+              stop: 3,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(existsSync(outPath)).toBe(true);
+    const info = await ffprobe(outPath);
+    expect(info.duration).toBeCloseTo(4, 0);
+  });
+
+  test("clip-local overlay only appears in its clip, not in others", async () => {
+    const outPath = "output/editly-test-clip-overlay-scoped.mp4";
+    if (existsSync(outPath)) unlinkSync(outPath);
+
+    await editly({
+      outPath,
+      width: 1280,
+      height: 720,
+      fps: 30,
+      clips: [
+        {
+          duration: 2,
+          layers: [{ type: "fill-color", color: "#ff0000" }],
+          transition: { name: "fade", duration: 0.3 },
+        },
+        {
+          duration: 2,
+          layers: [
+            { type: "fill-color", color: "#00ff00" },
+            {
+              type: "image-overlay",
+              path: IMAGE_SQUARE,
+              position: "center",
+              width: "30%",
+              start: 0.5,
+              stop: 1.5,
+            },
+          ],
+          transition: { name: "fade", duration: 0.3 },
+        },
+        {
+          duration: 2,
+          layers: [{ type: "fill-color", color: "#0000ff" }],
+        },
+      ],
+    });
+
+    expect(existsSync(outPath)).toBe(true);
+    const info = await ffprobe(outPath);
+    expect(info.duration).toBeGreaterThan(4);
+  });
 });

--- a/src/ai-sdk/providers/editly/index.ts
+++ b/src/ai-sdk/providers/editly/index.ts
@@ -168,6 +168,15 @@ function isImageOverlayLayer(layer: Layer): boolean {
   return layer.type === "image-overlay";
 }
 
+/**
+ * Clip-local image overlay: has start/stop timing (from <Overlay start end> inside <Clip>).
+ * These should be composited within their clip with enable expressions.
+ */
+function isClipLocalImageOverlay(layer: Layer): boolean {
+  if (!isImageOverlayLayer(layer)) return false;
+  return layer.start !== undefined || layer.stop !== undefined;
+}
+
 function isOverlayLayer(layer: Layer): boolean {
   return isVideoOverlayLayer(layer) || isImageOverlayLayer(layer);
 }
@@ -216,6 +225,10 @@ function buildBaseClipFilter(
     (l) => l && isClipLocalVideoOverlay(l),
   ) as VideoLayer[];
 
+  const clipLocalImageOverlays = clip.layers.filter(
+    (l) => l && isClipLocalImageOverlay(l),
+  ) as ImageOverlayLayer[];
+
   for (let i = 0; i < baseLayers.length; i++) {
     const layer = baseLayers[i];
     if (!layer) continue;
@@ -253,7 +266,10 @@ function buildBaseClipFilter(
     }
   }
 
-  if (!baseLabel && clipLocalOverlays.length > 0) {
+  if (
+    !baseLabel &&
+    (clipLocalOverlays.length > 0 || clipLocalImageOverlays.length > 0)
+  ) {
     const fillFilter = getFillColorFilter(
       { type: "fill-color", color: "#000000" },
       inputIdx,
@@ -295,8 +311,46 @@ function buildBaseClipFilter(
       width,
       height,
       outputLabel,
+      clip.duration,
     );
     filters.push(positionFilter);
+    baseLabel = outputLabel;
+    inputIdx++;
+  }
+
+  // Composite clip-local image overlays (from <Overlay start end> inside <Clip>)
+  for (let i = 0; i < clipLocalImageOverlays.length; i++) {
+    const layer = clipLocalImageOverlays[i];
+    if (!layer) continue;
+
+    if (!baseLabel) {
+      throw new Error(
+        `Clip ${clipIndex} is missing a base layer for image overlay placement`,
+      );
+    }
+
+    const imgFilter = getImageOverlayFilter(
+      layer,
+      inputIdx,
+      width,
+      height,
+      clip.duration,
+    );
+
+    inputs.push(layer.path);
+    filters.push(imgFilter.filterComplex);
+
+    const outputLabel = `clip${clipIndex}imgov${i}`;
+    const posFilter = getImageOverlayPositionFilter(
+      baseLabel,
+      imgFilter.outputLabel,
+      layer,
+      width,
+      height,
+      outputLabel,
+      clip.duration,
+    );
+    filters.push(posFilter);
     baseLabel = outputLabel;
     inputIdx++;
   }
@@ -356,7 +410,12 @@ function collectImageOverlays(
 
   for (const clip of clips) {
     for (const layer of clip.layers) {
-      if (layer && isImageOverlayLayer(layer)) {
+      // Skip clip-local image overlays (with start/stop) — they are composited per-clip
+      if (
+        layer &&
+        isImageOverlayLayer(layer) &&
+        !isClipLocalImageOverlay(layer)
+      ) {
         const imgLayer = layer as ImageOverlayLayer;
         const key = `${imgLayer.path}:${JSON.stringify(imgLayer.position ?? "")}:${imgLayer.width ?? ""}:${imgLayer.height ?? ""}`;
         const existing = overlays.get(key);

--- a/src/ai-sdk/providers/editly/layers.ts
+++ b/src/ai-sdk/providers/editly/layers.ts
@@ -247,6 +247,7 @@ export function getOverlayFilter(
   width: number,
   height: number,
   outputLabel: string,
+  clipDuration?: number,
 ): string {
   const baseX = layer.left !== undefined ? parseSize(layer.left, width) : 0;
   const baseY = layer.top !== undefined ? parseSize(layer.top, height) : 0;
@@ -266,7 +267,8 @@ export function getOverlayFilter(
     yExpr = `${baseY}-overlay_h`;
   }
 
-  return `[${baseLabel}][${overlayLabel}]overlay=${xExpr}:${yExpr}:shortest=1[${outputLabel}]`;
+  const enable = getEnableExpr(layer.start, layer.stop, clipDuration ?? 9999);
+  return `[${baseLabel}][${overlayLabel}]overlay=${xExpr}:${yExpr}:shortest=1${enable}[${outputLabel}]`;
 }
 
 export function getImageFilter(
@@ -594,9 +596,11 @@ export function getImageOverlayPositionFilter(
   width: number,
   height: number,
   outputLabel: string,
+  clipDuration?: number,
 ): string {
   const { x, y } = resolvePositionForOverlay(layer.position, width, height);
-  return `[${baseLabel}][${overlayLabel}]overlay=${x}:${y}:shortest=1[${outputLabel}]`;
+  const enable = getEnableExpr(layer.start, layer.stop, clipDuration ?? 9999);
+  return `[${baseLabel}][${overlayLabel}]overlay=${x}:${y}:shortest=1${enable}[${outputLabel}]`;
 }
 
 function getEnableExpr(

--- a/src/react/renderers/clip.ts
+++ b/src/react/renderers/clip.ts
@@ -12,6 +12,7 @@ import type {
   ClipProps,
   ImageProps,
   MusicProps,
+  OverlayProps,
   SpeechProps,
   VargElement,
   VargNode,
@@ -231,11 +232,79 @@ async function renderClipLayers(
       }
 
       case "overlay": {
-        console.warn(
-          "[varg] Warning: <Overlay> placed inside <Clip> will be ignored. " +
-            "Move <Overlay> to be a sibling of <Clip> inside <Render>. " +
-            "See: https://github.com/vargHQ/sdk/issues/45",
-        );
+        const overlayProps = element.props as OverlayProps;
+        for (const overlayChild of element.children) {
+          if (
+            !overlayChild ||
+            typeof overlayChild !== "object" ||
+            !("type" in overlayChild)
+          )
+            continue;
+          const overlayChildElement = overlayChild as VargElement;
+
+          if (overlayChildElement.type === "image") {
+            const hasPosition =
+              overlayProps.left !== undefined ||
+              overlayProps.top !== undefined ||
+              overlayProps.width !== undefined ||
+              overlayProps.height !== undefined;
+
+            pending.push({
+              type: "async",
+              promise: renderImage(
+                overlayChildElement as VargElement<"image">,
+                ctx,
+              )
+                .then((file) => ctx.backend.resolvePath(file))
+                .then((path) =>
+                  hasPosition
+                    ? ({
+                        type: "image-overlay",
+                        path,
+                        width: overlayProps.width,
+                        height: overlayProps.height,
+                        position: {
+                          x: overlayProps.left ?? 0,
+                          y: overlayProps.top ?? 0,
+                        },
+                        start: overlayProps.start,
+                        stop: overlayProps.end,
+                      } as ImageOverlayLayer)
+                    : ({
+                        type: "image",
+                        path,
+                        start: overlayProps.start,
+                        stop: overlayProps.end,
+                      } as ImageLayer),
+                ),
+            });
+          } else if (overlayChildElement.type === "video") {
+            pending.push({
+              type: "async",
+              promise: renderVideo(
+                overlayChildElement as VargElement<"video">,
+                ctx,
+              )
+                .then((file) => ctx.backend.resolvePath(file))
+                .then(
+                  (path) =>
+                    ({
+                      type: "video",
+                      path,
+                      mixVolume: overlayProps.keepAudio
+                        ? (overlayProps.volume ?? 1)
+                        : 0,
+                      left: overlayProps.left,
+                      top: overlayProps.top,
+                      width: overlayProps.width,
+                      height: overlayProps.height,
+                      start: overlayProps.start,
+                      stop: overlayProps.end,
+                    }) as VideoLayer,
+                ),
+            });
+          }
+        }
         break;
       }
     }

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -121,6 +121,10 @@ export interface ClipProps extends BaseProps {
 }
 
 export interface OverlayProps extends BaseProps, PositionProps, AudioProps {
+  /** Start time in seconds (relative to parent clip). Only used when inside a <Clip>. */
+  start?: number;
+  /** End time in seconds (relative to parent clip). Only used when inside a <Clip>. */
+  end?: number;
   children?: VargNode;
 }
 

--- a/src/react/warnings.test.ts
+++ b/src/react/warnings.test.ts
@@ -3,7 +3,7 @@ import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 
 describe("warnings", () => {
   test(
-    "issue #45: warns when Overlay is placed inside Clip",
+    "issue #45: Overlay inside Clip renders without warning",
     async () => {
       const script = `
 import { Clip, Image, Overlay, Render, render } from "./src/react/index";
@@ -45,8 +45,10 @@ await render(
       unlinkSync(tmpFile);
 
       const output = stdout + stderr;
-      expect(output).toContain("Overlay");
-      expect(output).toContain("Clip");
+      // <Overlay> inside <Clip> is now valid — no warning should be emitted
+      expect(output).not.toContain(
+        "<Overlay> placed inside <Clip> will be ignored",
+      );
       expect(existsSync("output/test-issue-45.mp4")).toBe(true);
     },
     { timeout: 15000 },


### PR DESCRIPTION
## Summary

- **Allow `<Overlay>` inside `<Clip>`** for per-segment control instead of only globally at `<Render>` level
- **Add `start`/`end` props** (seconds relative to clip) for intra-clip timing via FFmpeg `enable='between(t,start,end)'`
- **No breaking changes** — global `<Overlay>` at `<Render>` level continues working identically

## Usage

```tsx
// Per-clip overlay with timing (appears 1-3s within clip)
Clip({ duration: 5, children: [
  Image({ src: "background.mp4" }),
  Overlay({ left: "3%", top: "3%", width: "25%", start: 1, end: 3, children: [
    Image({ src: "badge.png" }),
  ]}),
]})

// Global overlay still works (unchanged)
Render({ children: [
  Clip({ ... }),
  Overlay({ left: "80%", top: "5%", width: "15%", children: [
    Image({ src: "watermark.png" }),
  ]}),
]})
```

## Changes

| File | Change |
|------|--------|
| `src/react/types.ts` | Added `start?: number`, `end?: number` to `OverlayProps` |
| `src/react/renderers/clip.ts` | Render `<Overlay>` children as positioned layers with timing (was: warning + ignore) |
| `src/ai-sdk/providers/editly/layers.ts` | `getOverlayFilter()` and `getImageOverlayPositionFilter()` now generate `enable` expressions |
| `src/ai-sdk/providers/editly/index.ts` | Clip-local image overlay compositing + skip in global `collectImageOverlays()` |
| `src/react/warnings.test.ts` | Updated issue #45 test (overlay inside clip is now valid) |
| `src/ai-sdk/providers/editly/editly.test.ts` | 3 new tests for per-clip overlay behavior |

## Verified

- TypeScript: 0 errors
- All existing tests pass (no regressions)
- Rendered demo video confirms overlay appears/disappears at correct times

Closes #45