### PR TITLE
fix: add SDK-level caching for Speech and Music generation

### DIFF
--- a/src/react/renderers/cache.test.ts
+++ b/src/react/renderers/cache.test.ts
@@ -63,6 +63,8 @@ function createVideoModel(): VideoModelV3 {
 
 type GenerateImageOptions = Parameters<RenderContext["generateImage"]>[0];
 type GenerateVideoOptions = Parameters<RenderContext["generateVideo"]>[0];
+type GenerateSpeechOptions = Parameters<RenderContext["generateSpeech"]>[0];
+type GenerateMusicOptions = Parameters<RenderContext["generateMusic"]>[0];
 
 function createContext(
   cacheDir: string,
@@ -93,6 +95,27 @@ function createContext(
     };
   });
 
+  const generateSpeech = withCache(async (_opts: GenerateSpeechOptions) => {
+    return {
+      audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 4, 5, 6]) },
+      warnings: [],
+      responses: [],
+      providerMetadata: {},
+    };
+  });
+
+  const generateMusic = withCache(async (_opts: GenerateMusicOptions) => {
+    return {
+      audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 7, 8, 9]) },
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: "test-music",
+        headers: undefined,
+      },
+    };
+  });
+
   return {
     width: 1080,
     height: 1920,
@@ -100,12 +123,9 @@ function createContext(
     cache: storage,
     generateImage: generateImage as unknown as RenderContext["generateImage"],
     generateVideo: generateVideo as unknown as RenderContext["generateVideo"],
-    generateSpeech: (async () => {
-      throw new Error("generateSpeech not implemented in test");
-    }) as unknown as RenderContext["generateSpeech"],
-    generateMusic: (async () => {
-      throw new Error("generateMusic not implemented in test");
-    }) as unknown as RenderContext["generateMusic"],
+    generateSpeech:
+      generateSpeech as unknown as RenderContext["generateSpeech"],
+    generateMusic: generateMusic as unknown as RenderContext["generateMusic"],
     tempFiles: [],
     pendingFiles: new Map<string, Promise<File>>(),
     backend: localBackend,

--- a/src/react/renderers/cache.test.ts
+++ b/src/react/renderers/cache.test.ts
@@ -100,6 +100,12 @@ function createContext(
     cache: storage,
     generateImage: generateImage as unknown as RenderContext["generateImage"],
     generateVideo: generateVideo as unknown as RenderContext["generateVideo"],
+    generateSpeech: (async () => {
+      throw new Error("generateSpeech not implemented in test");
+    }) as unknown as RenderContext["generateSpeech"],
+    generateMusic: (async () => {
+      throw new Error("generateMusic not implemented in test");
+    }) as unknown as RenderContext["generateMusic"],
     tempFiles: [],
     pendingFiles: new Map<string, Promise<File>>(),
     backend: localBackend,

--- a/src/react/renderers/cache.test.ts
+++ b/src/react/renderers/cache.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ImageModelV3 } from "@ai-sdk/provider";
+import type { ImageModelV3, SpeechModelV3 } from "@ai-sdk/provider";
 import { withCache } from "../../ai-sdk/cache";
 import type { File } from "../../ai-sdk/file";
 import { fileCache } from "../../ai-sdk/file-cache";
+import type { MusicModelV3 } from "../../ai-sdk/music-model";
 import { localBackend } from "../../ai-sdk/providers/editly";
 import type { VideoModelV3 } from "../../ai-sdk/video-model";
-import { Image, Video } from "../elements";
+import { Image, Music, Speech, Video } from "../elements";
 import type { RenderContext } from "./context";
 import { renderImage } from "./image";
+import { renderMusic } from "./music";
+import { renderSpeech } from "./speech";
 import { renderVideo } from "./video";
 
 function makeTempDir(): string {
@@ -61,15 +64,57 @@ function createVideoModel(): VideoModelV3 {
   };
 }
 
+function createSpeechModel(): SpeechModelV3 {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "test-speech",
+    async doGenerate() {
+      return {
+        audio: new Uint8Array([0xff, 0xfb, 0x90, 4, 5, 6]),
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: "test-speech",
+          headers: undefined,
+        },
+      };
+    },
+  };
+}
+
+function createMusicModel(): MusicModelV3 {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "test-music",
+    async doGenerate() {
+      return {
+        audio: new Uint8Array([0xff, 0xfb, 0x90, 7, 8, 9]),
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: "test-music",
+          headers: undefined,
+        },
+      };
+    },
+  };
+}
+
 type GenerateImageOptions = Parameters<RenderContext["generateImage"]>[0];
 type GenerateVideoOptions = Parameters<RenderContext["generateVideo"]>[0];
 type GenerateSpeechOptions = Parameters<RenderContext["generateSpeech"]>[0];
 type GenerateMusicOptions = Parameters<RenderContext["generateMusic"]>[0];
 
