### PR TITLE
feat: add webhook delivery for renders

### DIFF
--- a/src/cli/commands/render.tsx
+++ b/src/cli/commands/render.tsx
@@ -180,6 +180,14 @@ const sharedArgs = {
     description: "open video after generation",
     default: false,
   },
+  "webhook-url": {
+    type: "string" as const,
+    description: "POST a JSON payload to this URL when render completes or errors",
+  },
+  "webhook-secret": {
+    type: "string" as const,
+    description: "HMAC-SHA256 secret for signing the webhook body (X-Varg-Signature header)",
+  },
 };
 
 async function runRender(
@@ -219,12 +227,18 @@ async function runRender(
 
   const defaults = await detectDefaultModels();
 
+  const webhookUrl = args["webhook-url"] as string | undefined;
+  const webhookSecret = args["webhook-secret"] as string | undefined;
+
   const buffer = await render(component, {
     output: outputPath,
     cache: useCache ? (args.cache as string) : undefined,
     mode,
     defaults,
     verbose: args.verbose as boolean,
+    quiet: args.quiet as boolean,
+    ...(webhookUrl != null && { webhookUrl }),
+    ...(webhookSecret != null && { webhookSecret }),
   });
 
   if (!args.quiet) {
@@ -313,6 +327,14 @@ function RenderHelpView() {
         <Text>
           <VargText variant="accent">--open </VargText>open video after
           generation
+        </Text>
+        <Text>
+          <VargText variant="accent">--webhook-url </VargText>POST JSON to URL
+          on completion or error
+        </Text>
+        <Text>
+          <VargText variant="accent">--webhook-secret </VargText>HMAC-SHA256
+          secret for X-Varg-Signature header
         </Text>
       </Box>
 

--- a/src/cli/commands/render.tsx
+++ b/src/cli/commands/render.tsx
@@ -186,7 +186,10 @@ const sharedArgs = {
   },
   "webhook-secret": {
     type: "string" as const,
-    description: "HMAC-SHA256 secret for signing the webhook body (X-Varg-Signature header)",
+    description:
+      "HMAC-SHA256 secret for signing the webhook body (X-Varg-Signature header). " +
+      "Falls back to VARG_WEBHOOK_SECRET env var. " +
+      "Warning: supplying secrets on the command line may expose them in process listings and shell/CI logs.",
   },
 };
 
@@ -228,7 +231,9 @@ async function runRender(
   const defaults = await detectDefaultModels();
 
   const webhookUrl = args["webhook-url"] as string | undefined;
-  const webhookSecret = args["webhook-secret"] as string | undefined;
+  const webhookSecret =
+    (args["webhook-secret"] as string | undefined) ??
+    process.env.VARG_WEBHOOK_SECRET;
 
   const buffer = await render(component, {
     output: outputPath,

--- a/src/react/render-webhook.ts
+++ b/src/react/render-webhook.ts
@@ -1,0 +1,215 @@
+import { createHmac } from "node:crypto";
+import type { File as VargFile } from "../ai-sdk/file";
+import type {
+  GenerationPricingEntry,
+  RenderOptions,
+  RenderResult,
+} from "./types";
+
+const WEBHOOK_TIMEOUT_MS = 30_000;
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 500;
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+const HEADER_EVENT = "x-varg-event";
+const HEADER_SIGNATURE = "x-varg-signature";
+
+export const WEBHOOK_EVENTS = {
+  COMPLETED: "render.completed",
+  FAILED: "render.failed",
+} as const;
+
+type WebhookEvent = (typeof WEBHOOK_EVENTS)[keyof typeof WEBHOOK_EVENTS];
+
+interface CompletedPayload {
+  event: typeof WEBHOOK_EVENTS.COMPLETED;
+  timestamp: string;
+  durationMs: number;
+  output: {
+    byteLength: number;
+    outputPath?: string;
+    videoUrl?: string;
+  };
+  files: ReturnType<VargFile["toJSON"]>[];
+  generations: GenerationPricingEntry[];
+  cost: { estimated: number; actual: number };
+}
+
+interface FailedPayload {
+  event: typeof WEBHOOK_EVENTS.FAILED;
+  timestamp: string;
+  durationMs: number;
+  error: { message: string; name?: string };
+}
+
+export type RenderWebhookPayload = CompletedPayload | FailedPayload;
+
+interface RenderWebhookCoordinator {
+  wrapOptions(opts: RenderOptions): RenderOptions;
+  onComplete(result: RenderResult): Promise<void>;
+  onError(err: unknown): void;
+}
+
+const NOOP_COORDINATOR: RenderWebhookCoordinator = {
+  wrapOptions: (o) => o,
+  onComplete: async () => {},
+  onError: () => {},
+};
+
+/**
+ * Returns a coordinator that wires webhook delivery into a render. When no
+ * `webhookUrl` is set, returns a no-op so render.ts stays clean.
+ */
+export function createRenderWebhook(
+  options: RenderOptions,
+): RenderWebhookCoordinator {
+  if (!options.webhookUrl) return NOOP_COORDINATOR;
+
+  const startedAt = Date.now();
+  const generations: GenerationPricingEntry[] = [];
+
+  return {
+    wrapOptions: (o) => ({
+      ...o,
+      onGeneration: (entry) => {
+        generations.push(entry);
+        o.onGeneration?.(entry);
+      },
+    }),
+    async onComplete(result) {
+      const videoUrl = await uploadVideo(result.video, options);
+      void fireRenderWebhook(
+        options,
+        buildCompletedPayload({
+          result,
+          generations,
+          startedAt,
+          ...(videoUrl != null && { videoUrl }),
+          ...(options.output != null && { outputPath: options.output }),
+        }),
+      );
+    },
+    onError(err) {
+      void fireRenderWebhook(options, buildFailedPayload({ err, startedAt }));
+    },
+  };
+}
+
+async function uploadVideo(
+  video: Uint8Array,
+  options: RenderOptions,
+): Promise<string | undefined> {
+  if (!options.storage) return undefined;
+  try {
+    return await options.storage.upload(
+      video,
+      `renders/${crypto.randomUUID()}.mp4`,
+      "video/mp4",
+    );
+  } catch (err) {
+    if (!options.quiet) {
+      console.warn(`[webhook] storage upload failed: ${errorMessage(err)}`);
+    }
+    return undefined;
+  }
+}
+
+export function buildCompletedPayload(input: {
+  result: RenderResult;
+  generations: GenerationPricingEntry[];
+  startedAt: number;
+  videoUrl?: string;
+  outputPath?: string;
+}): CompletedPayload {
+  const { result, generations, startedAt, videoUrl, outputPath } = input;
+  const cost = generations.reduce(
+    (acc, g) => ({
+      estimated: acc.estimated + (g.estimated ?? 0),
+      actual: acc.actual + (g.actual ?? 0),
+    }),
+    { estimated: 0, actual: 0 },
+  );
+
+  return {
+    event: WEBHOOK_EVENTS.COMPLETED,
+    timestamp: new Date().toISOString(),
+    durationMs: Date.now() - startedAt,
+    output: {
+      byteLength: result.video.byteLength,
+      ...(outputPath != null && { outputPath }),
+      ...(videoUrl != null && { videoUrl }),
+    },
+    files: result.files.map((f) => f.toJSON()),
+    generations,
+    cost,
+  };
+}
+
+export function buildFailedPayload(input: {
+  err: unknown;
+  startedAt: number;
+}): FailedPayload {
+  const { err, startedAt } = input;
+  const name = err instanceof Error ? err.name : undefined;
+  return {
+    event: WEBHOOK_EVENTS.FAILED,
+    timestamp: new Date().toISOString(),
+    durationMs: Date.now() - startedAt,
+    error: { message: errorMessage(err), ...(name != null && { name }) },
+  };
+}
+
+export async function fireRenderWebhook(
+  opts: Pick<RenderOptions, "webhookUrl" | "webhookSecret" | "quiet">,
+  payload: RenderWebhookPayload,
+): Promise<void> {
+  if (!opts.webhookUrl) return;
+
+  const body = JSON.stringify(payload);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    [HEADER_EVENT]: payload.event satisfies WebhookEvent,
+  };
+  if (opts.webhookSecret) {
+    headers[HEADER_SIGNATURE] = createHmac("sha256", opts.webhookSecret)
+      .update(body)
+      .digest("hex");
+  }
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    try {
+      const res = await fetch(opts.webhookUrl, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller.signal,
+      });
+      if (res.ok) return;
+      lastError = new Error(`webhook responded ${res.status}`);
+      if (!RETRYABLE_STATUS.has(res.status)) break;
+    } catch (err) {
+      lastError = err;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (attempt < MAX_ATTEMPTS - 1) {
+      const delay = BASE_DELAY_MS * 2 ** attempt;
+      const jitter = delay * 0.3 * Math.random();
+      await new Promise((r) => setTimeout(r, Math.round(delay + jitter)));
+    }
+  }
+
+  if (!opts.quiet) {
+    console.warn(
+      `[webhook] delivery to ${opts.webhookUrl} failed: ${errorMessage(lastError)}`,
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/react/render-webhook.ts
+++ b/src/react/render-webhook.ts
@@ -1,4 +1,5 @@
 import { createHmac } from "node:crypto";
+import { isPrivateWebhookUrl } from "../studio/webhook-validate";
 import type { File as VargFile } from "../ai-sdk/file";
 import type {
   GenerationPricingEntry,
@@ -13,6 +14,7 @@ const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 
 const HEADER_EVENT = "x-varg-event";
 const HEADER_SIGNATURE = "x-varg-signature";
+const HEADER_TIMESTAMP = "x-varg-timestamp";
 
 export const WEBHOOK_EVENTS = {
   COMPLETED: "render.completed",
@@ -47,13 +49,13 @@ export type RenderWebhookPayload = CompletedPayload | FailedPayload;
 interface RenderWebhookCoordinator {
   wrapOptions(opts: RenderOptions): RenderOptions;
   onComplete(result: RenderResult): Promise<void>;
-  onError(err: unknown): void;
+  onError(err: unknown): Promise<void>;
 }
 
 const NOOP_COORDINATOR: RenderWebhookCoordinator = {
   wrapOptions: (o) => o,
   onComplete: async () => {},
-  onError: () => {},
+  onError: async () => {},
 };
 
 /**
@@ -78,7 +80,7 @@ export function createRenderWebhook(
     }),
     async onComplete(result) {
       const videoUrl = await uploadVideo(result.video, options);
-      void fireRenderWebhook(
+      await fireRenderWebhook(
         options,
         buildCompletedPayload({
           result,
@@ -89,8 +91,8 @@ export function createRenderWebhook(
         }),
       );
     },
-    onError(err) {
-      void fireRenderWebhook(options, buildFailedPayload({ err, startedAt }));
+    async onError(err) {
+      await fireRenderWebhook(options, buildFailedPayload({ err, startedAt }));
     },
   };
 }
@@ -164,15 +166,25 @@ export async function fireRenderWebhook(
   payload: RenderWebhookPayload,
 ): Promise<void> {
   if (!opts.webhookUrl) return;
+  if (isPrivateWebhookUrl(opts.webhookUrl)) {
+    if (!opts.quiet) {
+      console.warn(
+        `[webhook] rejected private/non-HTTPS URL: ${opts.webhookUrl}`,
+      );
+    }
+    return;
+  }
 
   const body = JSON.stringify(payload);
+  const timestamp = String(Date.now());
   const headers: Record<string, string> = {
     "content-type": "application/json",
     [HEADER_EVENT]: payload.event satisfies WebhookEvent,
+    [HEADER_TIMESTAMP]: timestamp,
   };
   if (opts.webhookSecret) {
     headers[HEADER_SIGNATURE] = createHmac("sha256", opts.webhookSecret)
-      .update(body)
+      .update(`${timestamp}.${body}`)
       .digest("hex");
   }
 

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -1,6 +1,7 @@
 import { type CacheStorage, withCache } from "../ai-sdk/cache";
 import { fileCache } from "../ai-sdk/file-cache";
 import { localBackend } from "../ai-sdk/providers/editly";
+import { createRenderWebhook } from "./render-webhook";
 import { renderRoot } from "./renderers";
 import { resolveLazy } from "./renderers/resolve-lazy";
 import { withResolveContext } from "./resolve-context";
@@ -30,10 +31,8 @@ export async function render(
 ): Promise<RenderResult> {
   const backend = options.backend ?? localBackend;
   const cache = resolveCacheStorage(options.cache);
+  const webhook = createRenderWebhook(options);
 
-  // Resolve lazy elements (from async components) within the resolve context.
-  // This makes backend/cache/storage available to `await Speech()` etc. via
-  // AsyncLocalStorage, so they use the same infrastructure as the render pipeline.
   const resolved = (await withResolveContext(
     { backend, cache, storage: options.storage },
     () => resolveLazy(element),
@@ -43,7 +42,17 @@ export async function render(
     throw new Error("Root element must be <Render>");
   }
 
-  return renderRoot(resolved as VargElement<"render">, options);
+  try {
+    const result = await renderRoot(
+      resolved as VargElement<"render">,
+      webhook.wrapOptions(options),
+    );
+    await webhook.onComplete(result);
+    return result;
+  } catch (err) {
+    webhook.onError(err);
+    throw err;
+  }
 }
 
 /** Streaming render interface that yields progress events. */

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -33,16 +33,16 @@ export async function render(
   const cache = resolveCacheStorage(options.cache);
   const webhook = createRenderWebhook(options);
 
-  const resolved = (await withResolveContext(
-    { backend, cache, storage: options.storage },
-    () => resolveLazy(element),
-  )) as VargElement;
-
-  if (resolved.type !== "render") {
-    throw new Error("Root element must be <Render>");
-  }
-
   try {
+    const resolved = (await withResolveContext(
+      { backend, cache, storage: options.storage },
+      () => resolveLazy(element),
+    )) as VargElement;
+
+    if (resolved.type !== "render") {
+      throw new Error("Root element must be <Render>");
+    }
+
     const result = await renderRoot(
       resolved as VargElement<"render">,
       webhook.wrapOptions(options),
@@ -50,7 +50,7 @@ export async function render(
     await webhook.onComplete(result);
     return result;
   } catch (err) {
-    webhook.onError(err);
+    await webhook.onError(err);
     throw err;
   }
 }

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -392,6 +392,10 @@ export interface RenderOptions {
   concurrency?: number;
   /** Callback invoked after each AI generation completes. Used to accumulate per-model costs. */
   onGeneration?: (entry: GenerationPricingEntry) => void;
+  /** If set, POST a JSON payload to this URL when the render completes or errors. */
+  webhookUrl?: string;
+  /** Optional secret used to sign the webhook body via HMAC-SHA256 (sent as `X-Varg-Signature` header, hex). */
+  webhookSecret?: string;
 }
 
 // Re-export from file module for convenience

--- a/src/studio/server.ts
+++ b/src/studio/server.ts
@@ -96,6 +96,8 @@ export function createStudioServer(config: Partial<StudioConfig> = {}) {
     renderId: string,
     onProgress: (progress: RenderProgress) => void,
     _signal: AbortSignal,
+    webhookUrl?: string,
+    webhookSecret?: string,
   ): Promise<string> {
     const outputPath = join(outputDir, `${renderId}.mp4`);
     const tempDir = join(import.meta.dir, "../react/examples");
@@ -132,6 +134,8 @@ export function createStudioServer(config: Partial<StudioConfig> = {}) {
         output: outputPath,
         cache: cacheDir,
         quiet: false,
+        ...(webhookUrl != null && { webhookUrl }),
+        ...(webhookSecret != null && { webhookSecret }),
       });
 
       console.log(`[render] complete: ${outputPath}`);
@@ -251,6 +255,8 @@ export function createStudioServer(config: Partial<StudioConfig> = {}) {
                 renderId,
                 (progress) => send("progress", progress),
                 controller.signal,
+                body.webhookUrl,
+                body.webhookSecret,
               );
               send("complete", { videoUrl: `/api/output/${renderId}.mp4` });
             } catch (error) {

--- a/src/studio/server.ts
+++ b/src/studio/server.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { isPrivateWebhookUrl } from "./webhook-validate";
 import { getCacheItemMedia, scanCacheFolder } from "./scanner";
 import { extractStages, serializeStages } from "./stages";
 import {
@@ -233,6 +234,14 @@ export function createStudioServer(config: Partial<StudioConfig> = {}) {
 
       if (url.pathname === "/api/render" && req.method === "POST") {
         const body = (await req.json()) as RenderRequest;
+
+        if (body.webhookUrl && isPrivateWebhookUrl(body.webhookUrl)) {
+          return Response.json(
+            { error: "webhookUrl must be a public HTTPS URL" },
+            { status: 400 },
+          );
+        }
+
         const renderId = `render-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const controller = new AbortController();
         activeRenders.set(renderId, controller);

--- a/src/studio/types.ts
+++ b/src/studio/types.ts
@@ -37,6 +37,8 @@ export interface VideoData {
 export interface RenderRequest {
   code: string;
   cacheDir?: string;
+  webhookUrl?: string;
+  webhookSecret?: string;
 }
 
 export interface RenderProgress {

--- a/src/studio/webhook-validate.ts
+++ b/src/studio/webhook-validate.ts
@@ -1,0 +1,32 @@
+const PRIVATE_RANGES = [
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^0\./,
+  /^169\.254\./,
+];
+
+const ALLOWED_HOSTS = process.env.ALLOWED_WEBHOOK_HOSTS?.split(",").map((h) =>
+  h.trim().toLowerCase(),
+);
+
+export function isPrivateWebhookUrl(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return true;
+  }
+
+  if (parsed.protocol !== "https:") return true;
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (hostname === "localhost" || hostname === "::1") return true;
+  if (PRIVATE_RANGES.some((r) => r.test(hostname))) return true;
+
+  if (ALLOWED_HOSTS && !ALLOWED_HOSTS.includes(hostname)) return true;
+
+  return false;
+}


### PR DESCRIPTION
Adds `webhookUrl` and `webhookSecret` to RenderOptions (plus matching CLI flags and Studio request fields). When set, render() POSTs a JSON payload on completion or failure, optionally HMAC-SHA256 signed via `X-Varg-Signature`. If a `storage` provider is configured, the final mp4 is uploaded and the URL is included in the payload.

## What

Brief description of what this PR does.

## Why

Why is this change needed?

## How to test

Steps to verify the changes work correctly.

## Checklist

- [ ] Code follows existing style
- [ ] Tested locally with `bun run check`
- [ ] No breaking changes (or documented below)
