### PR TITLE
feat: provider cost formulas and render pricing callback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "ai": "^6.0.26",
         "apify-client": "^2.20.0",
         "citty": "^0.1.6",
+        "fflate": "^0.8.2",
         "fluent-ffmpeg": "^2.1.3",
         "groq-sdk": "^0.36.0",
         "ink": "^6.5.1",
@@ -824,6 +825,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ai": "^6.0.26",
     "apify-client": "^2.20.0",
     "citty": "^0.1.6",
+    "fflate": "^0.8.2",
     "fluent-ffmpeg": "^2.1.3",
     "groq-sdk": "^0.36.0",
     "ink": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@commitlint/config-conventional": "^20.0.0",
     "@size-limit/preset-small-lib": "^11.2.0",
     "@types/bun": "latest",
+    "@types/opentype.js": "^1.3.9",
     "@types/react": "^19.2.7",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7"
@@ -62,6 +63,7 @@
     "fluent-ffmpeg": "^2.1.3",
     "groq-sdk": "^0.36.0",
     "ink": "^6.5.1",
+    "opentype.js": "^1.3.4",
     "p-limit": "^6.2.0",
     "p-map": "^7.0.4",
     "react": "^19.2.0",
@@ -105,7 +107,7 @@
   "license": "Apache-2.0",
   "author": "varg.ai <hello@varg.ai> (https://varg.ai)",
   "sideEffects": false,
