### PR TITLE
feat: add browser-based OAuth login (vargai login)

### DIFF
--- a/src/cli/commands/login.tsx
+++ b/src/cli/commands/login.tsx
@@ -1,9 +1,10 @@
 /**
  * vargai login — agent-first authentication
  *
- * Two modes:
- *   1. Email OTP — sign in via email magic code (creates account + API key)
- *   2. API key   — paste an existing API key directly
+ * Three modes:
+ *   1. Browser   — OAuth via browser (recommended, supports Google + email)
+ *   2. Email OTP — sign in via email magic code (creates account + API key)
+ *   3. API key   — paste an existing API key directly
  *
  * The `runLogin()` function is exported so `init` can embed the login flow.
  */
@@ -14,9 +15,16 @@ import {
   getCredentialsPath,
   saveCredentials,
 } from "../credentials";
+import { startCallbackServer } from "../oauth/oauth-callback-server";
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+} from "../oauth/pkce";
 
 const APP_URL = process.env.VARG_APP_URL ?? "https://app.varg.ai";
 const GATEWAY_URL = process.env.VARG_GATEWAY_URL ?? "https://api.varg.ai";
+const MCP_URL = process.env.VARG_MCP_URL ?? "https://mcp.varg.ai";
 
 export const COLORS = {
   reset: "\x1b[0m",
@@ -178,6 +186,147 @@ export interface LoginResult {
   balanceCents: number;
   /** Only available after email OTP login, not API key login */
   accessToken: string;
+}
+
+// ──── Browser OAuth Login ────
+
+async function loginWithBrowser(): Promise<LoginResult | null> {
+  // Generate PKCE pair
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  // Start temporary localhost server for callback
+  const {
+    port,
+    result: callbackResult,
+    close: closeServer,
+  } = startCallbackServer(state);
+  const redirectUri = `http://127.0.0.1:${port}/callback`;
+
+  try {
+    // Register as a dynamic client with the MCP OAuth server
+    process.stdout.write(
+      `${COLORS.dim}  ● Preparing authentication...${COLORS.reset}`,
+    );
+
+    const registerRes = await fetch(`${MCP_URL}/oauth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: [redirectUri],
+        client_name: "varg CLI",
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code"],
+        response_types: ["code"],
+      }),
+    });
+
+    if (!registerRes.ok) {
+      process.stdout.write("\r\x1b[K");
+      log.error(
+        "Failed to initialize authentication. Try again or use email login.",
+      );
+      closeServer();
+      return null;
+    }
+
+    const client = (await registerRes.json()) as { client_id: string };
+    process.stdout.write("\r\x1b[K");
+
+    // Build authorization URL
+    const authUrl = new URL(`${MCP_URL}/oauth/authorize`);
+    authUrl.searchParams.set("client_id", client.client_id);
+    authUrl.searchParams.set("redirect_uri", redirectUri);
+    authUrl.searchParams.set("response_type", "code");
+    authUrl.searchParams.set("code_challenge", codeChallenge);
+    authUrl.searchParams.set("code_challenge_method", "S256");
+    authUrl.searchParams.set("state", state);
+    authUrl.searchParams.set("scope", "mcp:tools");
+
+    // Open browser
+    console.log();
+    log.info("Opening browser to authenticate...");
+    await openBrowser(authUrl.toString());
+
+    console.log();
+    console.log(
+      `${COLORS.dim}  If the browser didn't open, visit:${COLORS.reset}`,
+    );
+    console.log(`  ${COLORS.cyan}${authUrl.toString()}${COLORS.reset}`);
+    console.log();
+    process.stdout.write(
+      `${COLORS.dim}  ● Waiting for authorization... (press Ctrl+C to cancel)${COLORS.reset}`,
+    );
+
+    // Wait for the OAuth callback
+    const { code } = await callbackResult;
+    process.stdout.write("\r\x1b[K");
+
+    // Exchange auth code for access token (API key)
+    process.stdout.write(
+      `${COLORS.dim}  ● Completing authentication...${COLORS.reset}`,
+    );
+
+    const tokenRes = await fetch(`${MCP_URL}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        code_verifier: codeVerifier,
+        client_id: client.client_id,
+        redirect_uri: redirectUri,
+      }).toString(),
+    });
+
+    if (!tokenRes.ok) {
+      process.stdout.write("\r\x1b[K");
+      const err = (await tokenRes.json().catch(() => ({}))) as {
+        error_description?: string;
+      };
+      log.error(err.error_description ?? "Token exchange failed.");
+      return null;
+    }
+
+    const token = (await tokenRes.json()) as {
+      access_token: string;
+      token_type: string;
+    };
+
+    process.stdout.write("\r\x1b[K");
+
+    // Validate the API key and get balance
+    const balanceRes = await fetch(`${GATEWAY_URL}/v1/balance`, {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    });
+
+    let balanceCents = 0;
+    if (balanceRes.ok) {
+      const data = (await balanceRes.json()) as { balance_cents: number };
+      balanceCents = data.balance_cents;
+    }
+
+    return {
+      apiKey: token.access_token,
+      email: "", // email is not returned via OAuth token exchange
+      balanceCents,
+      accessToken: "", // not available via OAuth flow
+    };
+  } catch (err) {
+    process.stdout.write("\r\x1b[K");
+    closeServer();
+
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("timed out")) {
+      log.error("Authentication timed out. Please try again.");
+    } else if (message.includes("State mismatch")) {
+      log.error("Security check failed. Please try again.");
+    } else {
+      log.error(`Authentication failed: ${message}`);
+    }
+    return null;
+  }
 }
 
 // ──── API Key Login ────
@@ -531,22 +680,27 @@ export async function runLogin(
   log.step("Sign in to varg.ai");
   console.log();
   console.log(
-    `  ${COLORS.cyan}[1]${COLORS.reset}  Email ${COLORS.dim}— sign in with your email (creates account if needed)${COLORS.reset}`,
+    `  ${COLORS.cyan}[1]${COLORS.reset}  Browser ${COLORS.dim}— sign in via browser (recommended)${COLORS.reset}`,
   );
   console.log(
-    `  ${COLORS.cyan}[2]${COLORS.reset}  API key ${COLORS.dim}— paste an existing API key${COLORS.reset}`,
+    `  ${COLORS.cyan}[2]${COLORS.reset}  Email ${COLORS.dim}— sign in with your email (creates account if needed)${COLORS.reset}`,
+  );
+  console.log(
+    `  ${COLORS.cyan}[3]${COLORS.reset}  API key ${COLORS.dim}— paste an existing API key${COLORS.reset}`,
   );
   console.log();
 
-  const mode = await readLine(`  Select login method (1-2): `);
+  const mode = await readLine(`  Select login method (1-3): `);
 
   let result: LoginResult | null = null;
 
   if (mode === "2") {
+    result = await loginWithEmail();
+  } else if (mode === "3") {
     result = await loginWithApiKey();
   } else {
-    // Default to email login (mode "1" or anything else)
-    result = await loginWithEmail();
+    // Default to browser login (mode "1" or anything else)
+    result = await loginWithBrowser();
   }
 
   if (!result) {

--- a/src/cli/oauth/oauth-callback-server.ts
+++ b/src/cli/oauth/oauth-callback-server.ts
@@ -1,0 +1,173 @@
+/**
+ * Temporary localhost HTTP server for receiving OAuth callback redirects.
+ *
+ * Starts on a random available port, waits for a single GET /callback request
+ * with ?code=...&state=..., serves a success/error HTML page to the browser,
+ * then shuts down.
+ *
+ * Used by `vargai login` browser-based OAuth flow.
+ */
+
+import { createServer, type Server } from "node:http";
+
+export interface OAuthCallbackResult {
+  code: string;
+  state: string;
+}
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>varg.ai — Authenticated</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0a0a0a; color: #fafafa;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh;
+    }
+    .card {
+      text-align: center; padding: 3rem 2rem;
+      border: 1px solid #262626; border-radius: 12px;
+      background: #141414; max-width: 400px;
+    }
+    .check { font-size: 48px; margin-bottom: 1rem; }
+    h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    p { color: #a3a3a3; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="check">&#10003;</div>
+    <h1>Authenticated</h1>
+    <p>You can close this tab and return to your terminal.</p>
+  </div>
+</body>
+</html>`;
+
+const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>varg.ai — Authentication Failed</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0a0a0a; color: #fafafa;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh;
+    }
+    .card {
+      text-align: center; padding: 3rem 2rem;
+      border: 1px solid #262626; border-radius: 12px;
+      background: #141414; max-width: 400px;
+    }
+    .icon { font-size: 48px; margin-bottom: 1rem; }
+    h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    p { color: #a3a3a3; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">&#10007;</div>
+    <h1>Authentication Failed</h1>
+    <p>${msg}</p>
+  </div>
+</body>
+</html>`;
+
+/**
+ * Start a temporary localhost server to receive an OAuth callback.
+ *
+ * Returns the port and a promise that resolves when the callback is received.
+ * The server auto-shuts down after the callback or the timeout.
+ *
+ * @param expectedState - The state parameter to verify against CSRF
+ * @param timeoutMs - Timeout in ms (default: 5 minutes)
+ */
+export function startCallbackServer(
+  expectedState: string,
+  timeoutMs = 5 * 60 * 1000,
+): { port: number; result: Promise<OAuthCallbackResult>; close: () => void } {
+  let resolveResult: (value: OAuthCallbackResult) => void;
+  let rejectResult: (reason: Error) => void;
+  let server: Server;
+  let timer: ReturnType<typeof setTimeout>;
+
+  const result = new Promise<OAuthCallbackResult>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+
+  const shutdown = () => {
+    clearTimeout(timer);
+    server?.close();
+  };
+
+  server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost`);
+
+    // Only handle GET /callback
+    if (url.pathname !== "/callback") {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+      return;
+    }
+
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const error = url.searchParams.get("error");
+    const errorDescription = url.searchParams.get("error_description");
+
+    // Handle OAuth error response
+    if (error) {
+      const msg = errorDescription ?? error;
+      res.writeHead(400, { "Content-Type": "text/html" });
+      res.end(ERROR_HTML(msg));
+      setTimeout(shutdown, 500);
+      rejectResult(new Error(`OAuth error: ${msg}`));
+      return;
+    }
+
+    // Validate required params
+    if (!code || !state) {
+      res.writeHead(400, { "Content-Type": "text/html" });
+      res.end(ERROR_HTML("Missing code or state parameter."));
+      setTimeout(shutdown, 500);
+      rejectResult(new Error("Missing code or state in callback"));
+      return;
+    }
+
+    // Verify state matches (CSRF protection)
+    if (state !== expectedState) {
+      res.writeHead(400, { "Content-Type": "text/html" });
+      res.end(ERROR_HTML("State mismatch — possible CSRF attack."));
+      setTimeout(shutdown, 500);
+      rejectResult(new Error("State mismatch"));
+      return;
+    }
+
+    // Success
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(SUCCESS_HTML);
+    setTimeout(shutdown, 500);
+    resolveResult({ code, state });
+  });
+
+  // Listen on a random available port on loopback
+  server.listen(0, "127.0.0.1");
+
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  // Timeout — reject if no callback received within the limit
+  timer = setTimeout(() => {
+    shutdown();
+    rejectResult(new Error("OAuth callback timed out. Please try again."));
+  }, timeoutMs);
+
+  return { port, result, close: shutdown };
+}

