### PR TITLE
feat: add Phota models (text-to-image, edit, enhance)

### DIFF
--- a/src/ai-sdk/providers/fal.ts
+++ b/src/ai-sdk/providers/fal.ts
@@ -202,6 +202,10 @@ const IMAGE_MODELS: Record<string, string> = {
   "recraft-v4-pro": "fal-ai/recraft/v4/pro/text-to-image",
   // Reve - image editing
   "reve/edit": "fal-ai/reve/edit",
+  // Phota - personalized photo generation, editing, and enhancement
+  phota: "fal-ai/phota",
+  "phota/edit": "fal-ai/phota/edit",
+  "phota/enhance": "fal-ai/phota/enhance",
 };
 
 // Models that use image_size instead of aspect_ratio
@@ -221,7 +225,7 @@ const IMAGE_SIZE_MODELS = new Set([
 const QWEN_ANGLES_MODEL = "qwen-angles";
 
 // Models that use singular image_url instead of image_urls array
-const SINGULAR_IMAGE_URL_MODELS = new Set(["reve/edit"]);
+const SINGULAR_IMAGE_URL_MODELS = new Set(["reve/edit", "phota/enhance"]);
 
 // Map aspect ratio to image_size for Qwen Angles (base dimension 1024)
 const ASPECT_RATIO_TO_QWEN_SIZE: Record<

--- a/src/definitions/models/index.ts
+++ b/src/definitions/models/index.ts
@@ -9,6 +9,11 @@ export { definition as llama } from "./llama";
 export { definition as nanoBanana2 } from "./nano-banana-2";
 export { definition as nanoBananaPro } from "./nano-banana-pro";
 export { definition as omnihuman } from "./omnihuman";
+export {
+  photaDefinition as phota,
+  photaEditDefinition as photaEdit,
+  photaEnhanceDefinition as photaEnhance,
+} from "./phota";
 export { definition as qwenImage2 } from "./qwen-image-2";
 export { definition as recraftV4 } from "./recraft-v4";
 export { definition as reve } from "./reve";
@@ -26,6 +31,11 @@ import { definition as llamaDefinition } from "./llama";
 import { definition as nanoBanana2Definition } from "./nano-banana-2";
 import { definition as nanoBananaProDefinition } from "./nano-banana-pro";
 import { definition as omnihumanDefinition } from "./omnihuman";
+import {
+  photaDefinition,
+  photaEditDefinition,
+  photaEnhanceDefinition,
+} from "./phota";
 import { definition as qwenImage2Definition } from "./qwen-image-2";
 import { definition as recraftV4Definition } from "./recraft-v4";
 import { definition as reveDefinition } from "./reve";
@@ -42,6 +52,9 @@ export const allModels = [
   nanoBanana2Definition,
   qwenImage2Definition,
   recraftV4Definition,
+  photaDefinition,
+  photaEditDefinition,
+  photaEnhanceDefinition,
   reveDefinition,
   wanDefinition,
   omnihumanDefinition,

--- a/src/definitions/models/phota.ts
+++ b/src/definitions/models/phota.ts
@@ -1,0 +1,199 @@
+/**
+ * Phota image models — personalized photo generation, editing, and enhancement
+ * Three separate models:
+ *   - phota: text-to-image with profile-based personalization
+ *   - phota/edit: image editing with identity preservation
+ *   - phota/enhance: image enhancement with identity preservation
+ */
+
+import { z } from "zod";
+import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+
+// Shared enums
+const photaOutputFormatSchema = z.enum(["jpeg", "png", "webp"]);
+const photaResolutionSchema = z.enum(["1K", "4K"]);
+const photaAspectRatioSchema = z.enum([
+  "auto",
+  "1:1",
+  "16:9",
+  "4:3",
+  "3:4",
+  "9:16",
+]);
+
+// Shared output schema — all three endpoints return { images: [{ url }] }
+const photaOutputSchema = z.object({
+  images: z.array(
+    z.object({
+      url: z.string(),
+      file_name: z.string().optional(),
+      content_type: z.string().optional(),
+    }),
+  ),
+});
+
+// ---------------------------------------------------------------------------
+// Phota — text-to-image
+// ---------------------------------------------------------------------------
+
+const photaInputSchema = z.object({
+  prompt: z
+    .string()
+    .describe(
+      "Text description of the desired image. Use @Profile1, @Profile2, etc. to reference profiles.",
+    ),
+  num_images: z
+    .number()
+    .int()
+    .min(1)
+    .max(4)
+    .default(1)
+    .describe("Number of images to generate (1-4)"),
+  profile_ids: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Profile IDs for personalization. Tag them in the prompt as @Profile1, @Profile2, etc.",
+    ),
+  output_format: photaOutputFormatSchema
+    .default("jpeg")
+    .describe("Output image format"),
+  resolution: photaResolutionSchema
+    .default("1K")
+    .describe("Output resolution: 1K or 4K"),
+  aspect_ratio: photaAspectRatioSchema
+    .default("auto")
+    .describe("Output aspect ratio"),
+});
+
+const photaSchema: ZodSchema<
+  typeof photaInputSchema,
+  typeof photaOutputSchema
+> = {
+  input: photaInputSchema,
+  output: photaOutputSchema,
+};
+
+export const photaDefinition: ModelDefinition<typeof photaSchema> = {
+  type: "model",
+  name: "phota",
+  description:
+    "Phota text-to-image — personalized photograph generation with profile-based identity control.",
+  providers: ["fal"],
+  defaultProvider: "fal",
+  providerModels: {
+    fal: "fal-ai/phota",
+  },
+  schema: photaSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Phota Edit — image-to-image editing
+// ---------------------------------------------------------------------------
+
+const photaEditInputSchema = z.object({
+  prompt: z
+    .string()
+    .describe(
+      "Text description of the desired edit. Use @Profile1, @Profile2, etc. to reference profiles.",
+    ),
+  image_urls: z
+    .array(z.string())
+    .optional()
+    .describe("Image URLs to edit (up to 10 images)"),
+  num_images: z
+    .number()
+    .int()
+    .min(1)
+    .max(4)
+    .default(1)
+    .describe("Number of images to generate (1-4)"),
+  profile_ids: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Profile IDs for personalization. Tag them in the prompt as @Profile1, @Profile2, etc.",
+    ),
+  output_format: photaOutputFormatSchema
+    .default("jpeg")
+    .describe("Output image format"),
+  resolution: photaResolutionSchema
+    .default("1K")
+    .describe("Output resolution: 1K or 4K"),
+  aspect_ratio: photaAspectRatioSchema
+    .default("auto")
+    .describe("Output aspect ratio"),
+});
+
+const photaEditSchema: ZodSchema<
+  typeof photaEditInputSchema,
+  typeof photaOutputSchema
+> = {
+  input: photaEditInputSchema,
+  output: photaOutputSchema,
+};
+
+export const photaEditDefinition: ModelDefinition<typeof photaEditSchema> = {
+  type: "model",
+  name: "phota/edit",
+  description:
+    "Phota edit — personalized photo editing that preserves identity while erasing distractions.",
+  providers: ["fal"],
+  defaultProvider: "fal",
+  providerModels: {
+    fal: "fal-ai/phota/edit",
+  },
+  schema: photaEditSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Phota Enhance — image enhancement with identity preservation
+// ---------------------------------------------------------------------------
+
+const photaEnhanceInputSchema = z.object({
+  image_url: z
+    .string()
+    .describe("URL or Base64 data URI of the image to enhance"),
+  num_images: z
+    .number()
+    .int()
+    .min(1)
+    .max(4)
+    .default(1)
+    .describe("Number of images to generate (1-4)"),
+  profile_ids: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Profile IDs for identity preservation. Sent profiles are used as candidates.",
+    ),
+  output_format: photaOutputFormatSchema
+    .default("jpeg")
+    .describe("Output image format"),
+});
+
+const photaEnhanceSchema: ZodSchema<
+  typeof photaEnhanceInputSchema,
+  typeof photaOutputSchema
+> = {
+  input: photaEnhanceInputSchema,
+  output: photaOutputSchema,
+};
+
+export const photaEnhanceDefinition: ModelDefinition<
+  typeof photaEnhanceSchema
+> = {
+  type: "model",
+  name: "phota/enhance",
+  description:
+    "Phota enhance — upscale and enhance images while preserving identities.",
+  providers: ["fal"],
+  defaultProvider: "fal",
+  providerModels: {
+    fal: "fal-ai/phota/enhance",
+  },
+  schema: photaEnhanceSchema,
+};
+
+// Default export for the primary text-to-image model
+export default photaDefinition;


### PR DESCRIPTION
## Summary

- Add three new fal.ai Phota model integrations for personalized photo generation
- **`phota`** — text-to-image with profile-based identity control (`fal-ai/phota`)
- **`phota/edit`** — image editing with identity preservation (`fal-ai/phota/edit`)
- **`phota/enhance`** — image enhancement with identity preservation (`fal-ai/phota/enhance`)

## Changes

### New file
- `src/definitions/models/phota.ts` — Zod input/output schemas and `ModelDefinition` for all three models

### Modified files
- `src/definitions/models/index.ts` — exports + `allModels` array registration
- `src/ai-sdk/providers/fal.ts` — `IMAGE_MODELS` map entries + `phota/enhance` in `SINGULAR_IMAGE_URL_MODELS` (uses `image_url` not `image_urls`)

## Notes
- Companion gateway PR: https://github.com/vargHQ/gateway/pull/new/feature/add-phota-models
- Phota uses `aspect_ratio` natively, no `IMAGE_SIZE_MODELS` entry needed
- Pricing: $0.09/1K image, $0.18/4K image (edit + text-to-image), $0.13/image (enhance)