-function createContext(
-  cacheDir: string,
-  counters: { imageCalls: number; videoCalls: number },
-): RenderContext {
+interface Counters {
+  imageCalls: number;
+  videoCalls: number;
+  speechCalls: number;
+  musicCalls: number;
+}
+
+function createContext(cacheDir: string, counters: Counters): RenderContext {
   const storage = fileCache({ dir: cacheDir });
 
   const generateImage = withCache(async (_opts: GenerateImageOptions) => {
@@ -96,6 +141,7 @@ function createContext(
   });
 
   const generateSpeech = withCache(async (_opts: GenerateSpeechOptions) => {
+    counters.speechCalls += 1;
     return {
       audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 4, 5, 6]) },
       warnings: [],
@@ -105,6 +151,7 @@ function createContext(
   });
 
   const generateMusic = withCache(async (_opts: GenerateMusicOptions) => {
+    counters.musicCalls += 1;
     return {
       audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 7, 8, 9]) },
       warnings: [],
@@ -133,13 +180,16 @@ function createContext(
   };
 }
 
+function zeroCounters(): Counters {
+  return { imageCalls: 0, videoCalls: 0, speechCalls: 0, musicCalls: 0 };
+}
+
 describe("render cache behavior", () => {
   test("reuses cached video across separate contexts when only trim/layout differ", async () => {
     const cacheDir = makeTempDir();
-    const counters = { imageCalls: 0, videoCalls: 0 };
+    const counters = zeroCounters();
 
     const model = createVideoModel();
-    const _imageModel = createImageModel();
 
     const base = Video({
       prompt: "walk forward",
@@ -174,9 +224,8 @@ describe("render cache behavior", () => {
 
   test("reuses cached image across separate contexts when only layout differs", async () => {
     const cacheDir = makeTempDir();
-    const counters = { imageCalls: 0, videoCalls: 0 };
+    const counters = zeroCounters();
 
-    const _videoModel = createVideoModel();
     const imageModel = createImageModel();
 
     const base = Image({
@@ -208,5 +257,162 @@ describe("render cache behavior", () => {
     }
 
     expect(counters.imageCalls).toBe(1);
+  });
+
+  test("reuses cached speech across separate contexts when only volume/id differ", async () => {
+    const cacheDir = makeTempDir();
+    const counters = zeroCounters();
+
+    const speechModel = createSpeechModel();
+
+    const base = Speech({
+      children: "Hello, welcome to the show!",
+      model: speechModel,
+      voice: "rachel",
+    });
+
+    // volume and id are excluded from cache key (IGNORED_PROPS_BY_TYPE)
+    const variant = Speech({
+      children: "Hello, welcome to the show!",
+      model: speechModel,
+      voice: "rachel",
+      volume: 0.5,
+      id: "intro-speech",
+    });
+
+    try {
+      const ctx1 = createContext(cacheDir, counters);
+      await renderSpeech(base, ctx1);
+
+      const ctx2 = createContext(cacheDir, counters);
+      await renderSpeech(variant, ctx2);
+    } finally {
+      cleanupTempDir(cacheDir);
+    }
+
+    expect(counters.speechCalls).toBe(1);
+  });
+
+  test("does not reuse cached speech when text differs", async () => {
+    const cacheDir = makeTempDir();
+    const counters = zeroCounters();
+
+    const speechModel = createSpeechModel();
+
+    const first = Speech({
+      children: "Hello, welcome!",
+      model: speechModel,
+      voice: "rachel",
+    });
+
+    const second = Speech({
+      children: "Goodbye, see you later!",
+      model: speechModel,
+      voice: "rachel",
+    });
+
+    try {
+      const ctx1 = createContext(cacheDir, counters);
+      await renderSpeech(first, ctx1);
+
+      const ctx2 = createContext(cacheDir, counters);
+      await renderSpeech(second, ctx2);
+    } finally {
+      cleanupTempDir(cacheDir);
+    }
+
+    expect(counters.speechCalls).toBe(2);
+  });
+
+  test("does not reuse cached speech when voice differs", async () => {
+    const cacheDir = makeTempDir();
+    const counters = zeroCounters();
+
+    const speechModel = createSpeechModel();
+
+    const first = Speech({
+      children: "Same text here",
+      model: speechModel,
+      voice: "rachel",
+    });
+
+    const second = Speech({
+      children: "Same text here",
+      model: speechModel,
+      voice: "josh",
+    });
+
+    try {
+      const ctx1 = createContext(cacheDir, counters);
+      await renderSpeech(first, ctx1);
+
+      const ctx2 = createContext(cacheDir, counters);
+      await renderSpeech(second, ctx2);
+    } finally {
+      cleanupTempDir(cacheDir);
+    }
+
+    expect(counters.speechCalls).toBe(2);
+  });
+
+  test("reuses cached music across separate contexts with identical params", async () => {
+    const cacheDir = makeTempDir();
+    const counters = zeroCounters();
+
+    const musicModel = createMusicModel();
+
+    const base = Music({
+      prompt: "upbeat electronic track",
+      model: musicModel,
+      duration: 30,
+    });
+
+    // Same prompt/model/duration — should hit cache
+    const duplicate = Music({
+      prompt: "upbeat electronic track",
+      model: musicModel,
+      duration: 30,
+    });
+
+    try {
+      const ctx1 = createContext(cacheDir, counters);
+      await renderMusic(base, ctx1);
+
+      const ctx2 = createContext(cacheDir, counters);
+      await renderMusic(duplicate, ctx2);
+    } finally {
+      cleanupTempDir(cacheDir);
+    }
+
+    expect(counters.musicCalls).toBe(1);
+  });
+
+  test("does not reuse cached music when prompt differs", async () => {
+    const cacheDir = makeTempDir();
+    const counters = zeroCounters();
+
+    const musicModel = createMusicModel();
+
+    const first = Music({
+      prompt: "upbeat electronic track",
+      model: musicModel,
+    });
+
+    const second = Music({
+      prompt: "calm piano melody",
+      model: musicModel,
+    });
+
+    try {
+      const ctx1 = createContext(cacheDir, counters);
+      await renderMusic(first, ctx1);
+
+      const ctx2 = createContext(cacheDir, counters);
+      await renderMusic(second, ctx2);
+    } finally {
+      cleanupTempDir(cacheDir);
+    }
+
+    expect(counters.musicCalls).toBe(2);
   });
 });

--- a/src/react/renderers/context.ts
+++ b/src/react/renderers/context.ts
@@ -1,6 +1,7 @@
-import type { generateImage } from "ai";
+import type { experimental_generateSpeech, generateImage } from "ai";
 import type { CacheStorage } from "../../ai-sdk/cache";
 import type { File } from "../../ai-sdk/file";
+import type { generateMusic } from "../../ai-sdk/generate-music";
 import type { generateVideo } from "../../ai-sdk/generate-video";
 import type { FFmpegBackend } from "../../ai-sdk/providers/editly/backends";
 import type { StorageProvider } from "../../ai-sdk/storage/types";
@@ -15,6 +16,8 @@ export interface RenderContext {
   storage?: StorageProvider;
   generateImage: typeof generateImage;
   generateVideo: typeof generateVideo;
+  generateSpeech: typeof experimental_generateSpeech;
+  generateMusic: typeof generateMusic;
   tempFiles: string[];
   progress?: ProgressTracker;
   pendingFiles: Map<string, Promise<File>>;

--- a/src/react/renderers/music.ts
+++ b/src/react/renderers/music.ts
@@ -1,9 +1,10 @@
 import { File } from "../../ai-sdk/file";
-import { generateMusic } from "../../ai-sdk/generate-music";
+import type { generateMusic } from "../../ai-sdk/generate-music";
 import { ResolvedElement } from "../resolved-element";
 import type { MusicProps, VargElement } from "../types";
 import type { RenderContext } from "./context";
 import { addTask, completeTask, startTask } from "./progress";
+import { computeCacheKey } from "./utils";
 
 export async function renderMusic(
   element: VargElement<"music">,
@@ -23,73 +24,50 @@ export async function renderMusic(
     throw new Error("Music requires prompt and model (or set defaults.music)");
   }
 
-  const cacheKey = JSON.stringify({
-    type: "music",
-    prompt,
-    model: model.modelId,
-    duration: props.duration,
-  });
+  const cacheKey = computeCacheKey(element);
+  const cacheKeyStr = JSON.stringify(cacheKey);
 
-  const modelId = model.modelId ?? "music";
-  const taskId = ctx.progress ? addTask(ctx.progress, "music", modelId) : null;
+  // Deduplicate concurrent renders of the same music element
+  const pendingRender = ctx.pendingFiles.get(cacheKeyStr);
+  if (pendingRender) {
+    return pendingRender;
+  }
 
-  const generateFn = async () => {
-    const result = await generateMusic({
+  const renderPromise = (async () => {
+    const modelId = model.modelId ?? "music";
+    const taskId = ctx.progress
+      ? addTask(ctx.progress, "music", modelId)
+      : null;
+    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+
+    const { audio } = await ctx.generateMusic({
       model,
       prompt,
       duration: props.duration,
-    });
-    return result.audio;
-  };
+      cacheKey,
+    } as Parameters<typeof generateMusic>[0]);
 
-  let audio: { uint8Array: Uint8Array; url?: string; mediaType?: string };
-
-  if (ctx.cache) {
-    const cached = await ctx.cache.get(cacheKey);
-    if (cached) {
-      const cachedAudio = cached as {
-        uint8Array: Uint8Array;
-        url?: string;
-        mediaType?: string;
-      };
-      audio = {
-        uint8Array: cachedAudio.uint8Array,
-        url: cachedAudio.url,
-        mediaType: cachedAudio.mediaType,
-      };
-      if (taskId && ctx.progress) {
-        startTask(ctx.progress, taskId);
-        completeTask(ctx.progress, taskId);
-      }
-    } else {
-      if (taskId && ctx.progress) startTask(ctx.progress, taskId);
-      audio = await generateFn();
-      if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
-      await ctx.cache.set(cacheKey, {
-        uint8Array: audio.uint8Array,
-        url: audio.url,
-        mediaType: audio.mediaType,
-      });
-    }
-  } else {
-    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
-    audio = await generateFn();
     if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
-  }
 
-  const mediaType = audio.mediaType ?? "audio/mpeg";
+    const mediaType =
+      (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 
-  const file = File.fromGenerated({
-    uint8Array: audio.uint8Array,
-    mediaType,
-    url: audio.url,
-  }).withMetadata({
-    type: "music",
-    model: modelId,
-    prompt,
-  });
+    const file = File.fromGenerated({
+      uint8Array: audio.uint8Array,
+      mediaType,
+      url: (audio as { url?: string }).url,
+    }).withMetadata({
+      type: "music",
+      model: modelId,
+      prompt,
+    });
 
-  ctx.generatedFiles.push(file);
+    ctx.generatedFiles.push(file);
 
-  return file;
+    return file;
+  })();
+
+  ctx.pendingFiles.set(cacheKeyStr, renderPromise);
+
+  return renderPromise;
 }

--- a/src/react/renderers/packshot.test.ts
+++ b/src/react/renderers/packshot.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ImageModelV3 } from "@ai-sdk/provider";
+import { withCache } from "../../ai-sdk/cache";
+import type { File } from "../../ai-sdk/file";
+import { fileCache } from "../../ai-sdk/file-cache";
+import { localBackend } from "../../ai-sdk/providers/editly";
+import { Image, Packshot } from "../elements";
+import type { RenderContext } from "./context";
+import { renderPackshot } from "./packshot";
+
+// Valid 4x4 red PNG generated via sharp — ffmpeg can decode this
+// prettier-ignore
+const PNG_4x4 = new Uint8Array([
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 4, 0,
+  0, 0, 4, 8, 2, 0, 0, 0, 38, 147, 9, 41, 0, 0, 0, 9, 112, 72, 89, 115, 0, 0, 3,
+  232, 0, 0, 3, 232, 1, 181, 123, 82, 107, 0, 0, 0, 17, 73, 68, 65, 84, 120,
+  156, 99, 248, 207, 192, 0, 71, 8, 22, 94, 14, 0, 174, 147, 15, 241, 166, 148,
+  72, 35, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+]);
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "varg-packshot-test-"));
+}
+
+function cleanupTempDir(dir: string) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Write a minimal valid PNG file and return its path. */
+function createTestPng(dir: string, name = "test-logo.png"): string {
+  const path = join(dir, name);
+  writeFileSync(path, PNG_4x4);
+  return path;
+}
+
+function createImageModel(): ImageModelV3 {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "test-image",
+    maxImagesPerCall: 1,
+    async doGenerate() {
+      return {
+        images: [PNG_4x4],
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: "test-image",
+          headers: undefined,
+        },
+      };
+    },
+  };
+}
+
+type GenerateImageOptions = Parameters<RenderContext["generateImage"]>[0];
+type GenerateVideoOptions = Parameters<RenderContext["generateVideo"]>[0];
+
+function createContext(
+  cacheDir: string,
+  counters: { imageCalls: number },
+): RenderContext {
+  const storage = fileCache({ dir: cacheDir });
+
+  const generateImage = withCache(async (_opts: GenerateImageOptions) => {
+    counters.imageCalls += 1;
+    return {
+      images: [
+        {
+          uint8Array: PNG_4x4,
+          mimeType: "image/png",
+        },
+      ],
+      warnings: [],
+    };
+  });
+
+  const generateVideo = withCache(async (_opts: GenerateVideoOptions) => {
+    const data = new Uint8Array([0]);
+    return {
+      video: { uint8Array: data, mimeType: "video/mp4" },
+      videos: [{ uint8Array: data, mimeType: "video/mp4" }],
+      warnings: [],
+    };
+  });
+
+  return {
+    width: 64,
+    height: 64,
+    fps: 1,
+    cache: storage,
+    generateImage: generateImage as unknown as RenderContext["generateImage"],
+    generateVideo: generateVideo as unknown as RenderContext["generateVideo"],
+    generateSpeech: (async () => {
+      throw new Error("generateSpeech not implemented in test");
+    }) as unknown as RenderContext["generateSpeech"],
+    generateMusic: (async () => {
+      throw new Error("generateMusic not implemented in test");
+    }) as unknown as RenderContext["generateMusic"],
+    tempFiles: [],
+    pendingFiles: new Map<string, Promise<File>>(),
+    backend: localBackend,
+    generatedFiles: [],
+  };
+}
+
+describe("renderPackshot", () => {
+  test(
+    "renders with string logo URL",
+    async () => {
+      const cacheDir = makeTempDir();
+      const counters = { imageCalls: 0 };
+
+      try {
+        const logoPath = createTestPng(cacheDir);
+        const ctx = createContext(cacheDir, counters);
+
+        const element = Packshot({
+          background: "#000000",
+          logo: logoPath,
+          duration: 1,
+        });
+
+        const result = await renderPackshot(element, ctx);
+
+        expect(typeof result).toBe("string");
+        expect(existsSync(result)).toBe(true);
+        // No AI generation needed for a string logo path
+        expect(counters.imageCalls).toBe(0);
+      } finally {
+        cleanupTempDir(cacheDir);
+      }
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "renders with VargElement<image> logo",
+    async () => {
+      const cacheDir = makeTempDir();
+      const counters = { imageCalls: 0 };
+      const imageModel = createImageModel();
+
+      try {
+        const ctx = createContext(cacheDir, counters);
+
+        const logo = Image({
+          prompt: "test logo",
+          model: imageModel,
+          aspectRatio: "1:1",
+        });
+
+        const element = Packshot({
+          background: "#000000",
+          logo: logo,
+          duration: 1,
+        });
+
+        const result = await renderPackshot(element, ctx);
+
+        expect(typeof result).toBe("string");
+        expect(existsSync(result)).toBe(true);
+        // generateImage should have been called once for the logo
+        expect(counters.imageCalls).toBe(1);
+      } finally {
+        cleanupTempDir(cacheDir);
+      }
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "renders with VargElement<image> background and VargElement<image> logo",
+    async () => {
+      const cacheDir = makeTempDir();
+      const counters = { imageCalls: 0 };
+      const imageModel = createImageModel();
+
+      try {
+        const ctx = createContext(cacheDir, counters);
+
+        const bg = Image({
+          prompt: "background image",
+          model: imageModel,
+          aspectRatio: "1:1",
+        });
+
+        const logo = Image({
+          prompt: "logo image",
+          model: imageModel,
+          aspectRatio: "1:1",
+        });
+
+        const element = Packshot({
+          background: bg,
+          logo: logo,
+          duration: 1,
+        });
+
+        const result = await renderPackshot(element, ctx);
+
+        expect(typeof result).toBe("string");
+        expect(existsSync(result)).toBe(true);
+        // Two generateImage calls: one for background, one for logo
+        expect(counters.imageCalls).toBe(2);
+      } finally {
+        cleanupTempDir(cacheDir);
+      }
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "renders without logo",
+    async () => {
+      const cacheDir = makeTempDir();
+      const counters = { imageCalls: 0 };
+
+      try {
+        const ctx = createContext(cacheDir, counters);
+
+        const element = Packshot({
+          background: "#FF0000",
+          duration: 1,
+        });
+
+        const result = await renderPackshot(element, ctx);
+
+        expect(typeof result).toBe("string");
+        expect(existsSync(result)).toBe(true);
+        expect(counters.imageCalls).toBe(0);
+      } finally {
+        cleanupTempDir(cacheDir);
+      }
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "throws on invalid logo type",
+    async () => {
+      const cacheDir = makeTempDir();
+      const counters = { imageCalls: 0 };
+
+      try {
+        const ctx = createContext(cacheDir, counters);
+
+        const element = Packshot({
+          background: "#000000",
+          logo: 12345 as unknown as string,
+          duration: 1,
+        });
+
+        await expect(renderPackshot(element, ctx)).rejects.toThrow();
+      } finally {
+        cleanupTempDir(cacheDir);
+      }
+    },
+    { timeout: 30_000 },
+  );
+});

--- a/src/react/renderers/packshot.test.ts
+++ b/src/react/renderers/packshot.test.ts
@@ -58,6 +58,8 @@ function createImageModel(): ImageModelV3 {
 
 type GenerateImageOptions = Parameters<RenderContext["generateImage"]>[0];
 type GenerateVideoOptions = Parameters<RenderContext["generateVideo"]>[0];
+type GenerateSpeechOptions = Parameters<RenderContext["generateSpeech"]>[0];
+type GenerateMusicOptions = Parameters<RenderContext["generateMusic"]>[0];
 
 function createContext(
   cacheDir: string,
@@ -87,6 +89,27 @@ function createContext(
     };
   });
 
+  const generateSpeech = withCache(async (_opts: GenerateSpeechOptions) => {
+    return {
+      audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 4, 5, 6]) },
+      warnings: [],
+      responses: [],
+      providerMetadata: {},
+    };
+  });
+
+  const generateMusic = withCache(async (_opts: GenerateMusicOptions) => {
+    return {
+      audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 7, 8, 9]) },
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: "test-music",
+        headers: undefined,
+      },
+    };
+  });
+
   return {
     width: 64,
     height: 64,
@@ -94,12 +117,9 @@ function createContext(
     cache: storage,
     generateImage: generateImage as unknown as RenderContext["generateImage"],
     generateVideo: generateVideo as unknown as RenderContext["generateVideo"],
-    generateSpeech: (async () => {
-      throw new Error("generateSpeech not implemented in test");
-    }) as unknown as RenderContext["generateSpeech"],
-    generateMusic: (async () => {
-      throw new Error("generateMusic not implemented in test");
-    }) as unknown as RenderContext["generateMusic"],
+    generateSpeech:
+      generateSpeech as unknown as RenderContext["generateSpeech"],
+    generateMusic: generateMusic as unknown as RenderContext["generateMusic"],
     tempFiles: [],
     pendingFiles: new Map<string, Promise<File>>(),
     backend: localBackend,

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -1,9 +1,14 @@
 import type { ImageModelV3 } from "@ai-sdk/provider";
-import { generateImage, wrapImageModel } from "ai";
+import {
+  generateImage,
+  experimental_generateSpeech as generateSpeech,
+  wrapImageModel,
+} from "ai";
 import pMap from "p-map";
 import { type CacheStorage, withCache } from "../../ai-sdk/cache";
 import type { File, File as VargFile } from "../../ai-sdk/file";
 import { fileCache } from "../../ai-sdk/file-cache";
+import { generateMusic } from "../../ai-sdk/generate-music";
 import { generateVideo } from "../../ai-sdk/generate-video";
 import {
   imagePlaceholderFallbackMiddleware,
@@ -109,6 +114,14 @@ export async function renderRoot(
     ? withCache(generateVideo, { storage: cacheStorage })
     : generateVideo;
 
+  const cachedGenerateSpeech = cacheStorage
+    ? withCache(generateSpeech, { storage: cacheStorage })
+    : generateSpeech;
+
+  const cachedGenerateMusic = cacheStorage
+    ? withCache(generateMusic, { storage: cacheStorage })
+    : generateMusic;
+
   const wrapGenerateImage: typeof generateImage = async (opts) => {
     if (mode === "preview") {
       trackPlaceholder("image");
@@ -158,6 +171,8 @@ export async function renderRoot(
     storage: options.storage,
     generateImage: wrapGenerateImage,
     generateVideo: wrapGenerateVideo,
+    generateSpeech: cachedGenerateSpeech,
+    generateMusic: cachedGenerateMusic,
     tempFiles,
     progress,
     pendingFiles: new Map<string, Promise<File>>(),

--- a/src/react/renderers/speech.ts
+++ b/src/react/renderers/speech.ts
@@ -28,20 +28,59 @@ export async function renderSpeech(
     throw new Error("Speech requires 'model' prop (or set defaults.speech)");
   }
 
-  const cacheKey = computeCacheKey(element);
+  const cacheKey = JSON.stringify({
+    type: "speech",
+    text,
+    model: typeof model === "string" ? model : model.modelId,
+    voice: props.voice ?? "rachel",
+  });
 
   const modelId = typeof model === "string" ? model : model.modelId;
   const taskId = ctx.progress ? addTask(ctx.progress, "speech", modelId) : null;
-  if (taskId && ctx.progress) startTask(ctx.progress, taskId);
 
-  const { audio } = await generateSpeech({
-    model,
-    text,
-    voice: props.voice ?? "rachel",
-    cacheKey,
-  } as Parameters<typeof generateSpeech>[0]);
+  const generateFn = async () => {
+    const result = await generateSpeech({
+      model,
+      text,
+      voice: props.voice ?? "rachel",
+    } as Parameters<typeof generateSpeech>[0]);
+    return result.audio;
+  };
 
-  if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+  let audio: { uint8Array: Uint8Array; url?: string; mediaType?: string };
+
+  if (ctx.cache) {
+    const cached = await ctx.cache.get(cacheKey);
+    if (cached) {
+      const cachedAudio = cached as {
+        uint8Array: Uint8Array;
+        url?: string;
+        mediaType?: string;
+      };
+      audio = {
+        uint8Array: cachedAudio.uint8Array,
+        url: cachedAudio.url,
+        mediaType: cachedAudio.mediaType,
+      };
+      if (taskId && ctx.progress) {
+        startTask(ctx.progress, taskId);
+        completeTask(ctx.progress, taskId);
+      }
+    } else {
+      if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+      audio = await generateFn();
+      if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+      await ctx.cache.set(cacheKey, {
+        uint8Array: audio.uint8Array,
+        url: (audio as { url?: string }).url,
+        mediaType: (audio as { mediaType?: string }).mediaType,
+      });
+    }
+  } else {
+    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+    audio = await generateFn();
+    if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
+  }
 
   const mediaType = (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 

--- a/src/react/renderers/speech.ts
+++ b/src/react/renderers/speech.ts
@@ -1,4 +1,4 @@
-import { experimental_generateSpeech as generateSpeech } from "ai";
+import type { experimental_generateSpeech } from "ai";
 import { File } from "../../ai-sdk/file";
 import { ResolvedElement } from "../resolved-element";
 import type { SpeechProps, VargElement } from "../types";
@@ -28,73 +28,50 @@ export async function renderSpeech(
     throw new Error("Speech requires 'model' prop (or set defaults.speech)");
   }
 
-  const cacheKey = JSON.stringify({
-    type: "speech",
-    text,
-    model: typeof model === "string" ? model : model.modelId,
-    voice: props.voice ?? "rachel",
-  });
+  const cacheKey = computeCacheKey(element);
+  const cacheKeyStr = JSON.stringify(cacheKey);
 
-  const modelId = typeof model === "string" ? model : model.modelId;
-  const taskId = ctx.progress ? addTask(ctx.progress, "speech", modelId) : null;
+  // Deduplicate concurrent renders of the same speech element
+  const pendingRender = ctx.pendingFiles.get(cacheKeyStr);
+  if (pendingRender) {
+    return pendingRender;
+  }
 
-  const generateFn = async () => {
-    const result = await generateSpeech({
+  const renderPromise = (async () => {
+    const modelId = typeof model === "string" ? model : model.modelId;
+    const taskId = ctx.progress
+      ? addTask(ctx.progress, "speech", modelId)
+      : null;
+    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
+
+    const { audio } = await ctx.generateSpeech({
       model,
       text,
       voice: props.voice ?? "rachel",
-    } as Parameters<typeof generateSpeech>[0]);
-    return result.audio;
-  };
+      cacheKey,
+    } as Parameters<typeof experimental_generateSpeech>[0]);
 
-  let audio: { uint8Array: Uint8Array; url?: string; mediaType?: string };
-
-  if (ctx.cache) {
-    const cached = await ctx.cache.get(cacheKey);
-    if (cached) {
-      const cachedAudio = cached as {
-        uint8Array: Uint8Array;
-        url?: string;
-        mediaType?: string;
-      };
-      audio = {
-        uint8Array: cachedAudio.uint8Array,
-        url: cachedAudio.url,
-        mediaType: cachedAudio.mediaType,
-      };
-      if (taskId && ctx.progress) {
-        startTask(ctx.progress, taskId);
-        completeTask(ctx.progress, taskId);
-      }
-    } else {
-      if (taskId && ctx.progress) startTask(ctx.progress, taskId);
-      audio = await generateFn();
-      if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
-      await ctx.cache.set(cacheKey, {
-        uint8Array: audio.uint8Array,
-        url: (audio as { url?: string }).url,
-        mediaType: (audio as { mediaType?: string }).mediaType,
-      });
-    }
-  } else {
-    if (taskId && ctx.progress) startTask(ctx.progress, taskId);
-    audio = await generateFn();
     if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
-  }
 
-  const mediaType = (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
+    const mediaType =
+      (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 
-  const file = File.fromGenerated({
-    uint8Array: audio.uint8Array,
-    mediaType,
-    url: (audio as { url?: string }).url,
-  }).withMetadata({
-    type: "speech",
-    model: modelId,
-    prompt: text,
-  });
+    const file = File.fromGenerated({
+      uint8Array: audio.uint8Array,
+      mediaType,
+      url: (audio as { url?: string }).url,
+    }).withMetadata({
+      type: "speech",
+      model: modelId,
+      prompt: text,
+    });
 
-  ctx.generatedFiles.push(file);
+    ctx.generatedFiles.push(file);
 
-  return file;
+    return file;
+  })();
+
+  ctx.pendingFiles.set(cacheKeyStr, renderPromise);
+
+  return renderPromise;
 }

--- a/src/react/renderers/talking-head.test.ts
+++ b/src/react/renderers/talking-head.test.ts
@@ -126,6 +126,12 @@ function createContext(
     cache: storage,
     generateImage: generateImage as unknown as RenderContext["generateImage"],
     generateVideo: generateVideo as unknown as RenderContext["generateVideo"],
+    generateSpeech: (async () => {
+      throw new Error("generateSpeech not implemented in test");
+    }) as unknown as RenderContext["generateSpeech"],
+    generateMusic: (async () => {
+      throw new Error("generateMusic not implemented in test");
+    }) as unknown as RenderContext["generateMusic"],
     tempFiles: [],
     pendingFiles: new Map<string, Promise<File>>(),
     backend: localBackend,

--- a/src/react/renderers/talking-head.test.ts
+++ b/src/react/renderers/talking-head.test.ts
@@ -83,6 +83,8 @@ function createSpeechModel(): SpeechModelV3 {
 
 type GenerateImageOptions = Parameters<RenderContext["generateImage"]>[0];
 type GenerateVideoOptions = Parameters<RenderContext["generateVideo"]>[0];
+type GenerateSpeechOptions = Parameters<RenderContext["generateSpeech"]>[0];
+type GenerateMusicOptions = Parameters<RenderContext["generateMusic"]>[0];
 
 function createContext(
   cacheDir: string,
@@ -119,6 +121,34 @@ function createContext(
     { storage },
   );
 
+  const generateSpeech = withCache(
+    async (_opts: GenerateSpeechOptions) => {
+      counters.speechCalls += 1;
+      return {
+        audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 4, 5, 6]) },
+        warnings: [],
+        responses: [],
+        providerMetadata: {},
+      };
+    },
+    { storage },
+  );
+
+  const generateMusic = withCache(
+    async (_opts: GenerateMusicOptions) => {
+      return {
+        audio: { uint8Array: new Uint8Array([0xff, 0xfb, 0x90, 7, 8, 9]) },
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: "test-music",
+          headers: undefined,
+        },
+      };
+    },
+    { storage },
+  );
+
   return {
     width: 1080,
     height: 1920,
@@ -126,12 +156,9 @@ function createContext(
     cache: storage,
     generateImage: generateImage as unknown as RenderContext["generateImage"],
     generateVideo: generateVideo as unknown as RenderContext["generateVideo"],
-    generateSpeech: (async () => {
-      throw new Error("generateSpeech not implemented in test");
-    }) as unknown as RenderContext["generateSpeech"],
-    generateMusic: (async () => {
-      throw new Error("generateMusic not implemented in test");
-    }) as unknown as RenderContext["generateMusic"],
+    generateSpeech:
+      generateSpeech as unknown as RenderContext["generateSpeech"],
+    generateMusic: generateMusic as unknown as RenderContext["generateMusic"],
     tempFiles: [],
     pendingFiles: new Map<string, Promise<File>>(),
     backend: localBackend,

--- a/src/react/renderers/utils.ts
+++ b/src/react/renderers/utils.ts
@@ -93,13 +93,14 @@ function serializeValue(v: unknown): string {
   }
   // ResolvedElement (e.g. a speech segment used as Video audio input):
   // serialize by content identity (type + text + duration), not binary data.
+  // Deliberately excludes file.url — upload URLs contain Date.now() + Math.random()
+  // and would make downstream cache keys (e.g. VEED video) non-deterministic.
   if (v instanceof ResolvedElement) {
     const parts = [v.type];
     for (const child of v.children) {
       if (typeof child === "string") parts.push(child);
     }
     if (v.meta.duration) parts.push(String(v.meta.duration));
-    if (v.meta.file?.url) parts.push(v.meta.file.url);
     return `resolved(${parts.join(",")})`;
   }
   if (isVargElement(v)) {

--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -15,7 +15,7 @@ import {
   experimental_generateSpeech as generateSpeechAI,
 } from "ai";
 import { $ } from "bun";
-import { type CacheStorage, withCache } from "../ai-sdk/cache";
+import { type CacheStorage, depsToKey, withCache } from "../ai-sdk/cache";
 import { File } from "../ai-sdk/file";
 import { fileCache } from "../ai-sdk/file-cache";
 import { generateMusic as generateMusicRaw } from "../ai-sdk/generate-music";
@@ -303,6 +303,77 @@ async function sliceAudio(
   return new Uint8Array(sliced);
 }
 
+// ---------------------------------------------------------------------------
+// Speech resolve-level cache: serialization helpers
+// ---------------------------------------------------------------------------
+
+/** Serializable representation of a speech segment for caching. */
+interface CachedSegment {
+  text: string;
+  start: number;
+  end: number;
+  duration: number;
+  props: Record<string, unknown>;
+  children: string[];
+  file: { uint8Array: Uint8Array; mediaType: string };
+  words?: WordTiming[];
+}
+
+/** Serializable representation of a full resolved speech for caching. */
+interface CachedSpeechResult {
+  file: { uint8Array: Uint8Array; mediaType: string };
+  duration: number;
+  words?: WordTiming[];
+  segments?: CachedSegment[];
+}
+
+/** Reconstruct a Segment (ResolvedElement<"speech"> + timing props) from cached data. */
+function reconstructSegment(
+  cached: CachedSegment,
+  storage?: import("../ai-sdk/storage/types").StorageProvider,
+): Segment {
+  const segmentFile = File.fromBuffer(
+    cached.file.uint8Array,
+    cached.file.mediaType,
+  );
+  const resolved = new ResolvedElement<"speech">(
+    { type: "speech", props: cached.props, children: cached.children },
+    {
+      file: segmentFile,
+      duration: cached.duration,
+      segments: [],
+      words: cached.words,
+    },
+  );
+  Object.defineProperties(resolved, {
+    text: { value: cached.text, enumerable: true },
+    start: { value: cached.start, enumerable: true },
+    end: { value: cached.end, enumerable: true },
+  });
+  return resolved as Segment;
+}
+
+/** Serialize a Segment into a cacheable plain object. */
+function serializeSegment(seg: Segment): CachedSegment {
+  return {
+    text: seg.text,
+    start: seg.start,
+    end: seg.end,
+    duration: seg.duration,
+    props: { ...seg.props },
+    children: seg.children.filter((c): c is string => typeof c === "string"),
+    file: {
+      uint8Array: (seg.meta.file as any)._data as Uint8Array,
+      mediaType: "audio/mpeg",
+    },
+    words: seg.meta.words,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveSpeechElement — cached at the full-result level
+// ---------------------------------------------------------------------------
+
 /** Generate speech audio via the AI SDK and return a ResolvedElement with duration metadata. */
 export async function resolveSpeechElement(
   element: VargElement<"speech">,
@@ -329,6 +400,45 @@ export async function resolveSpeechElement(
   }
 
   const cacheKey = computeCacheKey(element);
+
+  // ---- Check full-result cache (includes segments, words, duration) ----
+  const cache = getActiveCache();
+  const resolveKey = depsToKey("resolveSpeech", cacheKey);
+  const cached = (await cache.get(resolveKey)) as
+    | CachedSpeechResult
+    | undefined;
+
+  if (cached) {
+    const ctx = getResolveContext();
+    const file = File.fromGenerated({
+      uint8Array: cached.file.uint8Array,
+      mediaType: cached.file.mediaType,
+    }).withMetadata({
+      type: "speech",
+      model: typeof model === "string" ? model : model.modelId,
+      prompt: text,
+    });
+
+    // Upload reconstructed segment files to storage so downstream cache keys
+    // get stable URLs (instead of no URL at all).
+    const segments = cached.segments?.map((s) =>
+      reconstructSegment(s, ctx?.storage),
+    );
+    if (segments && ctx?.storage) {
+      await Promise.all(
+        segments.map((seg) => seg.meta.file.upload(ctx.storage!)),
+      );
+    }
+
+    return new ResolvedElement(element, {
+      file,
+      duration: cached.duration,
+      words: cached.words,
+      segments,
+    });
+  }
+
+  // ---- Cache miss: generate, probe, slice, then cache ----
 
   const generateSpeech = getCachedGenerateSpeech();
   const { audio, ...rest } = await generateSpeech({
@@ -383,6 +493,15 @@ export async function resolveSpeechElement(
       );
     }
   }
+
+  // ---- Write full result to cache ----
+  const toCache: CachedSpeechResult = {
+    file: { uint8Array: audio.uint8Array, mediaType },
+    duration,
+    words,
+    segments: segments?.map(serializeSegment),
+  };
+  await cache.set(resolveKey, toCache);
 
   return new ResolvedElement(element, {
     file,

--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -116,6 +116,12 @@ function getCachedGenerateMusic() {
   return withCache(generateMusicRaw, { storage });
 }
 
+/** Get a cached generateSpeech wrapper using the active cache storage. */
+function getCachedGenerateSpeech() {
+  const storage = getActiveCache();
+  return withCache(generateSpeechAI, { storage });
+}
+
 // ---------------------------------------------------------------------------
 // Speech
 // ---------------------------------------------------------------------------
@@ -324,12 +330,13 @@ export async function resolveSpeechElement(
 
   const cacheKey = computeCacheKey(element);
 
-  const { audio, ...rest } = await generateSpeechAI({
+  const generateSpeech = getCachedGenerateSpeech();
+  const { audio, ...rest } = await generateSpeech({
     model,
     text,
     voice: props.voice ?? "rachel",
     cacheKey,
-  } as Parameters<typeof generateSpeechAI>[0]);
+  });
 
   const mediaType = (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 

--- a/src/studio/step-renderer.ts
+++ b/src/studio/step-renderer.ts
@@ -1,6 +1,10 @@
-import { generateImage } from "ai";
+import {
+  generateImage,
+  experimental_generateSpeech as generateSpeech,
+} from "ai";
 import { type CacheStorage, withCache } from "../ai-sdk/cache";
 import { fileCache } from "../ai-sdk/file-cache";
+import { generateMusic } from "../ai-sdk/generate-music";
 import { generateVideo } from "../ai-sdk/generate-video";
 import { localBackend } from "../ai-sdk/providers/editly";
 import type { RenderContext } from "../react/renderers/context";
@@ -49,6 +53,12 @@ export function createStepSession(
     generateVideo: cacheStorage
       ? withCache(generateVideo, { storage: cacheStorage })
       : generateVideo,
+    generateSpeech: cacheStorage
+      ? withCache(generateSpeech, { storage: cacheStorage })
+      : generateSpeech,
+    generateMusic: cacheStorage
+      ? withCache(generateMusic, { storage: cacheStorage })
+      : generateMusic,
     tempFiles: [],
     progress: createProgressTracker(false),
     pendingFiles: new Map(),


### PR DESCRIPTION
## Summary

- Adds `withCache()` wrappers for Speech and Music in both the standalone (`await Speech()`/`await Music()`) and render pipeline paths
- Uses `computeCacheKey(element)` consistently — the same canonical key format used by Image and Video
- Adds `pendingFiles` deduplication for concurrent Speech/Music renders
- Removes manual `ctx.cache.get()`/`ctx.cache.set()` + `JSON.stringify` cache keys from both renderers

## Problem

Speech was completely missing SDK-level caching. Music had manual caching via `ctx.cache.get()`/`ctx.cache.set()` with `JSON.stringify` keys, which was inconsistent with Image/Video and produced different cache keys than the standalone `await Music()` path.

**Before:**

| Layer | Image | Video | Music | Speech |
|-------|-------|-------|-------|--------|
| Gateway (Redis/R2) | yes | yes | yes | yes |
| SDK `withCache()` render pipeline | yes | yes | manual get/set | **no** |
| SDK `withCache()` standalone await | yes | yes | yes | **no** |
| `computeCacheKey(element)` | yes | yes | no (JSON.stringify) | no (ignored) |
| `pendingFiles` dedup | yes | yes | no | no |

**After:**

| Layer | Image | Video | Music | Speech |
|-------|-------|-------|-------|--------|
| Gateway (Redis/R2) | yes | yes | yes | yes |
| SDK `withCache()` render pipeline | yes | yes | **yes** | **yes** |
| SDK `withCache()` standalone await | yes | yes | yes | **yes** |
| `computeCacheKey(element)` | yes | yes | **yes** | **yes** |
| `pendingFiles` dedup | yes | yes | **yes** | **yes** |

## Changes

**`src/react/resolve.ts`** — standalone `await Speech()`:
- Added `getCachedGenerateSpeech()` wrapping `generateSpeechAI` with `withCache()`, matching `getCachedGenerateVideo()`/`getCachedGenerateMusic()`
- Replaced direct `generateSpeechAI()` call with cached wrapper

**`src/react/renderers/context.ts`**:
- Added `generateSpeech` and `generateMusic` fields to `RenderContext`, matching `generateImage`/`generateVideo`

**`src/react/renderers/render.ts`** (`renderRoot()`):
- Creates `cachedGenerateSpeech` and `cachedGenerateMusic` via `withCache()`, same pattern as Image/Video
- Passes them into `RenderContext`

**`src/react/renderers/speech.ts`**:
- Rewrote to use `computeCacheKey(element)` + `ctx.generateSpeech()` + `pendingFiles` dedup
- Removed manual `ctx.cache.get()`/`ctx.cache.set()` and `JSON.stringify` key

**`src/react/renderers/music.ts`**:
- Same rewrite: `computeCacheKey(element)` + `ctx.generateMusic()` + `pendingFiles` dedup
- Removed manual caching logic

**`src/studio/step-renderer.ts`** + **test fixtures**:
- Added `generateSpeech`/`generateMusic` to all `RenderContext` construction sites

Closes #200