--- a/src/cli/oauth/pkce.ts
+++ b/src/cli/oauth/pkce.ts
@@ -1,0 +1,28 @@
+/**
+ * PKCE (Proof Key for Code Exchange) utilities for OAuth 2.1.
+ *
+ * Generates a code_verifier (random string) and code_challenge (SHA-256 hash).
+ * Used by the CLI browser-based login flow.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+/** Base64url-encode a buffer (no padding). */
+function base64url(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+/** Generate a random code_verifier (43–128 characters, base64url). */
+export function generateCodeVerifier(): string {
+  return base64url(randomBytes(32));
+}
+
+/** Generate a code_challenge from a code_verifier (S256). */
+export function generateCodeChallenge(verifier: string): string {
+  return base64url(createHash("sha256").update(verifier).digest());
+}
+
+/** Generate a random state parameter for CSRF protection. */
+export function generateState(): string {
+  return base64url(randomBytes(32));
+}


### PR DESCRIPTION
## Summary

- Adds browser-based OAuth as the **default login method** for `vargai login`, reusing the MCP OAuth 2.1 server infrastructure at `mcp.varg.ai`
- Users can now sign in via **Google or email** through the app consent page, instead of typing OTP codes in the terminal
- Email OTP and API key paste remain as options 2 and 3 for headless/CI environments

## Flow

1. CLI starts a temporary HTTP server on `http://127.0.0.1:<random-port>`
2. CLI registers as a dynamic client via `POST mcp.varg.ai/oauth/register`
3. Browser opens to `mcp.varg.ai/oauth/authorize` with PKCE challenge
4. User authenticates on `app.varg.ai` (Google OAuth or email OTP)
5. User approves on the consent page ("varg CLI wants to access your account")
6. Browser redirects to localhost callback with auth code
7. CLI exchanges code for API key via PKCE token exchange
8. API key saved to `~/.varg/credentials`

## New files

| File | Purpose |
|------|---------|
| `src/cli/oauth/pkce.ts` | PKCE code_verifier/challenge generation + state parameter |
| `src/cli/oauth/oauth-callback-server.ts` | Temporary localhost HTTP server for OAuth callback, with success/error HTML pages |

## Modified files

| File | Change |
|------|---------|
| `src/cli/commands/login.tsx` | Added `loginWithBrowser()`, updated mode selector (browser=1, email=2, API key=3) |

## Companion PR

- **app**: vargHQ/app — `feature/generic-consent-page` — generalizes consent page text for non-MCP clients