### PR TITLE
chore: clean up npm bundle — exclude tests, examples, dev config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ coverage
 .idea
 .DS_Store
 .worktrees
+.vscode
 
 # Env
 .env
@@ -21,19 +22,53 @@ media/
 output/
 *.mp4
 
-# Dev scripts
-scripts/*
-!scripts/.gitkeep
+# Test files
+*.test.ts
+*.test.tsx
+.test-hooks.ts
+src/tests/
+test-*.ts
 test-*.tsx
-garry-tan-varg.tsx
+
+# Examples
+examples/
+src/ai-sdk/examples/
+src/react/examples/
+
+# Dev scripts & docs
+scripts/
+launch-videos/
+pipeline/
+ffmpeg/
+docs/
+skills/
+plan.md
+hello.tsx
+video.tsx
+CONTRIBUTING.md
+SKILLS.md
+STRUCTURE.md
+CLAUDE.md
+AGENTS.md
+
+# Dev config
+biome.json
+commitlint.config.js
+.size-limit.json
+tsconfig.cli.json
 
 # Git/CI
 .github/
 .husky/
 .claude/
+.opencode/
 .git/
 
 # Reference
 reference/
 sdk-py-reference
 __pycache__
+
+# Provider internal docs
+src/ai-sdk/providers/CONTRIBUTING.md
+src/ai-sdk/providers/editly/plan.md


### PR DESCRIPTION
## Summary

- Reduces published files from **293 to 178** and package size from **813KB to 675KB**
- Excludes test files (`*.test.ts`, `test-*.ts`, `src/tests/`), examples, launch-videos, pipeline cookbooks, dev configs (biome, commitlint, .size-limit), internal docs, and root-level dev scripts

## What was leaking

- `test-upload-binary.ts`, `test-nano-banana.ts`, `test-sync-v2.ts` — `.npmignore` only had `test-*.tsx`, not `test-*.ts`
- 18 `*.test.ts` files across the codebase
- `src/ai-sdk/examples/`, `src/react/examples/`, `examples/`
- `launch-videos/`, `pipeline/`, `docs/`, `skills/`, `ffmpeg/`
- `plan.md`, `CONTRIBUTING.md`, `SKILLS.md`, `STRUCTURE.md`, `CLAUDE.md`
- `biome.json`, `commitlint.config.js`, `.size-limit.json`