### PR TITLE
fix: resolve @vargai/gateway and vargai/* imports in bunx render

### DIFF
--- a/src/cli/commands/render.tsx
+++ b/src/cli/commands/render.tsx
@@ -75,7 +75,9 @@ async function loadComponent(filePath: string): Promise<VargElement> {
   const hasVargaiImport =
     source.includes("from 'vargai") ||
     source.includes('from "vargai') ||
-    source.includes("@jsxImportSource vargai");
+    source.includes("@jsxImportSource vargai") ||
+    source.includes('from "@vargai/gateway"') ||
+    source.includes("from '@vargai/gateway'");
 
   const hasRelativeImport =
     source.includes("from './") || source.includes('from "./');
@@ -94,12 +96,16 @@ async function loadComponent(filePath: string): Promise<VargElement> {
 
   if (hasVargaiImport) {
     const tmpFile = `${tmpDir}/${Date.now()}.tsx`;
-    // Resolve jsxImportSource pragma to absolute path so it works from the cache dir
+    // Resolve all vargai-related imports to absolute paths so they work from
+    // the bunx cache dir (where @vargai/gateway and vargai/* aren't installed)
     const runtimeDir = resolve(pkgDir, "src/react/runtime");
-    const resolvedSource = source.replace(
-      /@jsxImportSource\s+vargai/,
-      `@jsxImportSource ${runtimeDir}`,
-    );
+    const aiSdkDir = resolve(pkgDir, "src/ai-sdk/index.ts");
+    const reactDir = resolve(pkgDir, "src/react/index.ts");
+    const resolvedSource = source
+      .replace(/@jsxImportSource\s+vargai/, `@jsxImportSource ${runtimeDir}`)
+      .replace(/from\s+["']@vargai\/gateway["']/g, `from "${aiSdkDir}"`)
+      .replace(/from\s+["']vargai\/ai["']/g, `from "${aiSdkDir}"`)
+      .replace(/from\s+["']vargai\/react["']/g, `from "${reactDir}"`);
     await Bun.write(tmpFile, resolvedSource);
 
     try {


### PR DESCRIPTION
## Summary

- Fix `Cannot find module '@vargai/gateway'` when running `bunx vargai render`
- Rewrite all vargai-related import paths to absolute SDK paths in the CLI's `loadComponent()` temp-file pipeline

## Problem

`bunx vargai render hello.tsx` fails with:

```
Cannot find module '@vargai/gateway'
```

When `bunx` runs the CLI, it copies the SDK to a temp directory (e.g. `/private/var/folders/.../bunx-501-vargai@latest/...`). The CLI then copies the user's `.tsx` file to another temp dir for import rewriting. In that temp dir, `@vargai/gateway` isn't installed, so `import { createVarg } from "@vargai/gateway"` fails.

The CLI already handled this for the `@jsxImportSource vargai` JSX pragma by rewriting it to an absolute path. But it didn't handle `@vargai/gateway`, `vargai/ai`, or `vargai/react` imports.

## Fix

Extend the import rewriting in `loadComponent()` (`sdk/src/cli/commands/render.tsx`) to resolve **all** vargai-related imports to absolute paths pointing at the SDK's own source files:

| Import | Resolves to |
|--------|------------|
| `@jsxImportSource vargai` | `{pkgDir}/src/react/runtime` (existing) |
| `from "@vargai/gateway"` | `{pkgDir}/src/ai-sdk/index.ts` (new) |
| `from "vargai/ai"` | `{pkgDir}/src/ai-sdk/index.ts` (new) |
| `from "vargai/react"` | `{pkgDir}/src/react/index.ts` (new) |

Also extends `hasVargaiImport` detection to recognize `@vargai/gateway` imports, so they enter the temp-file rewriting pipeline.

## What this means

- `bunx vargai render hello.tsx` works regardless of whether the user has `@vargai/gateway` installed
- Templates using either `import { createVarg } from "@vargai/gateway"` or `import { createVarg } from "vargai/ai"` both work via `bunx`
- Cloud render (render.varg.ai) is unaffected — it strips all imports and injects globals via `buildScope()`
- No breaking changes

## Changes

- `src/cli/commands/render.tsx` — 1 file, ~12 lines changed