-  "version": "0.4.0-alpha105",
+  "version": "0.4.0-alpha107",
   "exports": {
     ".": "./src/index.ts",
     "./ai": "./src/ai-sdk/index.ts",

--- a/src/ai-sdk/providers/editly/backends/types.ts
+++ b/src/ai-sdk/providers/editly/backends/types.ts
@@ -47,6 +47,10 @@ export interface FFmpegRunOptions {
   verbose?: boolean;
   /** Max execution time in seconds (used by cloud backends like Rendi, ignored by local) */
   timeoutSeconds?: number;
+  /** Extra files (e.g. fonts) to include alongside inputs.
+   *  When present, cloud backends like Rendi use compressed folder mode
+   *  (input_compressed_folder) to bundle all files together. */
+  auxiliaryFiles?: { url: string; fileName: string }[];
 }
 
 export type FFmpegOutput =

--- a/src/ai-sdk/providers/editly/rendi/index.ts
+++ b/src/ai-sdk/providers/editly/rendi/index.ts
@@ -1,3 +1,4 @@
+import { zipSync } from "fflate";
 import sharp from "sharp";
 import { File } from "../../../file";
 import type { StorageProvider } from "../../../storage/types";
@@ -128,6 +129,11 @@ export class RendiBackend implements FFmpegBackend {
   }
 
   async run(options: FFmpegRunOptions): Promise<FFmpegRunResult> {
+    // When auxiliary files (e.g. fonts) are present, use compressed folder mode
+    if (options.auxiliaryFiles && options.auxiliaryFiles.length > 0) {
+      return this.runWithCompressedFolder(options);
+    }
+
     let {
       inputs,
       filterComplex,
@@ -277,6 +283,194 @@ export class RendiBackend implements FFmpegBackend {
       if (status.status === "FAILED") {
         throw new Error(
           `Rendi command failed: ${status.error_message ?? "Unknown error"}`,
+        );
+      }
+
+      await this.sleep(POLL_INTERVAL_MS);
+      attempts++;
+    }
+
+    throw new Error("Rendi command timed out");
+  }
+
+  /**
+   * Run an FFmpeg command using Rendi's input_compressed_folder mode.
+   *
+   * Used when auxiliary files (e.g. fonts for subtitle rendering) need to be
+   * bundled alongside regular inputs. Creates a ZIP containing all input files
+   * and auxiliary files, uploads it to storage, and submits to Rendi with
+   * `input_compressed_folder` instead of `input_files`.
+   *
+   * Inside the ZIP, all files are at the root level. The ffmpeg command
+   * references files by their bare filenames (not placeholders).
+   */
+  private async runWithCompressedFolder(
+    options: FFmpegRunOptions,
+  ): Promise<FFmpegRunResult> {
+    const {
+      inputs,
+      videoFilter,
+      filterComplex,
+      outputArgs = [],
+      outputPath,
+      verbose,
+      auxiliaryFiles = [],
+    } = options;
+
+    // 1. Resolve all input files to URLs
+    const inputEntries: { fileName: string; url: string }[] = [];
+    for (const input of inputs ?? []) {
+      const path = this.getInputPath(input);
+      const url = await this.resolvePath(path);
+      // Extract filename from URL or path
+      const fileName =
+        url.split("/").pop()?.split("?")[0] ?? `input_${inputEntries.length}`;
+      inputEntries.push({ fileName, url });
+    }
+
+    // 2. Download all files (inputs + auxiliary) into memory
+    const zipContents: Record<string, Uint8Array> = {};
+
+    const downloadTasks = [
+      ...inputEntries.map(async (entry) => {
+        const res = await fetch(entry.url);
+        if (!res.ok)
+          throw new Error(
+            `Failed to download input ${entry.fileName}: ${res.status}`,
+          );
+        zipContents[entry.fileName] = new Uint8Array(await res.arrayBuffer());
+      }),
+      ...auxiliaryFiles.map(async (file) => {
+        const res = await fetch(file.url);
+        if (!res.ok)
+          throw new Error(
+            `Failed to download auxiliary file ${file.fileName}: ${res.status}`,
+          );
+        zipContents[file.fileName] = new Uint8Array(await res.arrayBuffer());
+      }),
+    ];
+
+    await Promise.all(downloadTasks);
+
+    if (verbose) {
+      const totalSize = Object.values(zipContents).reduce(
+        (sum, buf) => sum + buf.length,
+        0,
+      );
+      console.log(
+        `[rendi] creating ZIP with ${Object.keys(zipContents).length} files (${(totalSize / 1024 / 1024).toFixed(1)} MB)`,
+      );
+    }
+
+    // 3. Create ZIP
+    const zipData = zipSync(zipContents, { level: 1 }); // fast compression
+
+    // 4. Upload ZIP to storage
+    const zipKey = `internal/rendi-compressed-${Date.now()}.zip`;
+    const zipUrl = await this.storage.upload(
+      zipData,
+      zipKey,
+      "application/zip",
+    );
+
+    if (verbose) {
+      console.log(
+        `[rendi] uploaded ZIP (${(zipData.length / 1024 / 1024).toFixed(1)} MB) -> ${zipUrl}`,
+      );
+    }
+
+    // 5. Build ffmpeg command using bare filenames (not {{in_X}} placeholders)
+    const inputArgs: string[] = [];
+    for (const [i, input] of (inputs ?? []).entries()) {
+      if (typeof input !== "string" && "options" in input && input.options) {
+        inputArgs.push(...input.options);
+      }
+      inputArgs.push("-i", inputEntries[i]!.fileName);
+    }
+
+    const filterArgs: string[] = [];
+    if (filterComplex) {
+      filterArgs.push("-filter_complex", filterComplex);
+    }
+    if (videoFilter) {
+      // For compressed folder mode, the video filter references files by
+      // their bare filenames (already resolved in the working directory)
+      filterArgs.push("-vf", videoFilter);
+    }
+
+    const processedOutputArgs = outputArgs.filter((arg) => arg !== "-y");
+
+    const commandParts = [
+      ...inputArgs,
+      ...filterArgs,
+      ...processedOutputArgs,
+      "{{out_1}}",
+    ];
+    const ffmpegCommand = this.buildCommandString(commandParts);
+    const outputFilename = outputPath?.split("/").pop() ?? "output.mp4";
+
+    if (verbose) {
+      console.log("[rendi] input_compressed_folder:", zipUrl);
+      console.log("[rendi] ffmpeg_command:", ffmpegCommand);
+    }
+
+    // 6. Submit to Rendi with input_compressed_folder
+    const submitResponse = await fetch(`${RENDI_API_BASE}/run-ffmpeg-command`, {
+      method: "POST",
+      headers: {
+        "X-API-KEY": this.apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        input_compressed_folder: zipUrl,
+        output_files: { out_1: outputFilename },
+        ffmpeg_command: ffmpegCommand,
+        max_command_run_seconds:
+          options.timeoutSeconds ?? this.maxCommandRunSeconds,
+      }),
+    });
+
+    if (!submitResponse.ok) {
+      const errorText = await submitResponse.text();
+      throw new Error(
+        `Rendi submit failed: ${submitResponse.status} - ${errorText}`,
+      );
+    }
+
+    const { command_id } =
+      (await submitResponse.json()) as RendiCommandResponse;
+
+    if (verbose) {
+      console.log("[rendi] command_id:", command_id);
+    }
+
+    // 7. Poll for completion (same as standard run)
+    let attempts = 0;
+    while (attempts < MAX_POLL_ATTEMPTS) {
+      const statusResponse = await fetch(
+        `${RENDI_API_BASE}/commands/${command_id}`,
+        {
+          headers: { "X-API-KEY": this.apiKey },
+        },
+      );
+
+      if (!statusResponse.ok) {
+        throw new Error(`Rendi poll failed: ${statusResponse.status}`);
+      }
+
+      const status = (await statusResponse.json()) as RendiStatusResponse;
+
+      if (status.status === "SUCCESS") {
+        const outputFile = status.output_files?.out_1;
+        if (!outputFile?.storage_url) {
+          throw new Error("Rendi completed but no output URL");
+        }
+        return { output: { type: "url", url: outputFile.storage_url } };
+      }
+
+      if (status.status === "FAILED") {
+        throw new Error(
+          `Rendi command failed: ${status.error_message ?? "unknown error"}`,
         );
       }
 

--- a/src/core/schema/types.ts
+++ b/src/core/schema/types.ts
@@ -237,6 +237,8 @@ export interface PricingParams {
   numImages?: number;
   /** Text length for speech models */
   characters?: number;
+  /** Whether to generate native audio (e.g. Kling video with audio) */
+  generateAudio?: boolean;
 
   // Input params (for v2v, upscaling, etc.)
   /** Duration of input video in seconds (for v2v models) */

--- a/src/core/schema/types.ts
+++ b/src/core/schema/types.ts
@@ -154,6 +154,12 @@ export interface ModelDefinition<S extends ZodSchema = ZodSchema> {
    * e.g., { fal: "fal-ai/kling-video/v2.5", replicate: "..." }
    */
   providerModels?: Record<string, string>;
+  /**
+   * Raw provider cost formulas, keyed by provider name.
+   * Each formula calculates the estimated provider cost in USD for a given
+   * set of generation parameters. The gateway applies markup on top of this.
+   */
+  pricing?: Record<string, ProviderPricing>;
 }
 
 export interface ActionRoute {
@@ -201,6 +207,63 @@ export type Definition =
   | ModelDefinition<ZodSchema>
   | ActionDefinition<ZodSchema>
   | SkillDefinition<ZodSchema>;
+
+// ============================================================================
+// Pricing Types
+// ============================================================================
+
+/**
+ * Standard inputs for pricing calculation.
+ * Every model's pricing function receives this — unused fields are undefined.
+ * This is the raw provider cost calculation — the gateway adds markup on top.
+ */
+export interface PricingParams {
+  // Output params (from the generation request)
+  /** Output video/audio duration in seconds */
+  duration?: number;
+  /** Output resolution preset, e.g. "480p" | "720p" | "1080p" | "2K" | "4K" */
+  resolution?: string;
+  /** Output aspect ratio, e.g. "16:9" | "9:16" | "1:1" */
+  aspectRatio?: string;
+  /** Output width in pixels */
+  width?: number;
+  /** Output height in pixels */
+  height?: number;
+  /** Frames per second */
+  fps?: number;
+  /** Explicit frame count (for frame-based models) */
+  numFrames?: number;
+  /** Number of images to generate (batch) */
+  numImages?: number;
+  /** Text length for speech models */
+  characters?: number;
+
+  // Input params (for v2v, upscaling, etc.)
+  /** Duration of input video in seconds (for v2v models) */
+  inputDuration?: number;
+  /** Input video/image width in pixels */
+  inputWidth?: number;
+  /** Input video/image height in pixels */
+  inputHeight?: number;
+
+  /** Catch-all for model-specific params that affect pricing */
+  providerOptions?: Record<string, unknown>;
+}
+
+/**
+ * Raw provider cost formula for a specific model+provider combination.
+ * The `calculate` function returns the estimated provider cost in USD.
+ */
+export interface ProviderPricing {
+  /** Human-readable description, e.g. "$0.25 per second of output video" */
+  description: string;
+  /** Calculate raw provider cost in USD given resolved params */
+  calculate: (params: PricingParams) => number;
+  /** Minimum possible provider cost in USD (for UI bounds / x402 headers) */
+  minUsd: number;
+  /** Maximum possible provider cost in USD (for UI bounds / x402 headers) */
+  maxUsd: number;
+}
 
 // ============================================================================
 // Execution Types

--- a/src/definitions/models/elevenlabs.ts
+++ b/src/definitions/models/elevenlabs.ts
@@ -55,7 +55,7 @@ export const definition: ModelDefinition<typeof schema> = {
         "$0.10 per 1,000 characters via ElevenLabs (Multilingual v2/v3). Flash/Turbo: $0.05/1K.",
       calculate: ({ characters = 500 }) => 0.0001 * characters,
       minUsd: 0.01, // ~100 chars
-      maxUsd: 0.4, // ~4000 chars
+      maxUsd: 1.0, // ~10,000 chars (long-form narration)
     },
   },
 };

--- a/src/definitions/models/elevenlabs.ts
+++ b/src/definitions/models/elevenlabs.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { elevenLabsModelSchema, percentSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Input schema with Zod
 const elevenlabsInputSchema = z.object({
@@ -45,6 +49,15 @@ export const definition: ModelDefinition<typeof schema> = {
     elevenlabs: "eleven_multilingual_v2",
   },
   schema,
+  pricing: {
+    elevenlabs: {
+      description:
+        "$0.10 per 1,000 characters via ElevenLabs (Multilingual v2/v3). Flash/Turbo: $0.05/1K.",
+      calculate: ({ characters = 500 }) => 0.0001 * characters,
+      minUsd: 0.01, // ~100 chars
+      maxUsd: 0.4, // ~4000 chars
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/flux.ts
+++ b/src/definitions/models/flux.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { imageSizeSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Input schema with Zod
 const fluxInputSchema = z.object({
@@ -51,6 +55,18 @@ export const definition: ModelDefinition<typeof schema> = {
     replicate: "black-forest-labs/flux-1.1-pro",
   },
   schema,
+  pricing: {
+    fal: {
+      description:
+        "$0.04 per megapixel via fal (rounded up). Standard 1MP image = $0.04.",
+      calculate: ({ numImages = 1, width = 1024, height = 768 }) => {
+        const megapixels = Math.ceil((width * height) / 1_000_000);
+        return 0.04 * megapixels * numImages;
+      },
+      minUsd: 0.04, // 1 image at 1MP
+      maxUsd: 0.16, // 4 images at 1MP
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/flux.ts
+++ b/src/definitions/models/flux.ts
@@ -64,7 +64,7 @@ export const definition: ModelDefinition<typeof schema> = {
         return 0.04 * megapixels * numImages;
       },
       minUsd: 0.04, // 1 image at 1MP
-      maxUsd: 0.16, // 4 images at 1MP
+      maxUsd: 0.64, // 4 images at 4MP (2048x2048)
     },
   },
 };

--- a/src/definitions/models/heygen.ts
+++ b/src/definitions/models/heygen.ts
@@ -4,7 +4,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 const heygenInputSchema = z.object({
   script: z.string().describe("Script text for the avatar to speak"),
@@ -56,6 +60,21 @@ export const definition: ModelDefinition<typeof schema> = {
     heygen: "avatar-iv",
   },
   schema,
+  pricing: {
+    heygen: {
+      description:
+        "$0.10 per second of output video, estimated from script length",
+      calculate: ({ duration, characters }) => {
+        // HeyGen charges $0.10/sec. Estimate duration from script if not provided.
+        // ~150 words/min = ~2.5 words/sec, avg word ~5 chars → ~12.5 chars/sec
+        const estimatedDuration =
+          duration ?? (characters ? Math.ceil(characters / 12.5) : 30);
+        return 0.1 * estimatedDuration;
+      },
+      minUsd: 1.0, // ~10s
+      maxUsd: 10.0, // ~100s
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/index.ts
+++ b/src/definitions/models/index.ts
@@ -2,6 +2,12 @@
  * Model definitions index
  */
 
+import type {
+  ModelDefinition,
+  PricingParams,
+  ProviderPricing,
+} from "../../core/schema/types";
+
 export { definition as elevenlabsTts } from "./elevenlabs";
 export { definition as flux } from "./flux";
 export { definition as heygenAvatar } from "./heygen";
@@ -81,3 +87,41 @@ export const allModels = [
   llamaDefinition,
   heygenAvatarDefinition,
 ];
+
+// ---------------------------------------------------------------------------
+// Pricing utilities
+// ---------------------------------------------------------------------------
+
+/** Look up the ProviderPricing formula for a model+provider pair. */
+export function getModelPricing(
+  modelName: string,
+  provider: string,
+): ProviderPricing | null {
+  const model = allModels.find((m) => m.name === modelName);
+  return model?.pricing?.[provider] ?? null;
+}
+
+/**
+ * Calculate the raw provider cost (USD) for a model+provider given params.
+ * Returns null if the model has no pricing formula for the given provider.
+ */
+export function calculateProviderCost(
+  modelName: string,
+  provider: string,
+  params: PricingParams,
+): number | null {
+  const pricing = getModelPricing(modelName, provider);
+  return pricing ? pricing.calculate(params) : null;
+}
+
+/**
+ * Get the pricing bounds (min/max USD) for a model+provider.
+ * Useful for UI estimation and x402 payment headers.
+ */
+export function getModelPricingBounds(
+  modelName: string,
+  provider: string,
+): { minUsd: number; maxUsd: number } | null {
+  const pricing = getModelPricing(modelName, provider);
+  return pricing ? { minUsd: pricing.minUsd, maxUsd: pricing.maxUsd } : null;
+}

--- a/src/definitions/models/kling.ts
+++ b/src/definitions/models/kling.ts
@@ -57,11 +57,13 @@ export const definition: ModelDefinition<typeof schema> = {
   schema,
   pricing: {
     fal: {
-      description:
-        "Kling O3 Pro: $0.112/sec (audio off), $0.14/sec (audio on). 5s video = $0.56-$0.70",
-      calculate: ({ duration = 5 }) => 0.112 * duration,
-      minUsd: 0.34, // 3s * $0.112
-      maxUsd: 2.1, // 15s * $0.14 (with audio)
+      description: "Kling O3 Pro: $0.112/sec (audio off), $0.14/sec (audio on)",
+      calculate: ({ duration = 5, generateAudio = false }) => {
+        const rate = generateAudio ? 0.14 : 0.112;
+        return rate * duration;
+      },
+      minUsd: 0.336, // 3s * $0.112 (audio off)
+      maxUsd: 2.1, // 15s * $0.14 (audio on)
     },
   },
 };

--- a/src/definitions/models/kling.ts
+++ b/src/definitions/models/kling.ts
@@ -8,7 +8,11 @@ import {
   aspectRatioSchema,
   videoDurationSchema,
 } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Input schema with Zod
 const klingInputSchema = z.object({
@@ -51,6 +55,15 @@ export const definition: ModelDefinition<typeof schema> = {
     replicate: "fofr/kling-v1.5",
   },
   schema,
+  pricing: {
+    fal: {
+      description:
+        "Kling O3 Pro: $0.112/sec (audio off), $0.14/sec (audio on). 5s video = $0.56-$0.70",
+      calculate: ({ duration = 5 }) => 0.112 * duration,
+      minUsd: 0.34, // 3s * $0.112
+      maxUsd: 2.1, // 15s * $0.14 (with audio)
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/llama.ts
+++ b/src/definitions/models/llama.ts
@@ -4,7 +4,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Llama model variants schema
 const llamaModelSchema = z.enum([
@@ -49,6 +53,14 @@ export const definition: ModelDefinition<typeof schema> = {
     groq: "llama-3.3-70b-versatile",
   },
   schema,
+  pricing: {
+    groq: {
+      description: "~$0.001 per 1K tokens via Groq",
+      calculate: () => 0.005, // typical request ~5K tokens
+      minUsd: 0.001,
+      maxUsd: 0.01,
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/ltx-a2v.ts
+++ b/src/definitions/models/ltx-a2v.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { urlSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 const cameraLoraSchema = z
   .enum([
@@ -190,6 +194,18 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "fal-ai/ltx-2-19b/audio-to-video",
   },
   schema,
+  pricing: {
+    fal: {
+      description:
+        "$0.0018 per megapixel of video data (width x height x frames) via fal. E.g. 121 frames at 1280x720 = ~112 MP = $0.20",
+      calculate: ({ width = 1024, height = 768, numFrames = 121 }) => {
+        const megapixels = (width * height * numFrames) / 1_000_000;
+        return Math.ceil(megapixels) * 0.0018;
+      },
+      minUsd: 0.05, // small video ~28 MP
+      maxUsd: 0.8, // 481 frames at 1280x720 ~443 MP
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/nano-banana-2.ts
+++ b/src/definitions/models/nano-banana-2.ts
@@ -4,7 +4,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Nano Banana 2 resolution options (includes 0.5K unlike nano-banana-pro)
 const nanoBanana2ResolutionSchema = z.enum(["0.5K", "1K", "2K", "4K"]);
@@ -111,6 +115,24 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "fal-ai/nano-banana-2",
   },
   schema,
+  pricing: {
+    fal: {
+      description:
+        "$0.08/image (1K), $0.06 (0.5K), $0.12 (2K), $0.16 (4K) via fal. Web search +$0.015, high thinking +$0.002.",
+      calculate: ({ numImages = 1, resolution }) => {
+        const rateMap: Record<string, number> = {
+          "0.5K": 0.06,
+          "1K": 0.08,
+          "2K": 0.12,
+          "4K": 0.16,
+        };
+        const rate = rateMap[resolution ?? "1K"] ?? 0.08;
+        return rate * numImages;
+      },
+      minUsd: 0.06, // 1 image at 0.5K
+      maxUsd: 0.64, // 4 images at 4K
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/nano-banana-pro.ts
+++ b/src/definitions/models/nano-banana-pro.ts
@@ -4,7 +4,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Nano Banana Pro resolution options
 const nanoBananaResolutionSchema = z.enum(["1K", "2K", "4K"]);
@@ -97,6 +101,18 @@ export const definition: ModelDefinition<typeof schema> = {
     replicate: "google/nano-banana-pro",
   },
   schema,
+  pricing: {
+    fal: {
+      description:
+        "$0.15 per 1K image, $0.30 per 4K image via fal. Web search adds $0.015.",
+      calculate: ({ numImages = 1, resolution }) => {
+        const rate = resolution === "4K" ? 0.3 : 0.15;
+        return rate * numImages;
+      },
+      minUsd: 0.15, // 1 image at 1K
+      maxUsd: 1.2, // 4 images at 4K
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/omnihuman.ts
+++ b/src/definitions/models/omnihuman.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { urlSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 const omnihumanResolutionSchema = z
   .enum(["720p", "1080p"])
@@ -66,6 +70,14 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "fal-ai/bytedance/omnihuman/v1.5",
   },
   schema,
+  pricing: {
+    fal: {
+      description: "$0.16 per second of output video via fal",
+      calculate: ({ duration = 5 }) => 0.16 * duration,
+      minUsd: 0.48, // ~3s minimum
+      maxUsd: 9.6, // 60s at 720p max
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/phota.ts
+++ b/src/definitions/models/phota.ts
@@ -7,7 +7,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Shared enums
 const photaOutputFormatSchema = z.enum(["jpeg", "png", "webp"]);
@@ -85,6 +89,14 @@ export const photaDefinition: ModelDefinition<typeof photaSchema> = {
     fal: "fal-ai/phota",
   },
   schema: photaSchema,
+  pricing: {
+    fal: {
+      description: "$0.09 per 1K image via fal",
+      calculate: ({ numImages = 1 }) => 0.09 * numImages,
+      minUsd: 0.09,
+      maxUsd: 0.36, // 4 images
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -144,6 +156,14 @@ export const photaEditDefinition: ModelDefinition<typeof photaEditSchema> = {
     fal: "fal-ai/phota/edit",
   },
   schema: photaEditSchema,
+  pricing: {
+    fal: {
+      description: "$0.09 per 1K image via fal",
+      calculate: ({ numImages = 1 }) => 0.09 * numImages,
+      minUsd: 0.09,
+      maxUsd: 0.36,
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -193,6 +213,14 @@ export const photaEnhanceDefinition: ModelDefinition<
     fal: "fal-ai/phota/enhance",
   },
   schema: photaEnhanceSchema,
+  pricing: {
+    fal: {
+      description: "$0.13 per image via fal",
+      calculate: ({ numImages = 1 }) => 0.13 * numImages,
+      minUsd: 0.13,
+      maxUsd: 0.52,
+    },
+  },
 };
 
 // Default export for the primary text-to-image model

--- a/src/definitions/models/pricing.test.ts
+++ b/src/definitions/models/pricing.test.ts
@@ -101,13 +101,30 @@ describe("SDK pricing formulas", () => {
 
   // --- Duration-based video models ---
 
-  test("kling: per-second pricing — longer duration costs more", () => {
-    const cost5 = calculateProviderCost("kling", "fal", { duration: 5 });
-    const cost10 = calculateProviderCost("kling", "fal", { duration: 10 });
-    expect(cost5).toBeGreaterThan(0);
-    expect(cost10).toBeGreaterThan(cost5!);
-    // 10s should be exactly 2x of 5s (linear per-second)
-    expect(cost10).toBe(cost5! * 2);
+  test("kling: 5s audio off = $0.56", () => {
+    const cost = calculateProviderCost("kling", "fal", { duration: 5 });
+    expect(cost).toBe(0.56);
+  });
+
+  test("kling: 5s audio on = $0.70", () => {
+    const cost = calculateProviderCost("kling", "fal", {
+      duration: 5,
+      generateAudio: true,
+    });
+    expect(cost).toBeCloseTo(0.7);
+  });
+
+  test("kling: 10s audio off = $1.12", () => {
+    const cost = calculateProviderCost("kling", "fal", { duration: 10 });
+    expect(cost).toBeCloseTo(1.12);
+  });
+
+  test("kling: 10s audio on = $1.40", () => {
+    const cost = calculateProviderCost("kling", "fal", {
+      duration: 10,
+      generateAudio: true,
+    });
+    expect(cost).toBeCloseTo(1.4);
   });
 
   // --- Image models: per-image ---

--- a/src/definitions/models/pricing.test.ts
+++ b/src/definitions/models/pricing.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import {
+  allModels,
+  calculateProviderCost,
+  getModelPricing,
+  getModelPricingBounds,
+} from "./index";
+
+describe("SDK pricing formulas", () => {
+  test("all models have pricing defined", () => {
+    for (const model of allModels) {
+      expect(model.pricing).toBeDefined();
+      expect(Object.keys(model.pricing!).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("all pricing formulas return positive numbers", () => {
+    for (const model of allModels) {
+      for (const [provider, pricing] of Object.entries(model.pricing!)) {
+        const cost = pricing.calculate({});
+        expect(cost).toBeGreaterThan(0);
+        expect(typeof cost).toBe("number");
+        expect(Number.isFinite(cost)).toBe(true);
+      }
+    }
+  });
+
+  test("all pricing formulas have valid bounds", () => {
+    for (const model of allModels) {
+      for (const [provider, pricing] of Object.entries(model.pricing!)) {
+        expect(pricing.minUsd).toBeGreaterThan(0);
+        expect(pricing.maxUsd).toBeGreaterThanOrEqual(pricing.minUsd);
+        expect(pricing.description.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  // --- Seedance: dynamic per-second pricing ---
+
+  test("seedance-2-preview: $0.25/s at 5s = $1.25", () => {
+    const cost = calculateProviderCost("seedance-2-preview", "piapi", {
+      duration: 5,
+    });
+    expect(cost).toBe(1.25);
+  });
+
+  test("seedance-2-preview: $0.25/s at 10s = $2.50", () => {
+    const cost = calculateProviderCost("seedance-2-preview", "piapi", {
+      duration: 10,
+    });
+    expect(cost).toBe(2.5);
+  });
+
+  test("seedance-2-preview: $0.25/s at 15s = $3.75", () => {
+    const cost = calculateProviderCost("seedance-2-preview", "piapi", {
+      duration: 15,
+    });
+    expect(cost).toBe(3.75);
+  });
+
+  test("seedance-2-fast-preview: $0.15/s at 5s = $0.75", () => {
+    const cost = calculateProviderCost("seedance-2-fast-preview", "piapi", {
+      duration: 5,
+    });
+    expect(cost).toBe(0.75);
+  });
+
+  test("seedance-2-fast-preview: $0.15/s at 15s = $2.25", () => {
+    const cost = calculateProviderCost("seedance-2-fast-preview", "piapi", {
+      duration: 15,
+    });
+    expect(cost).toBe(2.25);
+  });
+
+  test("seedance defaults to 5s when no duration provided", () => {
+    const cost = calculateProviderCost("seedance-2-preview", "piapi", {});
+    expect(cost).toBe(1.25); // $0.25 * 5
+  });
+
+  // --- HeyGen: per-second estimated from script ---
+
+  test("heygen-avatar: defaults to ~30s = $3.00 with no params", () => {
+    const cost = calculateProviderCost("heygen-avatar", "heygen", {});
+    expect(cost).toBe(3.0); // $0.10 * 30
+  });
+
+  test("heygen-avatar: explicit 10s duration = $1.00", () => {
+    const cost = calculateProviderCost("heygen-avatar", "heygen", {
+      duration: 10,
+    });
+    expect(cost).toBe(1.0);
+  });
+
+  test("heygen-avatar: estimates duration from characters", () => {
+    // 125 chars / 12.5 chars/sec = 10s → $1.00
+    const cost = calculateProviderCost("heygen-avatar", "heygen", {
+      characters: 125,
+    });
+    expect(cost).toBe(1.0);
+  });
+
+  // --- Duration-based video models ---
+
+  test("kling: per-second pricing — longer duration costs more", () => {
+    const cost5 = calculateProviderCost("kling", "fal", { duration: 5 });
+    const cost10 = calculateProviderCost("kling", "fal", { duration: 10 });
+    expect(cost5).toBeGreaterThan(0);
+    expect(cost10).toBeGreaterThan(cost5!);
+    // 10s should be exactly 2x of 5s (linear per-second)
+    expect(cost10).toBe(cost5! * 2);
+  });
+
+  // --- Image models: per-image ---
+
+  test("flux: per-image pricing, 1 image default", () => {
+    const cost = calculateProviderCost("flux", "fal", {});
+    expect(cost).toBeGreaterThan(0);
+  });
+
+  test("flux: 4 images costs 4x a single image", () => {
+    const cost1 = calculateProviderCost("flux", "fal", { numImages: 1 });
+    const cost4 = calculateProviderCost("flux", "fal", { numImages: 4 });
+    expect(cost4).toBe(cost1! * 4);
+  });
+
+  test("phota/enhance: per-image pricing", () => {
+    const cost = calculateProviderCost("phota/enhance", "fal", {});
+    expect(cost).toBe(0.13);
+  });
+
+  // --- Speech: per-character ---
+
+  test("elevenlabs-tts: per-character pricing scales with length", () => {
+    const cost500 = calculateProviderCost("elevenlabs-tts", "elevenlabs", {
+      characters: 500,
+    });
+    const cost1000 = calculateProviderCost("elevenlabs-tts", "elevenlabs", {
+      characters: 1000,
+    });
+    expect(cost1000).toBeGreaterThan(0);
+    expect(cost1000).toBe(cost500! * 2);
+  });
+
+  // --- Lookup utilities ---
+
+  test("getModelPricing returns null for unknown model", () => {
+    const pricing = getModelPricing("nonexistent-model", "fal");
+    expect(pricing).toBeNull();
+  });
+
+  test("getModelPricing returns null for unknown provider", () => {
+    const pricing = getModelPricing("kling", "nonexistent-provider");
+    expect(pricing).toBeNull();
+  });
+
+  test("calculateProviderCost returns null for unknown model", () => {
+    const cost = calculateProviderCost("nonexistent", "fal", {});
+    expect(cost).toBeNull();
+  });
+
+  test("getModelPricingBounds returns correct bounds for seedance", () => {
+    const bounds = getModelPricingBounds("seedance-2-preview", "piapi");
+    expect(bounds).not.toBeNull();
+    expect(bounds!.minUsd).toBe(1.25);
+    expect(bounds!.maxUsd).toBe(3.75);
+  });
+
+  test("getModelPricingBounds returns null for unknown model", () => {
+    const bounds = getModelPricingBounds("nonexistent", "fal");
+    expect(bounds).toBeNull();
+  });
+
+  // --- Whisper: multi-provider ---
+
+  test("whisper: groq pricing returns positive value", () => {
+    const cost = calculateProviderCost("whisper", "groq", {});
+    expect(cost).toBeGreaterThan(0);
+  });
+
+  test("whisper: fireworks pricing returns positive value", () => {
+    const cost = calculateProviderCost("whisper", "fireworks", {});
+    expect(cost).toBeGreaterThan(0);
+  });
+
+  test("whisper: groq and fireworks have different prices", () => {
+    const groq = calculateProviderCost("whisper", "groq", {});
+    const fireworks = calculateProviderCost("whisper", "fireworks", {});
+    expect(groq).not.toBe(fireworks);
+  });
+});

--- a/src/definitions/models/pricing.test.ts
+++ b/src/definitions/models/pricing.test.ts
@@ -158,6 +158,30 @@ describe("SDK pricing formulas", () => {
     expect(cost1000).toBe(cost500! * 2);
   });
 
+  // --- Soul: batch_size pricing ---
+
+  test("soul: 1 image = $0.05", () => {
+    const cost = calculateProviderCost("soul", "higgsfield", { numImages: 1 });
+    expect(cost).toBe(0.05);
+  });
+
+  test("soul: 4 images = $0.20", () => {
+    const cost = calculateProviderCost("soul", "higgsfield", { numImages: 4 });
+    expect(cost).toBe(0.2);
+  });
+
+  // --- Sonauto: num_songs pricing ---
+
+  test("sonauto: 1 song = $0.25", () => {
+    const cost = calculateProviderCost("sonauto", "fal", { numImages: 1 });
+    expect(cost).toBe(0.25);
+  });
+
+  test("sonauto: 2 songs = $0.50", () => {
+    const cost = calculateProviderCost("sonauto", "fal", { numImages: 2 });
+    expect(cost).toBe(0.5);
+  });
+
   // --- Lookup utilities ---
 
   test("getModelPricing returns null for unknown model", () => {

--- a/src/definitions/models/qwen-image-2.ts
+++ b/src/definitions/models/qwen-image-2.ts
@@ -6,7 +6,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Image size can be an enum string or an object with width/height
 const qwenImage2ImageSizeSchema = z.union([
@@ -108,6 +112,15 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "fal-ai/qwen-image-2/text-to-image",
   },
   schema,
+  pricing: {
+    fal: {
+      description:
+        "$0.035 per image via fal (standard). Pro endpoint: $0.075/image.",
+      calculate: ({ numImages = 1 }) => 0.035 * numImages,
+      minUsd: 0.035, // 1 image
+      maxUsd: 0.21, // 6 images
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/recraft-v4.ts
+++ b/src/definitions/models/recraft-v4.ts
@@ -5,7 +5,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Image size can be an enum string or an object with width/height
 const recraftV4ImageSizeSchema = z.union([
@@ -89,6 +93,14 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "fal-ai/recraft/v4/pro/text-to-image",
   },
   schema,
+  pricing: {
+    fal: {
+      description: "$0.25 per image via fal",
+      calculate: () => 0.25,
+      minUsd: 0.25,
+      maxUsd: 0.25,
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/reve.ts
+++ b/src/definitions/models/reve.ts
@@ -5,7 +5,11 @@
  */
 
 import { z } from "zod";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Output format options
 const reveOutputFormatSchema = z.enum(["png", "jpeg", "webp"]);
@@ -61,6 +65,14 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "fal-ai/reve/edit",
   },
   schema,
+  pricing: {
+    fal: {
+      description: "Flat ~$0.04 per image via fal",
+      calculate: ({ numImages = 1 }) => 0.04 * numImages,
+      minUsd: 0.04,
+      maxUsd: 0.16,
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/seedance.ts
+++ b/src/definitions/models/seedance.ts
@@ -9,7 +9,11 @@
 
 import { z } from "zod";
 import { aspectRatioSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Seedance supports 5, 10, or 15 second durations
 const seedanceDurationSchema = z.union([
@@ -78,6 +82,14 @@ export const definition: ModelDefinition<typeof schema> = {
     piapi: "seedance-2-preview",
   },
   schema,
+  pricing: {
+    piapi: {
+      description: "$0.25 per second of output video",
+      calculate: ({ duration = 5 }) => 0.25 * duration,
+      minUsd: 1.25, // 5s
+      maxUsd: 3.75, // 15s
+    },
+  },
 };
 
 export const fastDefinition: ModelDefinition<typeof schema> = {
@@ -91,6 +103,14 @@ export const fastDefinition: ModelDefinition<typeof schema> = {
     piapi: "seedance-2-fast-preview",
   },
   schema,
+  pricing: {
+    piapi: {
+      description: "$0.15 per second of output video",
+      calculate: ({ duration = 5 }) => 0.15 * duration,
+      minUsd: 0.75, // 5s
+      maxUsd: 2.25, // 15s
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/sonauto.ts
+++ b/src/definitions/models/sonauto.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { audioFormatSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Input schema with Zod
 const sonautoInputSchema = z.object({
@@ -63,6 +67,14 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "fal-ai/sonauto/bark",
   },
   schema,
+  pricing: {
+    fal: {
+      description: "Flat ~$0.25 per track via fal",
+      calculate: () => 0.25,
+      minUsd: 0.25,
+      maxUsd: 0.25,
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/sonauto.ts
+++ b/src/definitions/models/sonauto.ts
@@ -69,10 +69,10 @@ export const definition: ModelDefinition<typeof schema> = {
   schema,
   pricing: {
     fal: {
-      description: "Flat ~$0.25 per track via fal",
-      calculate: () => 0.25,
-      minUsd: 0.25,
-      maxUsd: 0.25,
+      description: "$0.25 per track via fal (num_songs 1-2)",
+      calculate: ({ numImages = 1 }) => 0.25 * numImages,
+      minUsd: 0.25, // 1 song
+      maxUsd: 0.5, // 2 songs
     },
   },
 };

--- a/src/definitions/models/soul.ts
+++ b/src/definitions/models/soul.ts
@@ -66,10 +66,10 @@ export const definition: ModelDefinition<typeof schema> = {
   schema,
   pricing: {
     higgsfield: {
-      description: "Flat ~$0.05 per image via Higgsfield",
-      calculate: () => 0.05,
-      minUsd: 0.05,
-      maxUsd: 0.05,
+      description: "$0.05 per image via Higgsfield (batch_size 1-4)",
+      calculate: ({ numImages = 1 }) => 0.05 * numImages,
+      minUsd: 0.05, // 1 image
+      maxUsd: 0.2, // 4 images
     },
   },
 };

--- a/src/definitions/models/soul.ts
+++ b/src/definitions/models/soul.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { soulQualitySchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Soul-specific dimension schema
 const soulDimensionSchema = z.enum([
@@ -60,6 +64,14 @@ export const definition: ModelDefinition<typeof schema> = {
     higgsfield: "/v1/text2image/soul",
   },
   schema,
+  pricing: {
+    higgsfield: {
+      description: "Flat ~$0.05 per image via Higgsfield",
+      calculate: () => 0.05,
+      minUsd: 0.05,
+      maxUsd: 0.05,
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/veed-fabric.ts
+++ b/src/definitions/models/veed-fabric.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { urlSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 const fabricResolutionSchema = z
   .enum(["480p", "720p"])
@@ -44,6 +48,17 @@ export const definition: ModelDefinition<typeof schema> = {
     fal: "veed/fabric-1.0",
   },
   schema,
+  pricing: {
+    fal: {
+      description: "$0.08/sec (480p), $0.15/sec (720p) via fal",
+      calculate: ({ duration = 5, resolution }) => {
+        const rate = resolution === "720p" ? 0.15 : 0.08;
+        return rate * duration;
+      },
+      minUsd: 0.24, // ~3s * $0.08 (480p)
+      maxUsd: 4.5, // ~30s * $0.15 (720p)
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/wan.ts
+++ b/src/definitions/models/wan.ts
@@ -46,11 +46,10 @@ export const definition: ModelDefinition<typeof schema> = {
   type: "model",
   name: "wan",
   description: "Wan-25 model for audio-driven video generation with lip sync",
-  providers: ["fal", "replicate"],
+  providers: ["fal"],
   defaultProvider: "fal",
   providerModels: {
     fal: "fal-ai/wan-25-preview/image-to-video",
-    replicate: "wan-video/wan-2.5-i2v",
   },
   schema,
   pricing: {

--- a/src/definitions/models/wan.ts
+++ b/src/definitions/models/wan.ts
@@ -8,7 +8,11 @@ import {
   resolutionSchema,
   videoDurationStringSchema,
 } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Input schema with Zod
 const wanInputSchema = z.object({
@@ -49,6 +53,23 @@ export const definition: ModelDefinition<typeof schema> = {
     replicate: "wan-video/wan-2.5-i2v",
   },
   schema,
+  pricing: {
+    fal: {
+      description:
+        "$0.05/sec (480p), $0.10/sec (720p), $0.15/sec (1080p) via fal",
+      calculate: ({ duration = 5, resolution }) => {
+        const rateMap: Record<string, number> = {
+          "480p": 0.05,
+          "720p": 0.1,
+          "1080p": 0.15,
+        };
+        const rate = rateMap[resolution ?? "480p"] ?? 0.05;
+        return rate * duration;
+      },
+      minUsd: 0.25, // 5s * $0.05 (480p)
+      maxUsd: 1.5, // 10s * $0.15 (1080p)
+    },
+  },
 };
 
 export default definition;

--- a/src/definitions/models/whisper.ts
+++ b/src/definitions/models/whisper.ts
@@ -5,7 +5,11 @@
 
 import { z } from "zod";
 import { filePathSchema } from "../../core/schema/shared";
-import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+import type {
+  ModelDefinition,
+  ProviderPricing,
+  ZodSchema,
+} from "../../core/schema/types";
 
 // Input schema with Zod
 const whisperInputSchema = z.object({
@@ -39,6 +43,26 @@ export const definition: ModelDefinition<typeof schema> = {
     fireworks: "whisper-v3-large",
   },
   schema,
+  pricing: {
+    groq: {
+      description:
+        "$0.111 per hour of audio via Groq (min 10s billing per request)",
+      calculate: ({ duration = 60 }) => {
+        const billableSeconds = Math.max(duration, 10);
+        return (billableSeconds / 3600) * 0.111;
+      },
+      minUsd: 0.0003, // 10s minimum
+      maxUsd: 0.111, // 1 hour
+    },
+    fireworks: {
+      description: "$0.0015 per audio minute via Fireworks (billed per second)",
+      calculate: ({ duration = 60 }) => {
+        return (duration / 60) * 0.0015;
+      },
+      minUsd: 0.0001, // few seconds
+      maxUsd: 0.09, // 1 hour
+    },
+  },
 };
 
 export default definition;

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -30,6 +30,7 @@ export type {
   ElementMeta,
   FileMetadata,
   GeneratedFileType,
+  GenerationPricingEntry,
   ImageProps,
   MusicProps,
   OverlayProps,

--- a/src/react/renderers/burn-captions.ts
+++ b/src/react/renderers/burn-captions.ts
@@ -1,3 +1,4 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { localBackend } from "@/ai-sdk/providers/editly";
 import type {
   FFmpegBackend,
@@ -16,12 +17,48 @@ async function resolveInputPathMaybeUpload(
   return backend.resolvePath(input.path);
 }
 
+/** Font file descriptor for caption rendering. */
+export interface CaptionFontFile {
+  /** Public URL of the font file (e.g. https://s3.varg.ai/fonts/Montserrat-Bold.ttf) */
+  url: string;
+  /** Filename (e.g. "Montserrat-Bold.ttf") */
+  fileName: string;
+}
+
 export interface CaptionOverlayOptions {
   video: FFmpegOutput;
   assPath: string;
   outputPath: string;
   backend?: FFmpegBackend;
   verbose?: boolean;
+  /** Font files to include for subtitle rendering. When provided, fontsdir is set. */
+  fontFiles?: CaptionFontFile[];
+}
+
+/** Local font cache directory. */
+const LOCAL_FONTS_DIR = "/tmp/varg-caption-fonts";
+
+/**
+ * Download font files to a local directory for the local FFmpeg backend.
+ * Fonts are cached by filename — only downloaded once per process lifetime.
+ */
+async function ensureLocalFonts(fontFiles: CaptionFontFile[]): Promise<string> {
+  if (!existsSync(LOCAL_FONTS_DIR)) {
+    mkdirSync(LOCAL_FONTS_DIR, { recursive: true });
+  }
+  await Promise.all(
+    fontFiles.map(async (font) => {
+      const localPath = `${LOCAL_FONTS_DIR}/${font.fileName}`;
+      if (existsSync(localPath)) return;
+      const res = await fetch(font.url);
+      if (!res.ok)
+        throw new Error(
+          `Failed to download font ${font.fileName}: ${res.status}`,
+        );
+      writeFileSync(localPath, new Uint8Array(await res.arrayBuffer()));
+    }),
+  );
+  return LOCAL_FONTS_DIR;
 }
 
 /**
@@ -32,30 +69,26 @@ export interface CaptionOverlayOptions {
  * FFmpeg backends - when using a cloud backend, input files are automatically
  * uploaded to storage.
  *
+ * When `fontFiles` are provided:
+ * - **Local backend**: fonts are downloaded to a temp directory, and `fontsdir=`
+ *   is appended to the subtitles filter so FFmpeg/libass can find them.
+ * - **Cloud backend (Rendi)**: font files are passed as `auxiliaryFiles` in the
+ *   run options. The backend bundles them into a compressed input folder and
+ *   uses `fontsdir=.` so FFmpeg finds them in the working directory.
+ *
  * @param options - Configuration for the caption burn operation
- * @param options.video - Source video as {@link FFmpegOutput} (file path or URL)
- * @param options.assPath - Path to the ASS subtitle file to burn
- * @param options.outputPath - Destination path for the output video (defaults to "output.mp4")
- * @param options.backend - Optional {@link FFmpegBackend} for cloud processing; uses local FFmpeg if omitted
- * @param options.verbose - Enable verbose FFmpeg logging
- *
  * @returns Promise resolving to {@link FFmpegOutput} containing the path or URL of the captioned video
- *
- * @throws May throw if FFmpeg execution fails, input files are missing, or upload fails for cloud backends
- *
- * @example
- * ```ts
- * const result = await burnCaptions({
- *   video: { type: "file", path: "input.mp4" },
- *   assPath: "captions.ass",
- *   outputPath: "output-with-captions.mp4",
- * });
- * ```
  */
 export async function burnCaptions(
   options: CaptionOverlayOptions,
 ): Promise<FFmpegOutput> {
-  const { video, assPath, outputPath = "output.mp4", verbose } = options;
+  const {
+    video,
+    assPath,
+    outputPath = "output.mp4",
+    verbose,
+    fontFiles,
+  } = options;
   const captions: FFmpegOutput = { type: "file", path: assPath };
 
   const backend = options.backend ?? localBackend;
@@ -71,12 +104,41 @@ export async function burnCaptions(
     ? assInput
     : assInput.replace(/\\/g, "\\\\").replace(/:/g, "\\:");
 
+  // Build the video filter with optional fontsdir
+  let videoFilter: string;
+  const useCompressedFolder = isCloud && fontFiles && fontFiles.length > 0;
+  if (fontFiles && fontFiles.length > 0) {
+    if (isCloud) {
+      // For Rendi compressed folder: use the bare filename of the ASS file
+      // (all files are in the same working directory after ZIP extraction)
+      const assFileName =
+        assInput.split("/").pop()?.split("?")[0] ?? "captions.ass";
+      videoFilter = `subtitles=${assFileName}:fontsdir=.`;
+    } else {
+      // For local: download fonts and point fontsdir to the local cache
+      const fontsDir = await ensureLocalFonts(fontFiles);
+      const escapedFontsDir = fontsDir
+        .replace(/\\/g, "\\\\")
+        .replace(/:/g, "\\:");
+      videoFilter = `subtitles=${subtitlesPath}:fontsdir=${escapedFontsDir}`;
+    }
+  } else {
+    videoFilter = `subtitles=${subtitlesPath}`;
+  }
+
+  // Build auxiliary files for cloud backends (fonts to bundle in compressed folder)
+  const auxiliaryFiles =
+    isCloud && fontFiles && fontFiles.length > 0
+      ? fontFiles.map((f) => ({ url: f.url, fileName: f.fileName }))
+      : undefined;
+
   const result = await backend.run({
     inputs: [videoInput, assInput],
-    videoFilter: `subtitles=${subtitlesPath}`,
+    videoFilter,
     outputArgs: ["-crf", "18", "-preset", "fast", "-c:a", "copy"],
     outputPath,
     verbose,
+    auxiliaryFiles,
   });
 
   return result.output;

--- a/src/react/renderers/captions.ts
+++ b/src/react/renderers/captions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { ResolvedElement } from "../resolved-element";
 import type { CaptionsProps, VargElement } from "../types";
 import type { RenderContext } from "./context";
+import { type FontResolution, getDefaultFontId, resolveFonts } from "./fonts";
 import { addTask, completeTask, startTask } from "./progress";
 import { renderSpeech } from "./speech";
 
@@ -156,12 +157,17 @@ function parseSrt(content: string): SrtEntry[] {
   return entries;
 }
 
+/**
+ * Format seconds to ASS timestamp `H:MM:SS.CC`.
+ * Computes from total centiseconds to avoid overflow when rounding
+ * lands on 100 cs (e.g. 1.999s would otherwise produce `0:00:01.100`).
+ */
 function formatAssTime(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  const cs = Math.floor((seconds % 1) * 100);
-
+  const totalCs = Math.max(0, Math.round(seconds * 100));
+  const h = Math.floor(totalCs / 360000);
+  const m = Math.floor((totalCs % 360000) / 6000);
+  const s = Math.floor((totalCs % 6000) / 100);
+  const cs = totalCs % 100;
   return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}.${String(cs).padStart(2, "0")}`;
 }
 
@@ -170,6 +176,7 @@ function convertSrtToAss(
   style: SubtitleStyle,
   width: number,
   height: number,
+  tagText?: (text: string) => string,
 ): string {
   const assHeader = `[Script Info]
 Title: Generated Subtitles
@@ -190,10 +197,17 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
   const entries = parseSrt(srtContent);
   const assDialogues = entries
-    .map((entry) => {
+    .map((entry, i) => {
       const start = formatAssTime(entry.start);
-      const end = formatAssTime(entry.end);
-      const text = entry.text.replace(/\n/g, "\\N");
+      // Clamp end to next entry's start to prevent overlapping subtitles
+      // (transcription engines often produce overlapping word timestamps)
+      const nextStart =
+        i < entries.length - 1 ? entries[i + 1]!.start : undefined;
+      const clampedEnd =
+        nextStart !== undefined ? Math.min(entry.end, nextStart) : entry.end;
+      const end = formatAssTime(clampedEnd);
+      const rawText = entry.text.replace(/\n/g, "\\N");
+      const text = tagText ? tagText(rawText) : rawText;
       return `Dialogue: 0,${start},${end},Default,,0,0,0,,${text}`;
     })
     .join("\n");
@@ -220,6 +234,7 @@ function convertSrtToAssGrouped(
   height: number,
   wordsPerLine: number,
   activeColor?: string,
+  tagText?: (text: string) => string,
 ): string {
   const assHeader = `[Script Info]
 Title: Generated Subtitles
@@ -256,7 +271,8 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
     if (!activeColor) {
       // No highlight — show entire group as one event
-      const text = group.map((e) => e.text.replace(/\n/g, " ")).join(" ");
+      const rawText = group.map((e) => e.text.replace(/\n/g, " ")).join(" ");
+      const text = tagText ? tagText(rawText) : rawText;
       dialogues.push(
         `Dialogue: 0,${formatAssTime(groupStart)},${formatAssTime(groupEnd)},Default,,0,0,0,,${text}`,
       );
@@ -268,9 +284,10 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         // Word ends at next word's start (within group), or at group end
         const wordEnd = wi < group.length - 1 ? group[wi + 1]!.start : groupEnd;
 
-        // Build the text line with ASS color overrides
+        // Build the text line with ASS color overrides (and optional font tags)
         const parts = group.map((entry, idx) => {
-          const word = entry.text.replace(/\n/g, " ").trim();
+          const rawWord = entry.text.replace(/\n/g, " ").trim();
+          const word = tagText ? tagText(rawWord) : rawWord;
           if (idx === wi) {
             // Active word — use highlight color
             return `{\\c${highlightColor}}${word}{\\c${baseColor}}`;
@@ -311,6 +328,8 @@ export interface CaptionsResult {
   assPath: string;
   srtPath?: string;
   audioPath?: string;
+  /** Font files needed for rendering (primary + any fallbacks for non-Latin scripts). */
+  fontFiles?: { url: string; fileName: string }[];
 }
 
 export async function renderCaptions(
@@ -436,12 +455,17 @@ export async function renderCaptions(
   };
   const baseStyle = STYLE_PRESETS[styleName] ?? defaultStyle;
 
+  // Resolve fonts: primary font from props.font or style default, plus fallbacks
+  const primaryFontId = props.font ?? getDefaultFontId(styleName);
+  const fontResolution = resolveFonts(srtContent, primaryFontId);
+
   const alignment = props.position
     ? (POSITION_ALIGNMENT[props.position] ?? baseStyle.alignment)
     : baseStyle.alignment;
 
   const style: SubtitleStyle = {
     ...baseStyle,
+    fontName: fontResolution.primary.fontName,
     fontSize: props.fontSize ?? baseStyle.fontSize,
     primaryColor: props.color
       ? colorToAss(props.color)
@@ -462,8 +486,15 @@ export async function renderCaptions(
         ctx.height,
         props.wordsPerLine,
         activeColorAss,
+        fontResolution.tagText,
       )
-    : convertSrtToAss(srtContent, style, ctx.width, ctx.height);
+    : convertSrtToAss(
+        srtContent,
+        style,
+        ctx.width,
+        ctx.height,
+        fontResolution.tagText,
+      );
   const assPath = `/tmp/varg-captions-${Date.now()}.ass`;
   writeFileSync(assPath, assContent);
   ctx.tempFiles.push(assPath);
@@ -472,5 +503,9 @@ export async function renderCaptions(
     assPath,
     srtPath,
     audioPath: props.withAudio ? audioPath : undefined,
+    fontFiles: fontResolution.fontFiles.map((f) => ({
+      url: f.url,
+      fileName: f.fileName,
+    })),
   };
 }

--- a/src/react/renderers/captions.ts
+++ b/src/react/renderers/captions.ts
@@ -2,12 +2,30 @@ import { writeFileSync } from "node:fs";
 import { groq } from "@ai-sdk/groq";
 import { experimental_transcribe as transcribe } from "ai";
 import { z } from "zod";
+import { smartJoin } from "../../speech/word-segmenter";
 import { ResolvedElement } from "../resolved-element";
 import type { CaptionsProps, VargElement } from "../types";
+import { ensureLocalFonts } from "./burn-captions";
 import type { RenderContext } from "./context";
+import {
+  calculateEmojiSize,
+  calculateEmojiY,
+  type EmojiInstance,
+  type EmojiOverlay,
+  extractEmoji,
+  hasEmoji,
+  stripEmoji,
+} from "./emoji";
 import { type FontResolution, getDefaultFontId, resolveFonts } from "./fonts";
 import { addTask, completeTask, startTask } from "./progress";
 import { renderSpeech } from "./speech";
+import {
+  type FontPathMap,
+  getCharXPositions,
+  getFontMetrics,
+  getSpaceWidth,
+  parseASSSegments,
+} from "./text-measure";
 
 const groqWordSchema = z.object({
   word: z.string(),
@@ -177,7 +195,9 @@ function convertSrtToAss(
   width: number,
   height: number,
   tagText?: (text: string) => string,
-): string {
+  collectEmoji?: boolean,
+  spacesPerEmoji?: number,
+): { ass: string; emojiData: EntryEmojiData[] } {
   const assHeader = `[Script Info]
 Title: Generated Subtitles
 ScriptType: v4.00+
@@ -195,24 +215,49 @@ Style: Default,${style.fontName},${style.fontSize},${style.primaryColor},&H00000
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 `;
 
+  const nSpaces = spacesPerEmoji ?? 1;
   const entries = parseSrt(srtContent);
+  const emojiData: EntryEmojiData[] = [];
+
   const assDialogues = entries
     .map((entry, i) => {
-      const start = formatAssTime(entry.start);
+      const startTime = entry.start;
       // Clamp end to next entry's start to prevent overlapping subtitles
       // (transcription engines often produce overlapping word timestamps)
       const nextStart =
         i < entries.length - 1 ? entries[i + 1]!.start : undefined;
       const clampedEnd =
         nextStart !== undefined ? Math.min(entry.end, nextStart) : entry.end;
+
+      const start = formatAssTime(startTime);
       const end = formatAssTime(clampedEnd);
-      const rawText = entry.text.replace(/\n/g, "\\N");
+
+      let rawText = entry.text.replace(/\n/g, "\\N");
+
+      // Strip emoji from text and collect overlay data
+      let entryEmojiInstances: EmojiInstance[] | undefined;
+      if (collectEmoji && hasEmoji(rawText)) {
+        entryEmojiInstances = extractEmoji(rawText, nSpaces);
+        rawText = stripEmoji(rawText, nSpaces);
+      }
+
       const text = tagText ? tagText(rawText) : rawText;
+
+      // Collect emoji data with the tagged text for precise measurement
+      if (entryEmojiInstances) {
+        emojiData.push({
+          instances: entryEmojiInstances,
+          taggedStrippedText: text,
+          startTime,
+          endTime: clampedEnd,
+        });
+      }
+
       return `Dialogue: 0,${start},${end},Default,,0,0,0,,${text}`;
     })
     .join("\n");
 
-  return assHeader + assDialogues;
+  return { ass: assHeader + assDialogues, emojiData };
 }
 
 /**
@@ -235,7 +280,9 @@ function convertSrtToAssGrouped(
   wordsPerLine: number,
   activeColor?: string,
   tagText?: (text: string) => string,
-): string {
+  collectEmoji?: boolean,
+  spacesPerEmoji?: number,
+): { ass: string; emojiData: EntryEmojiData[] } {
   const assHeader = `[Script Info]
 Title: Generated Subtitles
 ScriptType: v4.00+
@@ -253,8 +300,10 @@ Style: Default,${style.fontName},${style.fontSize},${style.primaryColor},&H00000
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 `;
 
+  const nSpaces = spacesPerEmoji ?? 1;
   const entries = parseSrt(srtContent);
   const dialogues: string[] = [];
+  const emojiData: EntryEmojiData[] = [];
   const baseColor = style.primaryColor;
   const highlightColor = activeColor ?? baseColor;
 
@@ -271,38 +320,100 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
     if (!activeColor) {
       // No highlight — show entire group as one event
-      const rawText = group.map((e) => e.text.replace(/\n/g, " ")).join(" ");
+      let rawText = smartJoin(group.map((e) => e.text.replace(/\n/g, " ")));
+
+      // Strip emoji from the grouped text line
+      let groupEmojiInstances: EmojiInstance[] | undefined;
+      if (collectEmoji && hasEmoji(rawText)) {
+        groupEmojiInstances = extractEmoji(rawText, nSpaces);
+        rawText = stripEmoji(rawText, nSpaces);
+      }
+
       const text = tagText ? tagText(rawText) : rawText;
+
+      if (groupEmojiInstances) {
+        emojiData.push({
+          instances: groupEmojiInstances,
+          taggedStrippedText: text,
+          startTime: groupStart,
+          endTime: groupEnd,
+        });
+      }
+
       dialogues.push(
         `Dialogue: 0,${formatAssTime(groupStart)},${formatAssTime(groupEnd)},Default,,0,0,0,,${text}`,
       );
     } else {
       // Karaoke highlight — one dialogue event per word, shifting the highlight
+      // For emoji in karaoke mode, we strip emoji from the full group line
+      // and collect overlay data once (for the full group duration).
+      const allGroupWords: string[] = [];
+      for (const entry of group) {
+        allGroupWords.push(entry.text.replace(/\n/g, " ").trim());
+      }
+      const fullLineRaw = smartJoin(allGroupWords);
+
+      let lineEmojiInstances: EmojiInstance[] | undefined;
+      let strippedFullLine: string | undefined;
+      if (collectEmoji && hasEmoji(fullLineRaw)) {
+        lineEmojiInstances = extractEmoji(fullLineRaw, nSpaces);
+        strippedFullLine = stripEmoji(fullLineRaw, nSpaces);
+      }
+
+      // Build per-word stripped words for highlight assembly
+      const strippedWords = lineEmojiInstances
+        ? allGroupWords.map((w) => (hasEmoji(w) ? stripEmoji(w, nSpaces) : w))
+        : allGroupWords;
+
       for (let wi = 0; wi < group.length; wi++) {
         const wordEntry = group[wi]!;
         const wordStart = wordEntry.start;
-        // Word ends at next word's start (within group), or at group end
         const wordEnd = wi < group.length - 1 ? group[wi + 1]!.start : groupEnd;
 
-        // Build the text line with ASS color overrides (and optional font tags)
-        const parts = group.map((entry, idx) => {
-          const rawWord = entry.text.replace(/\n/g, " ").trim();
+        const parts: string[] = [];
+        for (let idx = 0; idx < group.length; idx++) {
+          const rawWord = strippedWords[idx]?.trim() ?? "";
           const word = tagText ? tagText(rawWord) : rawWord;
           if (idx === wi) {
-            // Active word — use highlight color
-            return `{\\c${highlightColor}}${word}{\\c${baseColor}}`;
+            parts.push(`{\\c${highlightColor}}${word}{\\c${baseColor}}`);
+          } else {
+            parts.push(word);
           }
-          return word;
-        });
+        }
+
+        const lineText = smartJoin(parts);
+
+        // Collect emoji data once for the first word's dialogue
+        // (all words in the group show the same line text, just with different highlight)
+        if (wi === 0 && lineEmojiInstances) {
+          emojiData.push({
+            instances: lineEmojiInstances,
+            taggedStrippedText: lineText,
+            startTime: groupStart,
+            endTime: groupEnd,
+          });
+        }
 
         dialogues.push(
-          `Dialogue: 0,${formatAssTime(wordStart)},${formatAssTime(wordEnd)},Default,,0,0,0,,${parts.join(" ")}`,
+          `Dialogue: 0,${formatAssTime(wordStart)},${formatAssTime(wordEnd)},Default,,0,0,0,,${lineText}`,
         );
       }
     }
   }
 
-  return assHeader + dialogues.join("\n");
+  return { ass: assHeader + dialogues.join("\n"), emojiData };
+}
+
+/** Emoji data collected from a single ASS dialogue line. */
+interface EntryEmojiData {
+  /** Emoji instances found in this entry's text. */
+  instances: EmojiInstance[];
+  /** The stripped text (emoji replaced with spaces) AFTER {\fn} tagging by tagText(). */
+  taggedStrippedText: string;
+  /** Start time in seconds. */
+  startTime: number;
+  /** End time in seconds. */
+  endTime: number;
 }
 
 const POSITION_ALIGNMENT: Record<string, number> = {
@@ -330,6 +441,8 @@ export interface CaptionsResult {
   audioPath?: string;
   /** Font files needed for rendering (primary + any fallbacks for non-Latin scripts). */
   fontFiles?: { url: string; fileName: string }[];
+  /** Emoji overlay data for color emoji rendering via image overlay. */
+  emojiOverlays?: EmojiOverlay[];
 }
 
 export async function renderCaptions(
@@ -478,7 +591,45 @@ export async function renderCaptions(
     ? colorToAss(props.activeColor)
     : undefined;
 
-  const assContent = props.wordsPerLine
+  // Check if the SRT content has emoji — if so, we'll strip them from ASS
+  // text and build overlay data for color PNG rendering
+  const srtHasEmoji = hasEmoji(srtContent);
+
+  // When emoji are present, compute how many spaces to reserve per emoji
+  // using precise font metrics from the primary font
+  let spacesPerEmoji: number | undefined;
+  let fontPathMap: FontPathMap | undefined;
+  if (srtHasEmoji) {
+    // Download fonts locally for measurement
+    const localFontsDir = await ensureLocalFonts(
+      fontResolution.fontFiles.map((f) => ({
+        url: f.url,
+        fileName: f.fileName,
+      })),
+    );
+
+    // Build font name → local path mapping
+    fontPathMap = new Map();
+    for (const f of fontResolution.fontFiles) {
+      fontPathMap.set(f.fontName, `${localFontsDir}/${f.fileName}`);
+    }
+
+    // Compute spacesPerEmoji using real font metrics
+    const primaryFontPath = fontPathMap.get(fontResolution.primary.fontName);
+    if (primaryFontPath) {
+      const metrics = getFontMetrics(primaryFontPath, style.fontSize);
+      const emojiSize = calculateEmojiSize(
+        metrics.winAscent,
+        ctx.height,
+        ctx.height,
+      );
+      const spaceWidth = getSpaceWidth(primaryFontPath, style.fontSize);
+      // +1 buffer space for visual breathing room between emoji and adjacent text
+      spacesPerEmoji = Math.max(1, Math.ceil(emojiSize / spaceWidth) + 1);
+    }
+  }
+
+  const { ass: assContent, emojiData } = props.wordsPerLine
     ? convertSrtToAssGrouped(
         srtContent,
         style,
@@ -487,6 +638,8 @@ export async function renderCaptions(
         props.wordsPerLine,
         activeColorAss,
         fontResolution.tagText,
+        srtHasEmoji,
+        spacesPerEmoji,
       )
     : convertSrtToAss(
         srtContent,
@@ -494,18 +647,97 @@ export async function renderCaptions(
         ctx.width,
         ctx.height,
         fontResolution.tagText,
+        srtHasEmoji,
+        spacesPerEmoji,
       );
   const assPath = `/tmp/varg-captions-${Date.now()}.ass`;
   writeFileSync(assPath, assContent);
   ctx.tempFiles.push(assPath);
 
+  // Build emoji overlay descriptors with precise pixel positions from font metrics
+  let emojiOverlays: EmojiOverlay[] | undefined;
+  if (emojiData.length > 0 && fontPathMap) {
+    const primaryFontPath = fontPathMap.get(style.fontName);
+    const metrics = primaryFontPath
+      ? getFontMetrics(primaryFontPath, style.fontSize)
+      : {
+          ppem: style.fontSize * 0.64,
+          capHeight: style.fontSize * 0.45,
+          winAscent: style.fontSize * 0.7,
+          winDescent: style.fontSize * 0.3,
+        };
+    const emojiSize = calculateEmojiSize(
+      metrics.winAscent,
+      ctx.height,
+      ctx.height,
+    );
+    const nSpaces = spacesPerEmoji ?? 1;
+    const spaceW = primaryFontPath
+      ? getSpaceWidth(primaryFontPath, style.fontSize)
+      : metrics.ppem * 0.28;
+    emojiOverlays = [];
+    for (const entry of emojiData) {
+      const segments = parseASSSegments(
+        entry.taggedStrippedText,
+        style.fontName,
+      );
+      const charPositions = getCharXPositions(
+        segments,
+        fontPathMap,
+        style.fontSize,
+        ctx.width,
+        style.alignment,
+      );
+
+      for (const instance of entry.instances) {
+        // charIndex points to the first space in the reserved block.
+        // Center the emoji within the reserved space block.
+        const firstSpaceX = charPositions[instance.charIndex] ?? 0;
+        const lastSpaceIdx = Math.min(
+          instance.charIndex + nSpaces - 1,
+          charPositions.length - 1,
+        );
+        const lastSpaceX = charPositions[lastSpaceIdx] ?? firstSpaceX;
+        const blockEndX = lastSpaceX + spaceW;
+        const blockWidth = blockEndX - firstSpaceX;
+        const x = Math.round(firstSpaceX + blockWidth / 2 - emojiSize / 2);
+
+        const y = calculateEmojiY(
+          style.alignment,
+          style.marginV,
+          metrics.winDescent,
+          metrics.winAscent,
+          metrics.capHeight,
+          ctx.height,
+          ctx.height,
+        );
+        emojiOverlays.push({
+          url: instance.url,
+          fileName: `${instance.codepoints}.png`,
+          startTime: entry.startTime,
+          endTime: entry.endTime,
+          x,
+          y,
+          size: emojiSize,
+        });
+      }
+    }
+  }
+
+  // When emoji are overlaid as color PNGs, exclude Noto Emoji from font files
+  // (emoji chars are spaces in the ASS text, so the monochrome font is unused)
+  const fontFiles = fontResolution.fontFiles
+    .filter(
+      (f) =>
+        !(emojiOverlays && emojiOverlays.length > 0 && f.id === "noto-emoji"),
+    )
+    .map((f) => ({ url: f.url, fileName: f.fileName }));
+
   return {
     assPath,
     srtPath,
     audioPath: props.withAudio ? audioPath : undefined,
-    fontFiles: fontResolution.fontFiles.map((f) => ({
-      url: f.url,
-      fileName: f.fileName,
-    })),
+    fontFiles,
+    emojiOverlays,
   };
 }

--- a/src/react/renderers/emoji.ts
+++ b/src/react/renderers/emoji.ts
@@ -1,0 +1,247 @@
+/**
+ * Emoji image overlay for caption rendering.
+ *
+ * Since libass (used by ffmpeg's subtitles filter) cannot render color emoji
+ * from any font format, we extract emoji from caption text, replace them with
+ * spaces in the ASS subtitle, and overlay the emoji as PNG images using
+ * ffmpeg's overlay filter.
+ *
+ * Emoji PNGs are Apple-style, extracted from Apple Color Emoji and hosted
+ * on s3.varg.ai/emoji/{codepoint}.png (96x96 px with transparency).
+ */
+
+const EMOJI_S3_BASE = "https://s3.varg.ai/emoji";
+
+// Regex to match emoji characters (SMP pictographic emoji + common BMP emoji)
+// This covers:
+// - Emoticons (1F600-1F64F)
+// - Misc symbols and pictographs (1F300-1F5FF)
+// - Transport and map symbols (1F680-1F6FF)
+// - Supplemental symbols (1F900-1F9FF)
+// - Symbols extended-A (1FA00-1FAFF)
+// - Misc symbols (2600-26FF)
+// - Dingbats (2700-27BF)
+// - Various BMP emoji (2B50, 2705, etc.)
+// Also handles variation selectors (FE0F) and ZWJ (200D) sequences
+const EMOJI_REGEX =
+  /(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F)(?:\u200D(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F))*/gu;
+
+export interface EmojiInstance {
+  /** The emoji string (may be multi-codepoint for ZWJ sequences) */
+  emoji: string;
+  /** Hex codepoint(s) for the S3 filename (e.g. "1f4aa" or "1f468-200d-1f469") */
+  codepoints: string;
+  /** URL of the emoji PNG on S3 */
+  url: string;
+  /** Character index in the original text where this emoji starts */
+  charIndex: number;
+}
+
+export interface EmojiOverlay {
+  /** The emoji PNG URL */
+  url: string;
+  /** The emoji PNG filename */
+  fileName: string;
+  /** Start time in seconds */
+  startTime: number;
+  /** End time in seconds */
+  endTime: number;
+  /** X position in pixels (from left) */
+  x: number;
+  /** Y position in pixels (from top) */
+  y: number;
+  /** Size in pixels (width = height, emoji are square) */
+  size: number;
+}
+
+/**
+ * Strip emoji from text, replacing each emoji with a space character.
+ * This reserves horizontal space in the rendered subtitle.
+ */
+export function stripEmoji(text: string): string {
+  EMOJI_REGEX.lastIndex = 0;
+  return text.replace(EMOJI_REGEX, " ");
+}
+
+/**
+ * Extract emoji from text, returning their codepoints and positions.
+ *
+ * The `charIndex` in the result corresponds to the position in the
+ * STRIPPED text (where each emoji is replaced by a single space).
+ * This is the index needed for X-position calculation.
+ */
+export function extractEmoji(text: string): EmojiInstance[] {
+  const results: EmojiInstance[] = [];
+
+  // Reset regex state
+  EMOJI_REGEX.lastIndex = 0;
+
+  // Track how many characters have been "shrunk" by emoji → space replacement
+  // Each emoji (possibly multi-char in JS) gets replaced by one space
+  let shrinkage = 0;
+
+  for (
+    let match = EMOJI_REGEX.exec(text);
+    match !== null;
+    match = EMOJI_REGEX.exec(text)
+  ) {
+    const emoji = match[0];
+    // Build codepoint filename: strip variation selectors (FE0F) for lookup
+    const cps: number[] = [];
+    for (const char of emoji) {
+      const cp = char.codePointAt(0);
+      if (cp === undefined) continue;
+      // Skip variation selectors — S3 filenames don't include them
+      if (cp === 0xfe0f) continue;
+      cps.push(cp);
+    }
+    const codepoints = cps.map((cp) => cp.toString(16)).join("-");
+
+    // Position in the stripped text: original index minus accumulated shrinkage
+    const strippedIndex = match.index - shrinkage;
+
+    results.push({
+      emoji,
+      codepoints,
+      url: `${EMOJI_S3_BASE}/${codepoints}.png`,
+      charIndex: strippedIndex,
+    });
+
+    // This emoji occupies emoji.length chars in original but 1 space in stripped
+    shrinkage += emoji.length - 1;
+  }
+
+  return results;
+}
+
+/**
+ * Rendered emoji size in pixels, given the ASS font size and video dimensions.
+ *
+ * ASS fontSize doesn't map 1:1 to rendered pixel height — libass applies its
+ * own scaling. Empirically, the rendered text height is ~0.55x the ASS fontSize
+ * when PlayRes matches the video resolution (the common case in our pipeline).
+ */
+export function calculateEmojiSize(
+  fontSize: number,
+  playResY: number,
+  videoHeight: number,
+): number {
+  const scale = videoHeight / playResY;
+  // Emoji should be slightly larger than text cap-height for visual balance
+  return Math.round(fontSize * 0.55 * scale);
+}
+
+/**
+ * Calculate the X position of a character within a rendered subtitle line.
+ *
+ * Uses the empirical character width ratio for bold sans-serif fonts rendered
+ * by libass. The ratio is ~0.38 * fontSize (in PlayRes units).
+ *
+ * @param charIndex - Index of the character in the text string (after emoji stripping)
+ * @param textLength - Total number of characters in the text
+ * @param fontSize - ASS font size (in PlayRes units)
+ * @param playResX - ASS PlayResX (horizontal resolution)
+ * @param videoWidth - Actual video width in pixels
+ */
+export function calculateEmojiX(
+  charIndex: number,
+  textLength: number,
+  fontSize: number,
+  playResX: number,
+  videoWidth: number,
+): number {
+  // Empirical average character width for bold sans-serif in libass
+  const charWidth = fontSize * 0.38;
+  const totalTextWidth = textLength * charWidth;
+
+  // For center-aligned text (Alignment 2, 5, or 8):
+  const textStartX = playResX / 2 - totalTextWidth / 2;
+  const emojiX = textStartX + charIndex * charWidth;
+
+  const scale = videoWidth / playResX;
+  return Math.round(emojiX * scale);
+}
+
+/**
+ * Calculate the Y position of the emoji based on ASS alignment and margins.
+ *
+ * @param alignment - ASS alignment (2=bottom-center, 5=center, 8=top-center)
+ * @param marginV - ASS vertical margin
+ * @param fontSize - ASS font size
+ * @param playResY - ASS PlayResY
+ * @param videoHeight - Actual video height
+ */
+export function calculateEmojiY(
+  alignment: number,
+  marginV: number,
+  fontSize: number,
+  playResY: number,
+  videoHeight: number,
+): number {
+  const scale = videoHeight / playResY;
+  let y: number;
+
+  if (alignment >= 7) {
+    // Top alignment (7, 8, 9)
+    y = marginV;
+  } else if (alignment >= 4) {
+    // Center alignment (4, 5, 6)
+    y = playResY / 2 - (fontSize * 0.55) / 2;
+  } else {
+    // Bottom alignment (1, 2, 3)
+    // Empirical: text baseline sits at playResY - marginV - fontSize*0.75
+    y = playResY - marginV - fontSize * 0.75;
+  }
+
+  return Math.round(y * scale);
+}
+
+/**
+ * Build the ffmpeg filter_complex string for emoji overlays.
+ *
+ * The filter chain:
+ * 1. Apply subtitles filter to burn text captions
+ * 2. For each emoji, overlay its PNG at the calculated position with timing
+ *
+ * @param subtitlesFilter - The subtitles= filter string (already built)
+ * @param overlays - Array of emoji overlay descriptors
+ * @param inputCount - Number of existing inputs (video + ASS = 2)
+ * @returns The complete filter_complex string
+ */
+export function buildEmojiFilterComplex(
+  subtitlesFilter: string,
+  overlays: EmojiOverlay[],
+  inputCount: number,
+): string {
+  if (overlays.length === 0) {
+    // No emoji — just return the subtitles filter as a videoFilter
+    return subtitlesFilter;
+  }
+
+  const parts: string[] = [];
+
+  // Step 1: Apply subtitles filter
+  parts.push(`[0:v]${subtitlesFilter}[sub]`);
+
+  // Step 2: Scale and overlay each emoji PNG
+  let prevLabel = "sub";
+  for (let i = 0; i < overlays.length; i++) {
+    const overlay = overlays[i];
+    if (!overlay) continue;
+    const inputIdx = inputCount + i; // emoji inputs start after video + ASS
+    const nextLabel = i === overlays.length - 1 ? "vout" : `v${i}`;
+
+    // Scale emoji PNG to match font size, then overlay with timing
+    const scaleFilter = `[${inputIdx}:v]scale=${overlay.size}:${overlay.size}:flags=lanczos,format=rgba[emoji${i}]`;
+    parts.push(scaleFilter);
+
+    const overlayFilter =
+      `[${prevLabel}][emoji${i}]overlay=x=${overlay.x}:y=${overlay.y}` +
+      `:enable='between(t,${overlay.startTime.toFixed(2)},${overlay.endTime.toFixed(2)})'` +
+      `[${nextLabel}]`;
+    parts.push(overlayFilter);
+    prevLabel = nextLabel;
+  }
+
+  return parts.join(";");
+}

--- a/src/react/renderers/fonts.test.ts
+++ b/src/react/renderers/fonts.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from "bun:test";
+import {
+  detectScript,
+  detectScriptsInText,
+  FALLBACK_FONTS,
+  getDefaultFontId,
+  getPrimaryFont,
+  PRIMARY_FONTS,
+  resolveFonts,
+  type Script,
+} from "./fonts";
+
+// ---------------------------------------------------------------------------
+// detectScript
+// ---------------------------------------------------------------------------
+
+describe("detectScript", () => {
+  test("detects Latin characters", () => {
+    expect(detectScript("A".codePointAt(0)!)).toBe("latin");
+    expect(detectScript("z".codePointAt(0)!)).toBe("latin");
+    expect(detectScript("é".codePointAt(0)!)).toBe("latin");
+    expect(detectScript("ñ".codePointAt(0)!)).toBe("latin");
+  });
+
+  test("detects Cyrillic characters", () => {
+    expect(detectScript("Я".codePointAt(0)!)).toBe("cyrillic");
+    expect(detectScript("щ".codePointAt(0)!)).toBe("cyrillic");
+    expect(detectScript("Ї".codePointAt(0)!)).toBe("cyrillic");
+  });
+
+  test("detects Greek characters", () => {
+    expect(detectScript("Ω".codePointAt(0)!)).toBe("greek");
+    expect(detectScript("α".codePointAt(0)!)).toBe("greek");
+  });
+
+  test("detects Hiragana", () => {
+    expect(detectScript("あ".codePointAt(0)!)).toBe("hiragana");
+    expect(detectScript("ん".codePointAt(0)!)).toBe("hiragana");
+  });
+
+  test("detects Katakana", () => {
+    expect(detectScript("ア".codePointAt(0)!)).toBe("katakana");
+    expect(detectScript("ン".codePointAt(0)!)).toBe("katakana");
+  });
+
+  test("detects CJK ideographs", () => {
+    expect(detectScript("漢".codePointAt(0)!)).toBe("cjk");
+    expect(detectScript("字".codePointAt(0)!)).toBe("cjk");
+  });
+
+  test("detects Hangul", () => {
+    expect(detectScript("한".codePointAt(0)!)).toBe("hangul");
+    expect(detectScript("글".codePointAt(0)!)).toBe("hangul");
+  });
+
+  test("detects Arabic", () => {
+    expect(detectScript("ع".codePointAt(0)!)).toBe("arabic");
+    expect(detectScript("ب".codePointAt(0)!)).toBe("arabic");
+  });
+
+  test("detects Hebrew", () => {
+    expect(detectScript("א".codePointAt(0)!)).toBe("hebrew");
+    expect(detectScript("ש".codePointAt(0)!)).toBe("hebrew");
+  });
+
+  test("detects Devanagari", () => {
+    expect(detectScript("अ".codePointAt(0)!)).toBe("devanagari");
+    expect(detectScript("ह".codePointAt(0)!)).toBe("devanagari");
+  });
+
+  test("detects Thai", () => {
+    expect(detectScript("ก".codePointAt(0)!)).toBe("thai");
+    expect(detectScript("ม".codePointAt(0)!)).toBe("thai");
+  });
+
+  test("detects emoji", () => {
+    expect(detectScript("😀".codePointAt(0)!)).toBe("emoji");
+    expect(detectScript("🎉".codePointAt(0)!)).toBe("emoji");
+    expect(detectScript("💪".codePointAt(0)!)).toBe("emoji");
+  });
+
+  test("detects common characters (digits, punctuation, spaces)", () => {
+    expect(detectScript(" ".codePointAt(0)!)).toBe("common");
+    expect(detectScript("0".codePointAt(0)!)).toBe("common");
+    expect(detectScript("!".codePointAt(0)!)).toBe("common");
+    expect(detectScript(",".codePointAt(0)!)).toBe("common");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectScriptsInText
+// ---------------------------------------------------------------------------
+
+describe("detectScriptsInText", () => {
+  test("pure English", () => {
+    const scripts = detectScriptsInText("Hello world");
+    expect(scripts.has("latin")).toBe(true);
+    expect(scripts.size).toBe(1);
+  });
+
+  test("pure Japanese", () => {
+    const scripts = detectScriptsInText("こんにちは世界");
+    expect(scripts.has("hiragana")).toBe(true);
+    expect(scripts.has("cjk")).toBe(true);
+  });
+
+  test("mixed English + Japanese", () => {
+    const scripts = detectScriptsInText("Hello こんにちは");
+    expect(scripts.has("latin")).toBe(true);
+    expect(scripts.has("hiragana")).toBe(true);
+  });
+
+  test("Russian text", () => {
+    const scripts = detectScriptsInText("Привет мир");
+    expect(scripts.has("cyrillic")).toBe(true);
+    expect(scripts.size).toBe(1);
+  });
+
+  test("Arabic text", () => {
+    const scripts = detectScriptsInText("مرحبا بالعالم");
+    expect(scripts.has("arabic")).toBe(true);
+  });
+
+  test("Korean text", () => {
+    const scripts = detectScriptsInText("안녕하세요");
+    expect(scripts.has("hangul")).toBe(true);
+  });
+
+  test("English + emoji", () => {
+    const scripts = detectScriptsInText("Let's go! 💪🎉");
+    expect(scripts.has("latin")).toBe(true);
+    expect(scripts.has("emoji")).toBe(true);
+  });
+
+  test("mixed Japanese + English + emoji", () => {
+    const scripts = detectScriptsInText("エアスクワット Let's go! 💪");
+    expect(scripts.has("katakana")).toBe(true);
+    expect(scripts.has("latin")).toBe(true);
+    expect(scripts.has("emoji")).toBe(true);
+  });
+
+  test("empty string returns empty set", () => {
+    const scripts = detectScriptsInText("");
+    expect(scripts.size).toBe(0);
+  });
+
+  test("only punctuation returns empty set (common excluded)", () => {
+    const scripts = detectScriptsInText("... !!! ???");
+    expect(scripts.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFonts
+// ---------------------------------------------------------------------------
+
+describe("resolveFonts", () => {
+  test("pure Latin with Montserrat — no fallbacks needed", () => {
+    const { fontFiles, tagText, primary } = resolveFonts(
+      "Hello world, this is a test.",
+      "montserrat",
+    );
+    expect(primary.id).toBe("montserrat");
+    expect(fontFiles.length).toBe(1);
+    expect(fontFiles[0]!.id).toBe("montserrat");
+    // No tagging needed
+    expect(tagText("Hello world")).toBe("Hello world");
+  });
+
+  test("pure Cyrillic with Montserrat — no fallbacks (Montserrat covers Cyrillic)", () => {
+    const { fontFiles, tagText } = resolveFonts("Привет мир", "montserrat");
+    expect(fontFiles.length).toBe(1);
+    expect(tagText("Привет мир")).toBe("Привет мир");
+  });
+
+  test("Japanese text with Montserrat — Noto CJK JP fallback added", () => {
+    const { fontFiles, tagText, primary } = resolveFonts(
+      "こんにちは",
+      "montserrat",
+    );
+    expect(primary.id).toBe("montserrat");
+    expect(fontFiles.length).toBe(2); // Montserrat + Noto Sans CJK JP
+    expect(fontFiles.some((f) => f.id === "noto-sans-cjk-jp")).toBe(true);
+    // Text should be tagged with Noto font
+    const tagged = tagText("こんにちは");
+    expect(tagged).toContain("{\\fnNoto Sans CJK JP}");
+  });
+
+  test("mixed English + Japanese — tags at script boundaries", () => {
+    const { tagText } = resolveFonts("Hello こんにちは world", "montserrat");
+    const tagged = tagText("Hello こんにちは world");
+    // Should start with Latin (no tag needed, it's the default)
+    expect(tagged).toMatch(/^Hello /);
+    // Should switch to Noto for Japanese (space before Japanese inherits left context = primary)
+    expect(tagged).toContain("{\\fnNoto Sans CJK JP}こんにちは");
+    // Should switch back to Montserrat for English
+    // Note: space between Japanese and English inherits Japanese font (left context)
+    expect(tagged).toContain("{\\fnMontserrat}world");
+  });
+
+  test("Arabic text with Montserrat — Noto Arabic fallback", () => {
+    const { fontFiles, tagText } = resolveFonts("مرحبا بالعالم", "montserrat");
+    expect(fontFiles.some((f) => f.id === "noto-sans-arabic")).toBe(true);
+    const tagged = tagText("مرحبا بالعالم");
+    expect(tagged).toContain("{\\fnNoto Sans Arabic}");
+  });
+
+  test("Korean text with Roboto — Noto CJK KR fallback", () => {
+    const { fontFiles } = resolveFonts("안녕하세요", "roboto");
+    expect(fontFiles.some((f) => f.id === "noto-sans-cjk-kr")).toBe(true);
+  });
+
+  test("English + emoji — Noto Emoji fallback", () => {
+    const { fontFiles, tagText } = resolveFonts("Let's go! 💪", "montserrat");
+    expect(fontFiles.some((f) => f.id === "noto-emoji")).toBe(true);
+    const tagged = tagText("Let's go! 💪");
+    expect(tagged).toContain("{\\fnNoto Emoji}💪");
+  });
+
+  test("Poppins covers Devanagari — no fallback needed for Hindi", () => {
+    const { fontFiles } = resolveFonts("नमस्ते दुनिया", "poppins");
+    // Poppins covers devanagari natively
+    expect(fontFiles.length).toBe(1);
+    expect(fontFiles[0]!.id).toBe("poppins");
+  });
+
+  test("unknown font ID falls back to Montserrat", () => {
+    const { primary } = resolveFonts("Hello", "nonexistent-font");
+    expect(primary.id).toBe("montserrat");
+  });
+
+  test("multiple fallbacks for complex mixed text", () => {
+    const { fontFiles } = resolveFonts(
+      "Hello こんにちは 안녕 مرحبا 💪",
+      "montserrat",
+    );
+    // Need: montserrat + noto-cjk-jp (for hiragana/cjk) + noto-cjk-kr (for hangul) + noto-arabic + noto-emoji
+    expect(fontFiles.length).toBe(5);
+    const ids = fontFiles.map((f) => f.id);
+    expect(ids).toContain("montserrat");
+    expect(ids).toContain("noto-sans-cjk-jp");
+    expect(ids).toContain("noto-sans-cjk-kr");
+    expect(ids).toContain("noto-sans-arabic");
+    expect(ids).toContain("noto-emoji");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Font registry helpers
+// ---------------------------------------------------------------------------
+
+describe("font registry", () => {
+  test("all primary fonts have valid S3 URLs", () => {
+    for (const font of Object.values(PRIMARY_FONTS)) {
+      expect(font.url).toMatch(/^https:\/\/s3\.varg\.ai\/fonts\//);
+      expect(font.fileName).toBeTruthy();
+      expect(font.fontName).toBeTruthy();
+    }
+  });
+
+  test("all fallback fonts have valid S3 URLs", () => {
+    for (const font of FALLBACK_FONTS) {
+      expect(font.url).toMatch(/^https:\/\/s3\.varg\.ai\/fonts\//);
+      expect(font.fileName).toBeTruthy();
+      expect(font.fontName).toBeTruthy();
+    }
+  });
+
+  test("getPrimaryFont returns correct font", () => {
+    expect(getPrimaryFont("montserrat")?.fontName).toBe("Montserrat");
+    expect(getPrimaryFont("roboto")?.fontName).toBe("Roboto");
+    expect(getPrimaryFont("nonexistent")).toBeUndefined();
+  });
+
+  test("getDefaultFontId returns correct defaults", () => {
+    expect(getDefaultFontId("tiktok")).toBe("montserrat");
+    expect(getDefaultFontId("karaoke")).toBe("roboto");
+    expect(getDefaultFontId("bounce")).toBe("oswald");
+    expect(getDefaultFontId("typewriter")).toBe("dm-sans");
+    expect(getDefaultFontId("unknown")).toBe("montserrat");
+  });
+
+  test("every script has at least one fallback font", () => {
+    const allScripts: Script[] = [
+      "latin",
+      "cyrillic",
+      "greek",
+      "cjk",
+      "hiragana",
+      "katakana",
+      "hangul",
+      "arabic",
+      "hebrew",
+      "devanagari",
+      "thai",
+      "bengali",
+      "emoji",
+    ];
+    for (const script of allScripts) {
+      const hasFallback = FALLBACK_FONTS.some((f) =>
+        f.scripts.includes(script),
+      );
+      expect(hasFallback).toBe(true);
+    }
+  });
+});

--- a/src/react/renderers/fonts.ts
+++ b/src/react/renderers/fonts.ts
@@ -1,0 +1,509 @@
+/**
+ * Universal font support for ASS subtitle rendering.
+ *
+ * Two-layer system:
+ * - Primary fonts: aesthetic/style fonts (Montserrat, Roboto, etc.) for Latin/Cyrillic
+ * - Fallback fonts: Noto family, auto-selected per-script for characters the primary can't render
+ *
+ * The SDK detects which Unicode scripts are present in caption text, selects the
+ * minimum set of fonts needed, and injects {\fn} ASS override tags at script
+ * boundaries so mixed-language text renders correctly in a single subtitle line.
+ */
+
+// ---------------------------------------------------------------------------
+// Script detection
+// ---------------------------------------------------------------------------
+
+export type Script =
+  | "latin"
+  | "cyrillic"
+  | "greek"
+  | "cjk"
+  | "hiragana"
+  | "katakana"
+  | "hangul"
+  | "arabic"
+  | "hebrew"
+  | "devanagari"
+  | "thai"
+  | "bengali"
+  | "tamil"
+  | "emoji"
+  | "common";
+
+/**
+ * Detect the Unicode script for a single code point.
+ * Covers the major writing systems used by ~95% of the world population.
+ */
+export function detectScript(cp: number): Script {
+  // Common: ASCII control, basic punctuation, digits, symbols
+  if (cp <= 0x002f) return "common";
+  if (cp >= 0x0030 && cp <= 0x0039) return "common"; // digits
+  if (cp >= 0x003a && cp <= 0x0040) return "common"; // punctuation
+  if (cp >= 0x005b && cp <= 0x0060) return "common";
+  if (cp >= 0x007b && cp <= 0x007f) return "common";
+
+  // Basic Latin
+  if (cp >= 0x0041 && cp <= 0x005a) return "latin";
+  if (cp >= 0x0061 && cp <= 0x007a) return "latin";
+
+  // Latin Extended (accented chars, etc.)
+  if (cp >= 0x0080 && cp <= 0x024f) return "latin";
+  if (cp >= 0x1e00 && cp <= 0x1eff) return "latin"; // Latin Extended Additional
+  if (cp >= 0x2c60 && cp <= 0x2c7f) return "latin"; // Latin Extended-C
+
+  // General punctuation & symbols
+  if (cp >= 0x2000 && cp <= 0x206f) return "common"; // General Punctuation
+  if (cp >= 0x2070 && cp <= 0x209f) return "common"; // Superscripts/Subscripts
+  if (cp >= 0x20a0 && cp <= 0x20cf) return "common"; // Currency Symbols
+  if (cp >= 0x2100 && cp <= 0x214f) return "common"; // Letterlike Symbols
+  if (cp >= 0x2150 && cp <= 0x218f) return "common"; // Number Forms
+  if (cp >= 0x2190 && cp <= 0x21ff) return "common"; // Arrows
+  if (cp >= 0x2200 && cp <= 0x22ff) return "common"; // Math Operators
+
+  // Greek
+  if (cp >= 0x0370 && cp <= 0x03ff) return "greek";
+  if (cp >= 0x1f00 && cp <= 0x1fff) return "greek"; // Greek Extended
+
+  // Cyrillic
+  if (cp >= 0x0400 && cp <= 0x04ff) return "cyrillic";
+  if (cp >= 0x0500 && cp <= 0x052f) return "cyrillic"; // Cyrillic Supplement
+
+  // Armenian
+  if (cp >= 0x0530 && cp <= 0x058f) return "latin"; // treat as latin fallback
+
+  // Hebrew
+  if (cp >= 0x0590 && cp <= 0x05ff) return "hebrew";
+  if (cp >= 0xfb1d && cp <= 0xfb4f) return "hebrew"; // Hebrew Presentation Forms
+
+  // Arabic
+  if (cp >= 0x0600 && cp <= 0x06ff) return "arabic";
+  if (cp >= 0x0750 && cp <= 0x077f) return "arabic"; // Arabic Supplement
+  if (cp >= 0x08a0 && cp <= 0x08ff) return "arabic"; // Arabic Extended-A
+  if (cp >= 0xfb50 && cp <= 0xfdff) return "arabic"; // Arabic Presentation Forms-A
+  if (cp >= 0xfe70 && cp <= 0xfeff) return "arabic"; // Arabic Presentation Forms-B
+
+  // Devanagari
+  if (cp >= 0x0900 && cp <= 0x097f) return "devanagari";
+  if (cp >= 0xa8e0 && cp <= 0xa8ff) return "devanagari"; // Devanagari Extended
+
+  // Bengali
+  if (cp >= 0x0980 && cp <= 0x09ff) return "bengali";
+
+  // Tamil
+  if (cp >= 0x0b80 && cp <= 0x0bff) return "tamil";
+
+  // Thai
+  if (cp >= 0x0e00 && cp <= 0x0e7f) return "thai";
+
+  // CJK Radicals & Kangxi
+  if (cp >= 0x2e80 && cp <= 0x2eff) return "cjk";
+  if (cp >= 0x2f00 && cp <= 0x2fdf) return "cjk";
+
+  // CJK Symbols and Punctuation
+  if (cp >= 0x3000 && cp <= 0x303f) return "common"; // CJK punctuation (used by all CJK)
+
+  // Hiragana
+  if (cp >= 0x3040 && cp <= 0x309f) return "hiragana";
+
+  // Katakana
+  if (cp >= 0x30a0 && cp <= 0x30ff) return "katakana";
+  if (cp >= 0x31f0 && cp <= 0x31ff) return "katakana"; // Katakana Phonetic Extensions
+  if (cp >= 0xff65 && cp <= 0xff9f) return "katakana"; // Halfwidth Katakana
+
+  // Bopomofo
+  if (cp >= 0x3100 && cp <= 0x312f) return "cjk";
+
+  // Hangul Compatibility Jamo
+  if (cp >= 0x3130 && cp <= 0x318f) return "hangul";
+
+  // CJK Unified Ideographs
+  if (cp >= 0x3400 && cp <= 0x4dbf) return "cjk"; // Extension A
+  if (cp >= 0x4e00 && cp <= 0x9fff) return "cjk"; // Main block
+  if (cp >= 0xf900 && cp <= 0xfaff) return "cjk"; // Compatibility
+  if (cp >= 0x20000 && cp <= 0x2a6df) return "cjk"; // Extension B
+  if (cp >= 0x2a700 && cp <= 0x2b73f) return "cjk"; // Extension C
+  if (cp >= 0x2b740 && cp <= 0x2b81f) return "cjk"; // Extension D
+
+  // Hangul Syllables
+  if (cp >= 0xac00 && cp <= 0xd7af) return "hangul";
+  if (cp >= 0x1100 && cp <= 0x11ff) return "hangul"; // Hangul Jamo
+
+  // Halfwidth/Fullwidth Forms
+  if (cp >= 0xff01 && cp <= 0xff60) return "common"; // Fullwidth ASCII variants
+
+  // Emoji ranges
+  if (cp >= 0x1f000 && cp <= 0x1f02f) return "emoji"; // Mahjong/Dominos
+  if (cp >= 0x1f0a0 && cp <= 0x1f0ff) return "emoji"; // Playing Cards
+  if (cp >= 0x1f100 && cp <= 0x1f1ff) return "emoji"; // Enclosed Alphanumeric Supplement
+  if (cp >= 0x1f200 && cp <= 0x1f2ff) return "emoji"; // Enclosed Ideographic Supplement
+  if (cp >= 0x1f300 && cp <= 0x1f5ff) return "emoji"; // Misc Symbols and Pictographs
+  if (cp >= 0x1f600 && cp <= 0x1f64f) return "emoji"; // Emoticons
+  if (cp >= 0x1f680 && cp <= 0x1f6ff) return "emoji"; // Transport and Map
+  if (cp >= 0x1f700 && cp <= 0x1f77f) return "emoji"; // Alchemical Symbols
+  if (cp >= 0x1f780 && cp <= 0x1f7ff) return "emoji"; // Geometric Shapes Extended
+  if (cp >= 0x1f800 && cp <= 0x1f8ff) return "emoji"; // Supplemental Arrows-C
+  if (cp >= 0x1f900 && cp <= 0x1f9ff) return "emoji"; // Supplemental Symbols and Pictographs
+  if (cp >= 0x1fa00 && cp <= 0x1fa6f) return "emoji"; // Chess Symbols
+  if (cp >= 0x1fa70 && cp <= 0x1faff) return "emoji"; // Symbols and Pictographs Extended-A
+  if (cp >= 0x2600 && cp <= 0x26ff) return "emoji"; // Misc Symbols
+  if (cp >= 0x2700 && cp <= 0x27bf) return "emoji"; // Dingbats
+  if (cp >= 0x2b50 && cp <= 0x2b55) return "emoji"; // Stars, circles (commonly used as emoji)
+  if (cp >= 0xfe00 && cp <= 0xfe0f) return "common"; // Variation Selectors (emoji modifiers)
+  if (cp >= 0x200d && cp <= 0x200d) return "common"; // ZWJ
+
+  return "common";
+}
+
+/**
+ * Detect all scripts present in a text string.
+ */
+export function detectScriptsInText(text: string): Set<Script> {
+  const scripts = new Set<Script>();
+  for (const char of text) {
+    const cp = char.codePointAt(0);
+    if (cp === undefined) continue;
+    const script = detectScript(cp);
+    if (script !== "common") {
+      scripts.add(script);
+    }
+  }
+  return scripts;
+}
+
+// ---------------------------------------------------------------------------
+// Font registry
+// ---------------------------------------------------------------------------
+
+const S3_BASE = "https://s3.varg.ai/fonts";
+
+export interface FontEntry {
+  /** Short ID used in CaptionsProps.font (e.g. "montserrat") */
+  id: string;
+  /** Internal font family name as stored in the TTF/OTF name table (used in ASS {\fn} tags) */
+  fontName: string;
+  /** Filename on S3 */
+  fileName: string;
+  /** Full S3 URL */
+  url: string;
+  /** Which Unicode scripts this font covers */
+  scripts: Script[];
+}
+
+/** Primary (style) fonts — the aesthetic fonts users pick for their captions. */
+export const PRIMARY_FONTS: Record<string, FontEntry> = {
+  montserrat: {
+    id: "montserrat",
+    fontName: "Montserrat",
+    fileName: "Montserrat-Bold.ttf",
+    url: `${S3_BASE}/Montserrat-Bold.ttf`,
+    scripts: ["latin", "cyrillic"],
+  },
+  roboto: {
+    id: "roboto",
+    fontName: "Roboto",
+    fileName: "Roboto-Bold.ttf",
+    url: `${S3_BASE}/Roboto-Bold.ttf`,
+    scripts: ["latin", "cyrillic", "greek"],
+  },
+  poppins: {
+    id: "poppins",
+    fontName: "Poppins",
+    fileName: "Poppins-Bold.ttf",
+    url: `${S3_BASE}/Poppins-Bold.ttf`,
+    scripts: ["latin", "devanagari"],
+  },
+  inter: {
+    id: "inter",
+    fontName: "Inter",
+    fileName: "Inter-Bold.ttf",
+    url: `${S3_BASE}/Inter-Bold.ttf`,
+    scripts: ["latin", "cyrillic", "greek"],
+  },
+  "bebas-neue": {
+    id: "bebas-neue",
+    fontName: "Bebas Neue",
+    fileName: "BebasNeue-Regular.ttf",
+    url: `${S3_BASE}/BebasNeue-Regular.ttf`,
+    scripts: ["latin"],
+  },
+  "rock-salt": {
+    id: "rock-salt",
+    fontName: "Rock Salt",
+    fileName: "RockSalt-Regular.ttf",
+    url: `${S3_BASE}/RockSalt-Regular.ttf`,
+    scripts: ["latin"],
+  },
+  oswald: {
+    id: "oswald",
+    fontName: "Oswald",
+    fileName: "Oswald-Bold.ttf",
+    url: `${S3_BASE}/Oswald-Bold.ttf`,
+    scripts: ["latin", "cyrillic"],
+  },
+  "space-grotesk": {
+    id: "space-grotesk",
+    fontName: "Space Grotesk",
+    fileName: "SpaceGrotesk-Bold.ttf",
+    url: `${S3_BASE}/SpaceGrotesk-Bold.ttf`,
+    scripts: ["latin"],
+  },
+  "dm-sans": {
+    id: "dm-sans",
+    fontName: "DM Sans",
+    fileName: "DMSans-Bold.ttf",
+    url: `${S3_BASE}/DMSans-Bold.ttf`,
+    scripts: ["latin"],
+  },
+};
+
+/** Fallback fonts — Noto family, used only for scripts the primary font can't cover. */
+export const FALLBACK_FONTS: FontEntry[] = [
+  {
+    id: "noto-sans",
+    fontName: "Noto Sans",
+    fileName: "NotoSans-Bold.ttf",
+    url: `${S3_BASE}/NotoSans-Bold.ttf`,
+    scripts: ["latin", "cyrillic", "greek", "bengali", "tamil"],
+  },
+  {
+    id: "noto-sans-cjk-jp",
+    fontName: "Noto Sans CJK JP",
+    fileName: "NotoSansCJKjp-Bold.otf",
+    url: `${S3_BASE}/NotoSansCJKjp-Bold.otf`,
+    scripts: ["cjk", "hiragana", "katakana"],
+  },
+  {
+    id: "noto-sans-cjk-kr",
+    fontName: "Noto Sans CJK KR",
+    fileName: "NotoSansCJKkr-Bold.otf",
+    url: `${S3_BASE}/NotoSansCJKkr-Bold.otf`,
+    scripts: ["hangul"],
+  },
+  {
+    id: "noto-sans-cjk-sc",
+    fontName: "Noto Sans CJK SC",
+    fileName: "NotoSansCJKsc-Bold.otf",
+    url: `${S3_BASE}/NotoSansCJKsc-Bold.otf`,
+    scripts: ["cjk"], // for standalone Chinese text when no Japanese context
+  },
+  {
+    id: "noto-sans-arabic",
+    fontName: "Noto Sans Arabic",
+    fileName: "NotoSansArabic-Bold.ttf",
+    url: `${S3_BASE}/NotoSansArabic-Bold.ttf`,
+    scripts: ["arabic"],
+  },
+  {
+    id: "noto-sans-hebrew",
+    fontName: "Noto Sans Hebrew",
+    fileName: "NotoSansHebrew-Bold.ttf",
+    url: `${S3_BASE}/NotoSansHebrew-Bold.ttf`,
+    scripts: ["hebrew"],
+  },
+  {
+    id: "noto-sans-devanagari",
+    fontName: "Noto Sans Devanagari",
+    fileName: "NotoSansDevanagari-Bold.ttf",
+    url: `${S3_BASE}/NotoSansDevanagari-Bold.ttf`,
+    scripts: ["devanagari"],
+  },
+  {
+    id: "noto-sans-thai",
+    fontName: "Noto Sans Thai",
+    fileName: "NotoSansThai-Bold.ttf",
+    url: `${S3_BASE}/NotoSansThai-Bold.ttf`,
+    scripts: ["thai"],
+  },
+  {
+    id: "noto-emoji",
+    fontName: "Noto Emoji",
+    fileName: "NotoEmoji-Bold.ttf",
+    url: `${S3_BASE}/NotoEmoji-Bold.ttf`,
+    scripts: ["emoji"],
+  },
+];
+
+/** Default font IDs for each style preset. */
+const STYLE_FONT_DEFAULTS: Record<string, string> = {
+  tiktok: "montserrat",
+  karaoke: "roboto",
+  bounce: "oswald",
+  typewriter: "dm-sans",
+};
+
+/**
+ * Get the default primary font ID for a caption style preset.
+ */
+export function getDefaultFontId(style: string): string {
+  return STYLE_FONT_DEFAULTS[style] ?? "montserrat";
+}
+
+/**
+ * Look up a primary font by its short ID.
+ * Returns undefined for unknown IDs.
+ */
+export function getPrimaryFont(id: string): FontEntry | undefined {
+  return PRIMARY_FONTS[id];
+}
+
+// ---------------------------------------------------------------------------
+// Font resolution
+// ---------------------------------------------------------------------------
+
+export interface FontResolution {
+  /** The primary font entry. */
+  primary: FontEntry;
+  /** All font files needed (primary + any fallbacks for uncovered scripts). */
+  fontFiles: FontEntry[];
+  /** Tag a text string with {\fn} ASS override tags at script boundaries. */
+  tagText: (text: string) => string;
+}
+
+/**
+ * Resolve which fonts are needed for a given text and primary font.
+ *
+ * Scans the text for all Unicode scripts present, determines which the primary
+ * font covers vs which need a Noto fallback, and returns:
+ * - The full list of font files to include
+ * - A `tagText()` function that wraps text segments with `{\fnFontName}` tags
+ *
+ * @param allText - All caption text concatenated (used to detect scripts)
+ * @param primaryFontId - Short ID of the primary font (e.g. "montserrat")
+ */
+export function resolveFonts(
+  allText: string,
+  primaryFontId: string,
+): FontResolution {
+  const primary = PRIMARY_FONTS[primaryFontId] ?? PRIMARY_FONTS.montserrat!;
+  const scripts = detectScriptsInText(allText);
+
+  // Determine which scripts the primary font does NOT cover
+  const primaryScriptSet = new Set(primary.scripts);
+  const uncoveredScripts = new Set<Script>();
+  for (const s of scripts) {
+    if (!primaryScriptSet.has(s)) {
+      uncoveredScripts.add(s);
+    }
+  }
+
+  // Select minimum fallback fonts for uncovered scripts
+  const fallbackMap = new Map<Script, FontEntry>(); // script -> font
+  const selectedFallbacks: FontEntry[] = [];
+
+  for (const script of uncoveredScripts) {
+    if (fallbackMap.has(script)) continue;
+
+    // Find the first fallback font that covers this script
+    const fallback = FALLBACK_FONTS.find((f) => f.scripts.includes(script));
+    if (fallback) {
+      // Only add the fallback once, even if it covers multiple needed scripts
+      if (!selectedFallbacks.includes(fallback)) {
+        selectedFallbacks.push(fallback);
+      }
+      fallbackMap.set(script, fallback);
+      // Also mark other scripts this fallback covers
+      for (const s of fallback.scripts) {
+        if (uncoveredScripts.has(s) && !fallbackMap.has(s)) {
+          fallbackMap.set(s, fallback);
+        }
+      }
+    }
+  }
+
+  const fontFiles = [primary, ...selectedFallbacks];
+
+  /**
+   * Map a script to its font name. Primary font is used for covered scripts
+   * and "common" characters; fallbacks are used for uncovered scripts.
+   */
+  function fontForScript(script: Script): string {
+    if (script === "common" || primaryScriptSet.has(script)) {
+      return primary.fontName;
+    }
+    return fallbackMap.get(script)?.fontName ?? primary.fontName;
+  }
+
+  /**
+   * Tag text with {\fn} ASS override tags at script boundaries.
+   *
+   * Groups consecutive characters that use the same font, inserting
+   * {\fnFontName} only at transitions. If the entire text uses the
+   * primary font, no tags are inserted (clean output).
+   *
+   * "Common" characters (punctuation, digits, spaces) inherit the font
+   * of the preceding non-common script to avoid ugly fragmentation in
+   * CJK text where fullwidth punctuation would otherwise trigger a font switch.
+   */
+  function tagText(text: string): string {
+    if (uncoveredScripts.size === 0) {
+      // All scripts covered by primary — no tagging needed
+      return text;
+    }
+
+    // First pass: assign a font to each character.
+    // Common chars inherit the last non-common font (look-ahead/look-behind).
+    const chars: string[] = [];
+    const scripts: Script[] = [];
+    for (const char of text) {
+      const cp = char.codePointAt(0);
+      if (cp === undefined) continue;
+      chars.push(char);
+      scripts.push(detectScript(cp));
+    }
+
+    // Resolve common characters: they inherit the font of the nearest
+    // non-common character (prefer left context, fall back to right, then primary)
+    const resolvedFonts: string[] = new Array(chars.length);
+    let lastNonCommonFont = primary.fontName;
+
+    for (let i = 0; i < chars.length; i++) {
+      if (scripts[i] === "common") {
+        resolvedFonts[i] = lastNonCommonFont;
+      } else {
+        const font = fontForScript(scripts[i]!);
+        resolvedFonts[i] = font;
+        lastNonCommonFont = font;
+      }
+    }
+
+    // Build segments of consecutive characters with the same font
+    const segments: { font: string; chars: string }[] = [];
+    let currentFont = resolvedFonts[0] ?? primary.fontName;
+    let currentChars = "";
+
+    for (let i = 0; i < chars.length; i++) {
+      const font = resolvedFonts[i]!;
+      if (font !== currentFont && currentChars.length > 0) {
+        segments.push({ font: currentFont, chars: currentChars });
+        currentFont = font;
+        currentChars = chars[i]!;
+      } else {
+        currentChars += chars[i]!;
+      }
+    }
+    if (currentChars.length > 0) {
+      segments.push({ font: currentFont, chars: currentChars });
+    }
+
+    // Build the tagged string
+    // Skip the {\fn} tag for the first segment if it uses the primary font
+    // (the ASS style already sets it as default)
+    let result = "";
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i]!;
+      if (i === 0 && seg.font === primary.fontName) {
+        result += seg.chars;
+      } else if (seg.font === primary.fontName) {
+        // Reset to primary
+        result += `{\\fn${primary.fontName}}${seg.chars}`;
+      } else {
+        result += `{\\fn${seg.font}}${seg.chars}`;
+      }
+    }
+
+    return result;
+  }
+
+  return { primary, fontFiles, tagText };
+}

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -611,12 +611,22 @@ export async function renderRoot(
     const captionsTaskId = addTask(progress, "captions", "ffmpeg");
     startTask(progress, captionsTaskId);
 
+    // Collect font files from all caption results (deduplicated by URL)
+    const fontFileMap = new Map<string, { url: string; fileName: string }>();
+    for (const result of hoistedCaptionsResults) {
+      for (const font of result.fontFiles ?? []) {
+        fontFileMap.set(font.url, font);
+      }
+    }
+    const allFontFiles = [...fontFileMap.values()];
+
     output = await burnCaptions({
       video: output,
       assPath: finalAssPath,
       outputPath: finalOutPath,
       backend: options.backend,
       verbose: options.verbose,
+      fontFiles: allFontFiles.length > 0 ? allFontFiles : undefined,
     });
 
     if (!options.backend) {

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -38,6 +38,7 @@ import { burnCaptions } from "./burn-captions";
 import { type CaptionsResult, renderCaptions } from "./captions";
 import { renderClip } from "./clip";
 import type { RenderContext } from "./context";
+import type { EmojiOverlay } from "./emoji";
 import { renderImage } from "./image";
 import { mergeAssFiles, shiftAssTimestamps } from "./merge-ass";
 import { renderMusic } from "./music";
@@ -122,6 +123,33 @@ export async function renderRoot(
     ? withCache(generateMusic, { storage: cacheStorage })
     : generateMusic;
 
+  const onGeneration = options.onGeneration;
+
+  /** Extract pricing metadata from provider response and emit via callback. */
+  // biome-ignore lint/suspicious/noExplicitAny: result shapes vary across AI SDK model types
+  const emitPricing = (
+    type: "image" | "video" | "speech" | "music",
+    modelId: string,
+    result: any,
+  ) => {
+    if (!onGeneration) return;
+    const vargMeta = result?.providerMetadata?.varg as
+      | { pricing?: Record<string, unknown>; jobId?: string }
+      | undefined;
+    if (vargMeta?.pricing) {
+      const p = vargMeta.pricing;
+      onGeneration({
+        type,
+        model: modelId,
+        estimated: p.estimated as number | undefined,
+        actual: p.actual as number | undefined,
+        billing: p.billing as "metered" | "byok" | "x402" | undefined,
+        cached: p.cached as boolean | undefined,
+        jobId: vargMeta.jobId,
+      });
+    }
+  };
+
   const wrapGenerateImage: typeof generateImage = async (opts) => {
     if (mode === "preview") {
       trackPlaceholder("image");
@@ -138,7 +166,11 @@ export async function renderRoot(
       } as Parameters<typeof cachedGenerateImage>[0]);
     }
 
-    return cachedGenerateImage(opts);
+    const result = await cachedGenerateImage(opts);
+    const imgModelId =
+      typeof opts.model === "string" ? opts.model : opts.model.modelId;
+    emitPricing("image", imgModelId, result);
+    return result;
   };
 
   const wrapGenerateVideo: typeof generateVideo = async (opts) => {
@@ -157,7 +189,25 @@ export async function renderRoot(
       } as Parameters<typeof cachedGenerateVideo>[0]);
     }
 
-    return cachedGenerateVideo(opts);
+    const result = await cachedGenerateVideo(opts);
+    emitPricing("video", opts.model.modelId, result);
+    return result;
+  };
+
+  const wrapGenerateSpeech: typeof generateSpeech = async (opts) => {
+    const result = await cachedGenerateSpeech(opts);
+    const speechModelId =
+      typeof opts.model === "string" ? opts.model : opts.model.modelId;
+    emitPricing("speech", speechModelId, result);
+    return result;
+  };
+
+  const wrapGenerateMusic: typeof generateMusic = async (opts) => {
+    const result = await cachedGenerateMusic(opts);
+    const musicModelId =
+      typeof opts.model === "string" ? opts.model : opts.model.modelId;
+    emitPricing("music", musicModelId, result);
+    return result;
   };
 
   const backend = options.backend ?? localBackend;
@@ -171,8 +221,8 @@ export async function renderRoot(
     storage: options.storage,
     generateImage: wrapGenerateImage,
     generateVideo: wrapGenerateVideo,
-    generateSpeech: cachedGenerateSpeech,
-    generateMusic: cachedGenerateMusic,
+    generateSpeech: onGeneration ? wrapGenerateSpeech : cachedGenerateSpeech,
+    generateMusic: onGeneration ? wrapGenerateMusic : cachedGenerateMusic,
     tempFiles,
     progress,
     pendingFiles: new Map<string, Promise<File>>(),
@@ -620,6 +670,24 @@ export async function renderRoot(
     }
     const allFontFiles = [...fontFileMap.values()];
 
+    // Collect emoji overlays from all caption results, shifting timing by clip offsets
+    const allEmojiOverlays: EmojiOverlay[] = [];
+    for (let i = 0; i < hoistedCaptionsResults.length; i++) {
+      const result = hoistedCaptionsResults[i]!;
+      const offset = clipStartOffsets[hoistedCaptions[i]!.clipIndex] ?? 0;
+      for (const overlay of result.emojiOverlays ?? []) {
+        allEmojiOverlays.push(
+          offset > 0
+            ? {
+                ...overlay,
+                startTime: overlay.startTime + offset,
+                endTime: overlay.endTime + offset,
+              }
+            : overlay,
+        );
+      }
+    }
+
     output = await burnCaptions({
       video: output,
       assPath: finalAssPath,
@@ -627,6 +695,7 @@ export async function renderRoot(
       backend: options.backend,
       verbose: options.verbose,
       fontFiles: allFontFiles.length > 0 ? allFontFiles : undefined,
+      emojiOverlays: allEmojiOverlays.length > 0 ? allEmojiOverlays : undefined,
     });
 
     if (!options.backend) {

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -257,6 +257,9 @@ export interface CaptionsProps extends BaseProps {
   wordsPerLine?: number;
   /** When src is a Speech element, include its audio track in the video. Defaults to false. */
   withAudio?: boolean;
+  /** Font to use for captions. Overrides the style preset's default font.
+   *  Available: "montserrat" | "roboto" | "poppins" | "inter" | "bebas-neue" | "rock-salt" | "oswald" | "space-grotesk" | "dm-sans" */
+  font?: string;
 }
 
 export interface SplitProps extends BaseProps {

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -354,6 +354,24 @@ export interface DefaultModels {
   transcription?: TranscriptionModelV3;
 }
 
+/** Pricing metadata for a single generation call, emitted via onGeneration. */
+export interface GenerationPricingEntry {
+  /** Generation type */
+  type: "image" | "video" | "speech" | "music" | "transcription";
+  /** Model ID used */
+  model: string;
+  /** Estimated cost in credits (before generation) */
+  estimated?: number;
+  /** Actual cost in credits (after generation) */
+  actual?: number;
+  /** Billing mode */
+  billing?: "metered" | "byok" | "x402";
+  /** Whether result was served from cache */
+  cached?: boolean;
+  /** Gateway job ID for this generation */
+  jobId?: string;
+}
+
 export interface RenderOptions {
   output?: string;
   cache?: string | CacheStorage;
@@ -365,6 +383,8 @@ export interface RenderOptions {
   storage?: StorageProvider;
   /** Max concurrent clip renders. Defaults to 3. */
   concurrency?: number;
+  /** Callback invoked after each AI generation completes. Used to accumulate per-model costs. */
+  onGeneration?: (entry: GenerationPricingEntry) => void;
 }
 
 // Re-export from file module for convenience

--- a/src/speech/map-segments.test.ts
+++ b/src/speech/map-segments.test.ts
@@ -175,4 +175,52 @@ describe("mapWordsToSegments", () => {
     expect(result[1]!.start).toBe(1.0);
     expect(result[1]!.end).toBe(1.6);
   });
+
+  // -----------------------------------------------------------------------
+  // CJK text (Japanese, Chinese) — uses countWords() with Intl.Segmenter
+  // -----------------------------------------------------------------------
+
+  test("maps Japanese segments correctly", () => {
+    // Simulates word timing from parseElevenLabsAlignment with Intl.Segmenter.
+    // Japanese text: "これはテストです。さようなら。"
+    // Segmented by Intl.Segmenter into individual morphological words.
+    // For this test, we provide the words that Intl.Segmenter would produce
+    // for each segment and verify alignment works.
+
+    // Sentence 1: "これはテストです。" — countWords will return >1
+    // Sentence 2: "さようなら。" — countWords will return >1
+    // We need the word timings to match what countWords returns.
+
+    // Use countWords to know how many words each segment has
+    const { countWords } = require("./word-segmenter");
+    const seg1 = "これはテストです。";
+    const seg2 = "さようなら。";
+    const count1 = countWords(seg1) as number;
+    const count2 = countWords(seg2) as number;
+
+    // Build word timings — one per word across both segments
+    const totalWords = count1 + count2;
+    const words: WordTiming[] = [];
+    for (let i = 0; i < totalWords; i++) {
+      words.push({
+        word: `w${i}`,
+        start: i * 0.3,
+        end: (i + 1) * 0.3,
+      });
+    }
+
+    const result = mapWordsToSegments(
+      words,
+      [seg1, seg2],
+      totalWords * 0.3 + 0.2,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.text).toBe(seg1);
+    expect(result[1]!.text).toBe(seg2);
+    // First segment starts at 0
+    expect(result[0]!.start).toBe(0);
+    // Last segment ends at audioDuration
+    expect(result[1]!.end).toBe(totalWords * 0.3 + 0.2);
+  });
 });

--- a/src/speech/map-segments.ts
+++ b/src/speech/map-segments.ts
@@ -1,4 +1,5 @@
 import type { SegmentDescriptor, WordTiming } from "./types";
+import { countWords } from "./word-segmenter";
 
 /**
  * Map word-level timings back to the original string array to produce segments.
@@ -67,7 +68,7 @@ export function mapWordsToSegments(
   let wordIndex = 0;
 
   for (const text of children) {
-    const segmentWordCount = text.trim().split(/\s+/).filter(Boolean).length;
+    const segmentWordCount = countWords(text);
 
     if (segmentWordCount === 0) {
       const pos =

--- a/src/speech/parse-alignment.test.ts
+++ b/src/speech/parse-alignment.test.ts
@@ -119,4 +119,190 @@ describe("parseElevenLabsAlignment", () => {
     // Last word ends at the end
     expect(result[3]!.end).toBe(n * 0.05);
   });
+
+  // -----------------------------------------------------------------------
+  // Japanese (spaceless script — uses Intl.Segmenter)
+  // -----------------------------------------------------------------------
+
+  test("segments Japanese text into morphological words", () => {
+    // "これはテストです" → これ, は, テスト, です
+    const text = "これはテストです";
+    const chars = [...text]; // split into individual characters
+    const n = chars.length;
+    const starts = Array.from({ length: n }, (_, i) => i * 0.1);
+    const ends = Array.from({ length: n }, (_, i) => (i + 1) * 0.1);
+
+    const result = parseElevenLabsAlignment({
+      characters: chars,
+      character_start_times_seconds: starts,
+      character_end_times_seconds: ends,
+    });
+
+    // Should produce multiple words, not a single mega-word
+    expect(result.length).toBeGreaterThan(1);
+    // Each word should have valid timing
+    for (const w of result) {
+      expect(w.start).toBeLessThan(w.end);
+      expect(w.word.length).toBeGreaterThan(0);
+    }
+    // Concatenated words should equal original text
+    expect(result.map((w) => w.word).join("")).toBe(text);
+    // First word starts at 0
+    expect(result[0]!.start).toBe(0);
+    // Last word ends at the end
+    expect(result[result.length - 1]!.end).toBe(n * 0.1);
+  });
+
+  test("segments mixed Japanese-English text", () => {
+    // "Varg AIはすごいです" — mix of Latin and Japanese
+    const text = "Varg AIはすごいです";
+    const chars = [...text];
+    const n = chars.length;
+    const starts = Array.from({ length: n }, (_, i) => i * 0.05);
+    const ends = Array.from({ length: n }, (_, i) => (i + 1) * 0.05);
+
+    const result = parseElevenLabsAlignment({
+      characters: chars,
+      character_start_times_seconds: starts,
+      character_end_times_seconds: ends,
+    });
+
+    // Should have multiple words including "Varg", "AI", and Japanese words
+    expect(result.length).toBeGreaterThan(2);
+    // Should contain "Varg" and "AI" as separate words
+    const wordTexts = result.map((w) => w.word);
+    expect(wordTexts).toContain("Varg");
+    expect(wordTexts).toContain("AI");
+  });
+
+  // -----------------------------------------------------------------------
+  // Chinese (spaceless script)
+  // -----------------------------------------------------------------------
+
+  test("segments Chinese text into words", () => {
+    // "今天天气很好" → 今天, 天气, 很好
+    const text = "今天天气很好";
+    const chars = [...text];
+    const n = chars.length;
+    const starts = Array.from({ length: n }, (_, i) => i * 0.15);
+    const ends = Array.from({ length: n }, (_, i) => (i + 1) * 0.15);
+
+    const result = parseElevenLabsAlignment({
+      characters: chars,
+      character_start_times_seconds: starts,
+      character_end_times_seconds: ends,
+    });
+
+    expect(result.length).toBeGreaterThan(1);
+    expect(result.map((w) => w.word).join("")).toBe(text);
+  });
+
+  // -----------------------------------------------------------------------
+  // Thai (spaceless script)
+  // -----------------------------------------------------------------------
+
+  test("segments Thai text into words", () => {
+    // "สวัสดีครับ" → สวัสดี, ครับ
+    const text = "สวัสดีครับ";
+    const chars = [...text];
+    const n = chars.length;
+    const starts = Array.from({ length: n }, (_, i) => i * 0.08);
+    const ends = Array.from({ length: n }, (_, i) => (i + 1) * 0.08);
+
+    const result = parseElevenLabsAlignment({
+      characters: chars,
+      character_start_times_seconds: starts,
+      character_end_times_seconds: ends,
+    });
+
+    expect(result.length).toBeGreaterThan(1);
+    expect(result.map((w) => w.word).join("")).toBe(text);
+  });
+
+  // -----------------------------------------------------------------------
+  // Space-delimited scripts should still work as before
+  // -----------------------------------------------------------------------
+
+  test("Arabic text uses whitespace splitting (has spaces)", () => {
+    // "مرحبا بالعالم" — Arabic with a space
+    const chars = [
+      "م",
+      "ر",
+      "ح",
+      "ب",
+      "ا",
+      " ",
+      "ب",
+      "ا",
+      "ل",
+      "ع",
+      "ا",
+      "ل",
+      "م",
+    ];
+    const n = chars.length;
+    const starts = Array.from({ length: n }, (_, i) => i * 0.05);
+    const ends = Array.from({ length: n }, (_, i) => (i + 1) * 0.05);
+
+    const result = parseElevenLabsAlignment({
+      characters: chars,
+      character_start_times_seconds: starts,
+      character_end_times_seconds: ends,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.word).toBe("مرحبا");
+    expect(result[1]!.word).toBe("بالعالم");
+  });
+
+  test("Korean text uses whitespace splitting (has spaces)", () => {
+    // "안녕하세요 세계" — Korean with a space
+    const text = "안녕하세요 세계";
+    const chars = [...text];
+    const n = chars.length;
+    const starts = Array.from({ length: n }, (_, i) => i * 0.05);
+    const ends = Array.from({ length: n }, (_, i) => (i + 1) * 0.05);
+
+    const result = parseElevenLabsAlignment({
+      characters: chars,
+      character_start_times_seconds: starts,
+      character_end_times_seconds: ends,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.word).toBe("안녕하세요");
+    expect(result[1]!.word).toBe("세계");
+  });
+
+  // -----------------------------------------------------------------------
+  // Timing precision
+  // -----------------------------------------------------------------------
+
+  test("Japanese words get correct per-character timing", () => {
+    // "はい" (2 chars) + space + "OK" (2 chars)
+    // But since "はい" triggers spaceless path, this goes through Intl.Segmenter
+    const chars = ["は", "い", " ", "O", "K"];
+    const starts = [0, 0.1, 0.2, 0.3, 0.4];
+    const ends = [0.1, 0.2, 0.3, 0.4, 0.5];
+
+    const result = parseElevenLabsAlignment({
+      characters: chars,
+      character_start_times_seconds: starts,
+      character_end_times_seconds: ends,
+    });
+
+    // Should find "はい" and "OK" as separate words
+    const words = result.map((w) => w.word);
+    expect(words).toContain("はい");
+    expect(words).toContain("OK");
+
+    // Timing: "はい" should be 0-0.2, "OK" should be 0.3-0.5
+    const hai = result.find((w) => w.word === "はい")!;
+    expect(hai.start).toBe(0);
+    expect(hai.end).toBe(0.2);
+
+    const ok = result.find((w) => w.word === "OK")!;
+    expect(ok.start).toBe(0.3);
+    expect(ok.end).toBe(0.5);
+  });
 });

--- a/src/speech/parse-alignment.ts
+++ b/src/speech/parse-alignment.ts
@@ -1,21 +1,33 @@
 import type { ElevenLabsCharacterAlignment, WordTiming } from "./types";
+import { hasSpacelessChars, segmentWords } from "./word-segmenter";
 
 /**
  * Convert ElevenLabs character-level alignment to word-level timing.
  *
  * ElevenLabs returns arrays of individual characters with start/end times.
- * This function groups consecutive non-whitespace characters into words
- * and computes each word's start (first char start) and end (last char end).
+ * This function groups characters into words and computes each word's
+ * start (first char start) and end (last char end).
+ *
+ * For languages that use spaces (English, Arabic, Korean, etc.), words are
+ * split at whitespace boundaries — same as before.
+ *
+ * For spaceless-script languages (Japanese, Chinese, Thai, etc.), we use
+ * `Intl.Segmenter` (ICU-backed) to find linguistically correct word
+ * boundaries, then map each word back to the character-level timing data.
  *
  * @example
  * ```ts
+ * // English
  * const alignment = {
  *   characters: ["H","e","l","l","o"," ","w","o","r","l","d"],
  *   character_start_times_seconds: [0, 0.05, 0.1, 0.15, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55],
  *   character_end_times_seconds:   [0.05, 0.1, 0.15, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.65],
  * };
- * const words = parseElevenLabsAlignment(alignment);
+ * parseElevenLabsAlignment(alignment);
  * // [{word: "Hello", start: 0, end: 0.3}, {word: "world", start: 0.35, end: 0.65}]
+ *
+ * // Japanese — "これはテストです" → ["これ", "は", "テスト", "です"]
+ * // Each word gets precise timing from the character-level data.
  * ```
  */
 export function parseElevenLabsAlignment(
@@ -35,13 +47,40 @@ export function parseElevenLabsAlignment(
     return [];
   }
 
+  // Reconstruct the full text and check if it contains spaceless scripts
+  const fullText = characters.join("");
+
+  if (hasSpacelessChars(fullText)) {
+    return parseWithSegmenter(
+      fullText,
+      characters,
+      character_start_times_seconds,
+      character_end_times_seconds,
+    );
+  }
+
+  return parseByWhitespace(
+    characters,
+    character_start_times_seconds,
+    character_end_times_seconds,
+  );
+}
+
+/**
+ * Original whitespace-based parsing for space-delimited languages.
+ */
+function parseByWhitespace(
+  characters: string[],
+  startTimes: number[],
+  endTimes: number[],
+): WordTiming[] {
   const words: WordTiming[] = [];
   let wordChars = "";
   let wordStart = 0;
 
   for (let i = 0; i < characters.length; i++) {
     const char = characters[i]!;
-    const startTime = character_start_times_seconds[i]!;
+    const startTime = startTimes[i]!;
     const isWhitespace =
       char === " " || char === "\n" || char === "\t" || char === "\r";
 
@@ -51,7 +90,7 @@ export function parseElevenLabsAlignment(
         words.push({
           word: wordChars,
           start: wordStart,
-          end: character_end_times_seconds[i - 1] ?? wordStart,
+          end: endTimes[i - 1] ?? wordStart,
         });
         wordChars = "";
       }
@@ -66,11 +105,77 @@ export function parseElevenLabsAlignment(
 
   // Flush final word
   if (wordChars) {
-    const lastEnd = character_end_times_seconds[characters.length - 1];
+    const lastEnd = endTimes[characters.length - 1];
     words.push({
       word: wordChars,
       start: wordStart,
       end: lastEnd ?? wordStart,
+    });
+  }
+
+  return words;
+}
+
+/**
+ * Intl.Segmenter-based parsing for text containing spaceless scripts.
+ *
+ * Steps:
+ * 1. Build a mapping from each code-unit offset in the full text to its
+ *    index in the ElevenLabs character arrays (handling multi-char graphemes).
+ * 2. Use `Intl.Segmenter` to find word boundaries in the full text.
+ * 3. For each word-like segment, look up the start time of its first character
+ *    and the end time of its last character from the alignment data.
+ */
+function parseWithSegmenter(
+  fullText: string,
+  characters: string[],
+  startTimes: number[],
+  endTimes: number[],
+): WordTiming[] {
+  // Build a mapping: code-unit offset in fullText → character array index.
+  // ElevenLabs characters may be single code points or multi-code-unit chars
+  // (e.g., emoji), so we track offsets carefully.
+  const offsetToCharIndex = new Map<number, number>();
+  let offset = 0;
+  for (let ci = 0; ci < characters.length; ci++) {
+    offsetToCharIndex.set(offset, ci);
+    offset += characters[ci]!.length;
+  }
+
+  // Segment the full text into words
+  const segments = segmentWords(fullText);
+
+  const words: WordTiming[] = [];
+  for (const seg of segments) {
+    // Find the character indices for this segment's boundaries
+    const segStart = seg.index;
+    const segEnd = seg.index + seg.length;
+
+    // Find the first character index in this segment
+    let firstCharIdx: number | undefined;
+    let lastCharIdx: number | undefined;
+
+    // Walk through offsets to find all char indices within this segment
+    for (const [off, ci] of offsetToCharIndex) {
+      if (off >= segStart && off < segEnd) {
+        if (firstCharIdx === undefined || ci < firstCharIdx) {
+          firstCharIdx = ci;
+        }
+        if (lastCharIdx === undefined || ci > lastCharIdx) {
+          lastCharIdx = ci;
+        }
+      }
+    }
+
+    if (firstCharIdx === undefined || lastCharIdx === undefined) continue;
+
+    const wordStart = startTimes[firstCharIdx] ?? 0;
+    const wordEnd = endTimes[lastCharIdx] ?? wordStart;
+
+    words.push({
+      word: seg.word,
+      start: wordStart,
+      end: wordEnd,
     });
   }
 

--- a/src/speech/word-segmenter.test.ts
+++ b/src/speech/word-segmenter.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import {
+  countWords,
+  hasSpacelessChars,
+  isSpacelessScript,
+  segmentWords,
+  smartJoin,
+} from "./word-segmenter";
+
+// ---------------------------------------------------------------------------
+// isSpacelessScript
+// ---------------------------------------------------------------------------
+
+describe("isSpacelessScript", () => {
+  test("detects hiragana", () => {
+    expect(isSpacelessScript("あ".codePointAt(0)!)).toBe(true);
+    expect(isSpacelessScript("ん".codePointAt(0)!)).toBe(true);
+  });
+
+  test("detects katakana", () => {
+    expect(isSpacelessScript("ア".codePointAt(0)!)).toBe(true);
+    expect(isSpacelessScript("ン".codePointAt(0)!)).toBe(true);
+  });
+
+  test("detects CJK ideographs", () => {
+    expect(isSpacelessScript("漢".codePointAt(0)!)).toBe(true);
+    expect(isSpacelessScript("字".codePointAt(0)!)).toBe(true);
+  });
+
+  test("detects Thai", () => {
+    expect(isSpacelessScript("ก".codePointAt(0)!)).toBe(true);
+    expect(isSpacelessScript("ม".codePointAt(0)!)).toBe(true);
+  });
+
+  test("rejects Latin", () => {
+    expect(isSpacelessScript("A".codePointAt(0)!)).toBe(false);
+    expect(isSpacelessScript("z".codePointAt(0)!)).toBe(false);
+  });
+
+  test("rejects Arabic", () => {
+    expect(isSpacelessScript("ع".codePointAt(0)!)).toBe(false);
+  });
+
+  test("rejects Korean (hangul uses spaces)", () => {
+    expect(isSpacelessScript("한".codePointAt(0)!)).toBe(false);
+  });
+
+  test("rejects digits and punctuation", () => {
+    expect(isSpacelessScript("0".codePointAt(0)!)).toBe(false);
+    expect(isSpacelessScript(".".codePointAt(0)!)).toBe(false);
+    expect(isSpacelessScript(" ".codePointAt(0)!)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasSpacelessChars
+// ---------------------------------------------------------------------------
+
+describe("hasSpacelessChars", () => {
+  test("detects Japanese text", () => {
+    expect(hasSpacelessChars("これはテストです")).toBe(true);
+  });
+
+  test("detects mixed text with Japanese", () => {
+    expect(hasSpacelessChars("Hello これは test")).toBe(true);
+  });
+
+  test("returns false for English", () => {
+    expect(hasSpacelessChars("Hello world")).toBe(false);
+  });
+
+  test("returns false for Arabic", () => {
+    expect(hasSpacelessChars("مرحبا بالعالم")).toBe(false);
+  });
+
+  test("returns false for Korean", () => {
+    expect(hasSpacelessChars("안녕하세요 세계")).toBe(false);
+  });
+
+  test("detects Chinese", () => {
+    expect(hasSpacelessChars("今天天气很好")).toBe(true);
+  });
+
+  test("detects Thai", () => {
+    expect(hasSpacelessChars("สวัสดีครับ")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// segmentWords
+// ---------------------------------------------------------------------------
+
+describe("segmentWords", () => {
+  test("segments English text by whitespace", () => {
+    const result = segmentWords("Hello world test");
+    expect(result.map((s) => s.word)).toEqual(["Hello", "world", "test"]);
+  });
+
+  test("segments Japanese into morphological words", () => {
+    const result = segmentWords("これはテストです");
+    expect(result.length).toBeGreaterThan(1);
+    // All segments joined = original text
+    expect(result.map((s) => s.word).join("")).toBe("これはテストです");
+  });
+
+  test("segments Chinese into words", () => {
+    const result = segmentWords("今天天气很好");
+    expect(result.length).toBeGreaterThan(1);
+    expect(result.map((s) => s.word).join("")).toBe("今天天气很好");
+  });
+
+  test("segments Thai into words", () => {
+    const result = segmentWords("สวัสดีครับ");
+    expect(result.length).toBeGreaterThan(1);
+  });
+
+  test("handles mixed Japanese-English", () => {
+    const result = segmentWords("Varg AIはすごい");
+    const words = result.map((s) => s.word);
+    expect(words).toContain("Varg");
+    expect(words).toContain("AI");
+    expect(words.length).toBeGreaterThan(2);
+  });
+
+  test("returns character indices", () => {
+    const result = segmentWords("Hello world");
+    expect(result[0]!.index).toBe(0);
+    expect(result[0]!.length).toBe(5);
+    expect(result[1]!.index).toBe(6); // after "Hello "
+    expect(result[1]!.length).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countWords
+// ---------------------------------------------------------------------------
+
+describe("countWords", () => {
+  test("counts English words by whitespace", () => {
+    expect(countWords("Hello world test")).toBe(3);
+  });
+
+  test("counts Japanese morphological words", () => {
+    // Uses Intl.Segmenter, should find multiple words
+    expect(countWords("これはテストです")).toBeGreaterThan(1);
+  });
+
+  test("counts Chinese words", () => {
+    expect(countWords("今天天气很好")).toBeGreaterThan(1);
+  });
+
+  test("counts words with extra whitespace", () => {
+    expect(countWords("  Hello   world  ")).toBe(2);
+  });
+
+  test("returns 0 for empty string", () => {
+    expect(countWords("")).toBe(0);
+  });
+
+  test("returns 0 for whitespace-only string", () => {
+    expect(countWords("   ")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// smartJoin
+// ---------------------------------------------------------------------------
+
+describe("smartJoin", () => {
+  test("joins English words with spaces", () => {
+    expect(smartJoin(["Hello", "world", "test"])).toBe("Hello world test");
+  });
+
+  test("joins Japanese words without spaces", () => {
+    expect(smartJoin(["これ", "は", "テスト", "です"])).toBe(
+      "これはテストです",
+    );
+  });
+
+  test("joins Chinese words without spaces", () => {
+    expect(smartJoin(["今天", "天气", "很好"])).toBe("今天天气很好");
+  });
+
+  test("joins mixed Japanese-English without space at boundary", () => {
+    // "Varg" + "は" → "Vargは" (no space — Japanese side)
+    expect(smartJoin(["Varg", "は", "すごい"])).toBe("Vargはすごい");
+  });
+
+  test("joins English words before CJK without space at boundary", () => {
+    // "AI" + "は" → "AIは"
+    expect(smartJoin(["Varg", "AI", "は"])).toBe("Varg AIは");
+  });
+
+  test("handles single word", () => {
+    expect(smartJoin(["Hello"])).toBe("Hello");
+  });
+
+  test("handles empty array", () => {
+    expect(smartJoin([])).toBe("");
+  });
+
+  test("joins Thai words without spaces", () => {
+    expect(smartJoin(["สวัสดี", "ครับ"])).toBe("สวัสดีครับ");
+  });
+
+  test("Arabic words get spaces (space-delimited script)", () => {
+    expect(smartJoin(["مرحبا", "بالعالم"])).toBe("مرحبا بالعالم");
+  });
+
+  test("Korean words get spaces (space-delimited script)", () => {
+    expect(smartJoin(["안녕하세요", "세계"])).toBe("안녕하세요 세계");
+  });
+
+  test("handles ASS override tags mixed with CJK", () => {
+    // When karaoke mode wraps words in color tags
+    const parts = ["{\\c&H428CFF&}これ{\\c&HFFFFFF&}", "は", "テスト"];
+    const result = smartJoin(parts);
+    // The closing } is not a spaceless char, but the next char は is
+    // so no space should be inserted
+    expect(result).not.toContain("} は");
+  });
+});

--- a/src/speech/word-segmenter.ts
+++ b/src/speech/word-segmenter.ts
@@ -1,0 +1,172 @@
+/**
+ * Language-aware word segmentation utilities.
+ *
+ * Uses `Intl.Segmenter` (ICU-backed, zero dependencies) to handle languages
+ * that don't use spaces between words: Japanese, Chinese, Thai, Khmer, etc.
+ *
+ * For Latin/Cyrillic/Arabic/Korean and other space-delimited scripts, simple
+ * whitespace splitting is equivalent — but `Intl.Segmenter` handles them too,
+ * so we use a single code path for all languages.
+ */
+
+// ---------------------------------------------------------------------------
+// Script detection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a code point belongs to a script that doesn't use spaces between words.
+ *
+ * Covers: CJK ideographs, Hiragana, Katakana, Thai, Lao, Myanmar, Khmer, Tibetan.
+ * Does NOT include Korean (Hangul) — Korean uses spaces between words.
+ */
+export function isSpacelessScript(cp: number): boolean {
+  // Hiragana
+  if (cp >= 0x3040 && cp <= 0x309f) return true;
+  // Katakana
+  if (cp >= 0x30a0 && cp <= 0x30ff) return true;
+  if (cp >= 0x31f0 && cp <= 0x31ff) return true; // Katakana Phonetic Extensions
+  if (cp >= 0xff65 && cp <= 0xff9f) return true; // Halfwidth Katakana
+  // CJK Unified Ideographs
+  if (cp >= 0x4e00 && cp <= 0x9fff) return true;
+  if (cp >= 0x3400 && cp <= 0x4dbf) return true; // Extension A
+  if (cp >= 0xf900 && cp <= 0xfaff) return true; // Compatibility
+  if (cp >= 0x20000 && cp <= 0x2a6df) return true; // Extension B
+  if (cp >= 0x2a700 && cp <= 0x2b73f) return true; // Extension C
+  if (cp >= 0x2b740 && cp <= 0x2b81f) return true; // Extension D
+  // CJK Radicals
+  if (cp >= 0x2e80 && cp <= 0x2eff) return true;
+  if (cp >= 0x2f00 && cp <= 0x2fdf) return true;
+  // Thai
+  if (cp >= 0x0e00 && cp <= 0x0e7f) return true;
+  // Lao
+  if (cp >= 0x0e80 && cp <= 0x0eff) return true;
+  // Myanmar
+  if (cp >= 0x1000 && cp <= 0x109f) return true;
+  // Khmer
+  if (cp >= 0x1780 && cp <= 0x17ff) return true;
+  // Tibetan
+  if (cp >= 0x0f00 && cp <= 0x0fff) return true;
+
+  return false;
+}
+
+/**
+ * Check if a string contains any characters from spaceless scripts.
+ * Used as a fast gate to decide whether we need `Intl.Segmenter`.
+ */
+export function hasSpacelessChars(text: string): boolean {
+  for (const char of text) {
+    const cp = char.codePointAt(0);
+    if (cp !== undefined && isSpacelessScript(cp)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Intl.Segmenter-based word segmentation
+// ---------------------------------------------------------------------------
+
+interface WordSegment {
+  /** The word text. */
+  word: string;
+  /** Character offset in the original string (code-unit index). */
+  index: number;
+  /** Length in code units. */
+  length: number;
+}
+
+/** Cached segmenter instance (default locale, word granularity). */
+let _segmenter: Intl.Segmenter | undefined;
+
+function getSegmenter(): Intl.Segmenter {
+  if (!_segmenter) {
+    _segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
+  }
+  return _segmenter;
+}
+
+/**
+ * Segment text into word-like tokens using `Intl.Segmenter`.
+ *
+ * Returns only word-like segments (no punctuation-only or whitespace segments).
+ * Works correctly for all languages including Japanese, Chinese, Thai, Korean,
+ * Arabic, Hindi, etc.
+ */
+export function segmentWords(text: string): WordSegment[] {
+  const segmenter = getSegmenter();
+  const result: WordSegment[] = [];
+  for (const seg of segmenter.segment(text)) {
+    if (seg.isWordLike) {
+      result.push({
+        word: seg.segment,
+        index: seg.index,
+        length: seg.segment.length,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Count the number of word-like tokens in a string.
+ *
+ * Uses `Intl.Segmenter` for spaceless scripts, whitespace splitting for others.
+ * This matches the word count from `segmentWords()` / `parseElevenLabsAlignment()`.
+ */
+export function countWords(text: string): number {
+  if (hasSpacelessChars(text)) {
+    return segmentWords(text).length;
+  }
+  // Fast path for space-delimited scripts
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+// ---------------------------------------------------------------------------
+// Smart join — language-aware word concatenation
+// ---------------------------------------------------------------------------
+
+/**
+ * Join words without inserting incorrect spaces between CJK/Thai tokens.
+ *
+ * Rules:
+ * - Between two spaceless-script tokens → no space (日本語 + テスト → 日本語テスト)
+ * - Between a spaceless-script token and a Latin token → no space (Varg + は → Vargは)
+ * - Between two Latin/Cyrillic/etc. tokens → space (Hello + world → Hello world)
+ *
+ * This matches how the original text would look — CJK/Thai don't use spaces.
+ */
+export function smartJoin(words: string[]): string {
+  if (words.length === 0) return "";
+  if (words.length === 1) return words[0]!;
+
+  let result = words[0]!;
+  for (let i = 1; i < words.length; i++) {
+    const prev = words[i - 1]!;
+    const curr = words[i]!;
+
+    // Check the last char of prev and first char of curr
+    const prevLastCp = lastCodePoint(prev);
+    const currFirstCp = curr.codePointAt(0) ?? 0;
+
+    // No space if either side is a spaceless script character
+    const needsSpace =
+      !isSpacelessScript(prevLastCp) && !isSpacelessScript(currFirstCp);
+
+    result += needsSpace ? ` ${curr}` : curr;
+  }
+  return result;
+}
+
+/**
+ * Get the last code point of a string.
+ */
+function lastCodePoint(s: string): number {
+  if (s.length === 0) return 0;
+  // Handle surrogate pairs
+  const last = s.codePointAt(s.length - 1);
+  if (last !== undefined && last >= 0xdc00 && last <= 0xdfff && s.length >= 2) {
+    // Low surrogate — the actual code point starts one position earlier
+    return s.codePointAt(s.length - 2) ?? 0;
+  }
+  return last ?? 0;
+}


### PR DESCRIPTION
## Summary

- **Provider cost formulas**: All 22 model definitions now include `pricing` formulas that calculate raw provider cost in USD based on generation parameters (duration, resolution, character count, etc.)
- **Pricing types**: `PricingParams`, `ProviderPricing` added to `ModelDefinition`
- **Utility functions**: `calculateProviderCost()`, `getModelPricing()`, `getModelPricingBounds()` exported from model definitions
- **Render pricing callback**: `GenerationPricingEntry` type and `onGeneration` callback on `RenderOptions` — emits per-generation cost data from `providerMetadata.varg.pricing`
- **25 tests** covering all pricing formulas

### Pricing formula examples

| Model | Type | Formula |
|-------|------|---------|
| kling-v2.5 | per-second | ~$0.112/s (5s=$0.56, 10s=$1.12) |
| flux-schnell | flat | $0.006/image |
| eleven_multilingual_v2 | per-character | $0.10/1K chars |
| seedance | per-second | ~$0.40/5s |
| whisper-large-v3 | per-minute | $0.006/min |

### Files changed

| File | Change |
|------|--------|
| `src/core/schema/types.ts` | `PricingParams`, `ProviderPricing` types on `ModelDefinition` |
| `src/definitions/models/*.ts` | All 22 model files with `pricing` formulas |
| `src/definitions/models/index.ts` | `calculateProviderCost()`, `getModelPricing()`, `getModelPricingBounds()` |
| `src/definitions/models/pricing.test.ts` | 25 pricing tests |
| `src/react/types.ts` | `GenerationPricingEntry` type, `onGeneration` on `RenderOptions` |
| `src/react/renderers/render.ts` | `emitPricing()` wired into all 4 generate wrappers |
| `src/react/index.ts` | Export `GenerationPricingEntry` |

### How it connects

The SDK owns the raw cost formulas. The gateway imports these via `calculateProviderCost()` and applies markup (1.2x default). The render service uses `onGeneration` to accumulate per-generation costs during a render job.

### Note
Pre-push `tsc` errors on `Uint8Array` types in `file.ts`, `fal.ts`, `heygen.ts`, `openai.ts`, `varg.ts` are pre-existing and unrelated to this change.