### PR TITLE
feat: support _gateway prop for cloud auth in Slice/FFmpeg/Probe resolvers

### DIFF
--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -904,8 +904,17 @@ async function resolveSourceUrl(
   throw new Error("cannot resolve source URL from input");
 }
 
-/** Get the varg gateway client settings. */
-function getGatewayConfig(): { apiKey: string; baseUrl: string } | null {
+/** Get the varg gateway client settings.
+ *  Checks for `_gateway` injected by `varg.slice()` / `varg.probe()` / `varg.ffmpeg()`
+ *  first, then falls back to `process.env.VARG_API_KEY` for local CLI usage.
+ */
+function getGatewayConfig(
+  props?: Record<string, unknown>,
+): { apiKey: string; baseUrl: string } | null {
+  if (props?._gateway) {
+    const gw = props._gateway as { apiKey: string; baseUrl: string };
+    if (gw.apiKey) return gw;
+  }
   const apiKey = process.env.VARG_API_KEY;
   if (!apiKey) return null;
   return {
@@ -918,8 +927,9 @@ function getGatewayConfig(): { apiKey: string; baseUrl: string } | null {
 async function gatewayJobRequest(
   path: string,
   body: Record<string, unknown>,
+  props?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const config = getGatewayConfig();
+  const config = getGatewayConfig(props);
   if (!config) throw new Error("VARG_API_KEY not set");
 
   const submitRes = await fetch(`${config.baseUrl}/v1${path}`, {
@@ -982,7 +992,11 @@ export async function resolveSliceElement(
   if (props.count !== undefined) body.count = props.count;
   if (props.ranges !== undefined) body.ranges = props.ranges;
 
-  const result = await gatewayJobRequest("/ffmpeg/slice", body);
+  const result = await gatewayJobRequest(
+    "/ffmpeg/slice",
+    body,
+    props as unknown as Record<string, unknown>,
+  );
   const output = result.output as
     | { url?: string; metadata?: Record<string, unknown> }
     | undefined;
@@ -1052,11 +1066,15 @@ export async function resolveFFmpegElement(
     ? "OUTPUT_FOLDER"
     : { out_1: "output.mp4" };
 
-  const result = await gatewayJobRequest("/ffmpeg", {
-    command,
-    input_files: inputFiles,
-    output_files: outputFiles,
-  });
+  const result = await gatewayJobRequest(
+    "/ffmpeg",
+    {
+      command,
+      input_files: inputFiles,
+      output_files: outputFiles,
+    },
+    props as unknown as Record<string, unknown>,
+  );
 
   const output = result.output as
     | { url?: string; media_type?: string }
@@ -1079,7 +1097,7 @@ export async function resolveProbeElement(
 ): Promise<ResolvedElement<"probe">> {
   const srcUrl = await resolveSourceUrl(props.src);
 
-  const config = getGatewayConfig();
+  const config = getGatewayConfig(props as unknown as Record<string, unknown>);
   if (!config) throw new Error("VARG_API_KEY not set");
 
   const res = await fetch(`${config.baseUrl}/v1/ffmpeg/probe`, {

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -419,6 +419,8 @@ export interface SliceProps {
   count?: number;
   /** Split at explicit time ranges */
   ranges?: Array<{ start: number; end: number }>;
+  /** @internal Gateway config injected by varg.slice() for cloud auth. */
+  _gateway?: { apiKey: string; baseUrl: string };
 }
 
 export interface FFmpegProps {
@@ -428,11 +430,15 @@ export interface FFmpegProps {
   inputs?: Record<string, string | File | VargElement>;
   /** FFmpeg command flags (without -i input, which is added automatically for src) */
   command: string;
+  /** @internal Gateway config injected by varg.ffmpeg() for cloud auth. */
+  _gateway?: { apiKey: string; baseUrl: string };
 }
 
 export interface ProbeProps {
   /** Source to probe: URL string, File object, or ResolvedElement */
   src: string | File | VargElement;
+  /** @internal Gateway config injected by varg.probe() for cloud auth. */
+  _gateway?: { apiKey: string; baseUrl: string };
 }
 
 /**


### PR DESCRIPTION
## Summary

- `getGatewayConfig()` now checks for a `_gateway` prop (injected by `varg.slice()`/`varg.probe()`/`varg.ffmpeg()`) before falling back to `process.env.VARG_API_KEY`
- Adds optional `_gateway` field to `SliceProps`, `FFmpegProps`, `ProbeProps` (internal, not user-facing)
- Passes props through to `gatewayJobRequest()` and `getGatewayConfig()` in all 3 resolvers

Standalone `Slice()`/`FFmpeg()`/`Probe()` continue working via env var for local CLI. Cloud rendering uses the injected `_gateway` from `varg.slice()` etc.

Part of the varg.slice/probe/ffmpeg auth fix (see companion PRs in gateway and render repos).