### PR TITLE
feat: add Magnific provider with BYOK direct + gateway paths

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "fluent-ffmpeg": "^2.1.3",
         "groq-sdk": "^0.36.0",
         "ink": "^6.5.1",
+        "opentype.js": "^1.3.4",
         "p-limit": "^6.2.0",
         "p-map": "^7.0.4",
         "react": "^19.2.0",
@@ -44,6 +45,7 @@
         "@commitlint/config-conventional": "^20.0.0",
         "@size-limit/preset-small-lib": "^11.2.0",
         "@types/bun": "latest",
+        "@types/opentype.js": "^1.3.9",
         "@types/react": "^19.2.7",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
@@ -552,6 +554,8 @@
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
+    "@types/opentype.js": ["@types/opentype.js@1.3.9", "", {}, "sha512-KOGywvDPncA4/tTWV5xKNhjpsoSSAHIx3mHOhL5l3XX+c6Xu2dQnHvGs7mRNQsQRte1EqmQ0cPQQ8Z14lkv+yw=="],
+
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
@@ -1059,6 +1063,8 @@
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
+
+    "opentype.js": ["opentype.js@1.3.5", "", { "bin": { "ot": "bin/ot" } }, "sha512-thKDiELidAApOvXlncrpwDZKJCa9fXLEKM4+FoEWI+qTLDeNb+h7EkN+8a7KQODsB1GZ+Exz9KknkoPrEdXZDw=="],
 
     "ow": ["ow@0.28.2", "", { "dependencies": { "@sindresorhus/is": "^4.2.0", "callsites": "^3.1.0", "dot-prop": "^6.0.1", "lodash.isequal": "^4.5.0", "vali-date": "^1.0.0" } }, "sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q=="],
 

--- a/src/ai-sdk/providers/magnific.test.ts
+++ b/src/ai-sdk/providers/magnific.test.ts
@@ -1,0 +1,1716 @@
+/**
+ * Magnific provider tests — covers BYOK precedence, routing fork, apiKey
+ * scrubbing, and per-endpoint payload shape (one test per builder, exhaustive).
+ *
+ * No network: every fetch is mocked via Bun's spyOn. The "payload shape" tests
+ * call `_internal_buildBody` to assemble the outgoing request body and snapshot
+ * every property — this is the binding artifact for the property coverage rule.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  _internal_buildBody,
+  IMAGE_MODELS,
+  listMagnificModels,
+  MAGNIFIC_BASE_URL,
+  MAGNIFIC_PREFIX,
+  MagnificAPIError,
+  MUSIC_MODELS,
+  parseMagnificModelId,
+  resolveMagnificKey,
+  SPEECH_MODELS,
+  VIDEO_MODELS,
+} from "./magnific";
+import { createVarg } from "./varg";
+
+// ---------------------------------------------------------------------------
+// Test fetch harness
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown> | null;
+}
+
+function makeFetchHarness(
+  responses: Array<{
+    status?: number;
+    json?: unknown;
+    bytes?: Uint8Array;
+  }>,
+): { calls: FetchCall[]; restore: () => void } {
+  const calls: FetchCall[] = [];
+  const queue = [...responses];
+  const original = globalThis.fetch;
+  // biome-ignore lint/suspicious/noExplicitAny: harness
+  (globalThis as any).fetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    const rawHeaders = init?.headers ?? {};
+    const headers: Record<string, string> = {};
+    if (rawHeaders instanceof Headers) {
+      rawHeaders.forEach((v, k) => {
+        headers[k.toLowerCase()] = v;
+      });
+    } else if (Array.isArray(rawHeaders)) {
+      for (const [k, v] of rawHeaders) headers[k.toLowerCase()] = v;
+    } else {
+      for (const [k, v] of Object.entries(rawHeaders)) {
+        if (typeof v === "string") headers[k.toLowerCase()] = v;
+      }
+    }
+    let body: Record<string, unknown> | null = null;
+    if (typeof init?.body === "string") {
+      const ct = (headers["content-type"] ?? "").toLowerCase();
+      if (ct.includes("application/x-www-form-urlencoded")) {
+        body = Object.fromEntries(new URLSearchParams(init.body));
+      } else {
+        try {
+          body = JSON.parse(init.body) as Record<string, unknown>;
+        } catch {
+          body = null;
+        }
+      }
+    }
+    calls.push({ url, method, headers, body });
+
+    const next = queue.shift() ?? { status: 200, json: {} };
+    const status = next.status ?? 200;
+    if (next.bytes) {
+      // biome-ignore lint/suspicious/noExplicitAny: Uint8Array<ArrayBufferLike> typing mismatch in lib.dom.d.ts
+      return new Response(next.bytes as any, { status });
+    }
+    return new Response(JSON.stringify(next.json ?? {}), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  return {
+    calls,
+    restore: () => {
+      // biome-ignore lint/suspicious/noExplicitAny: harness
+      (globalThis as any).fetch = original;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants & introspection
+// ---------------------------------------------------------------------------
+
+describe("magnific module shape", () => {
+  test("MAGNIFIC_PREFIX is the namespace prefix", () => {
+    expect(MAGNIFIC_PREFIX).toBe("magnific/");
+    expect(MAGNIFIC_BASE_URL).toBe("https://api.magnific.com/v1");
+  });
+
+  test("parseMagnificModelId strips prefix or returns null", () => {
+    expect(parseMagnificModelId("magnific/upscale-creative")).toBe(
+      "upscale-creative",
+    );
+    expect(parseMagnificModelId("magnific/kling-v3-pro")).toBe("kling-v3-pro");
+    expect(parseMagnificModelId("seedvr")).toBeNull();
+    expect(parseMagnificModelId("")).toBeNull();
+  });
+
+  test("model maps cover every endpoint we expect", () => {
+    expect(Object.keys(IMAGE_MODELS).length).toBe(18);
+    expect(Object.keys(VIDEO_MODELS).length).toBe(19);
+    expect(Object.keys(MUSIC_MODELS).length).toBe(1);
+    expect(Object.keys(SPEECH_MODELS).length).toBe(2);
+    expect(IMAGE_MODELS["upscale-creative"]).toBe("ai/image-upscaler");
+    expect(VIDEO_MODELS["kling-v3-pro"]).toBe("ai/video/kling-v3-pro");
+    expect(SPEECH_MODELS["audio-isolation"]).toBe("ai/audio-isolation");
+  });
+
+  test("listMagnificModels returns namespaced ids", () => {
+    const all = listMagnificModels();
+    expect(all.image).toContain("magnific/upscale-creative");
+    expect(all.video).toContain("magnific/kling-v3-pro");
+    expect(all.speech).toContain("magnific/audio-isolation");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BYOK key resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveMagnificKey", () => {
+  const ENV_BACKUP = process.env.MAGNIFIC_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.MAGNIFIC_API_KEY;
+  });
+  afterEach(() => {
+    if (ENV_BACKUP === undefined) delete process.env.MAGNIFIC_API_KEY;
+    else process.env.MAGNIFIC_API_KEY = ENV_BACKUP;
+  });
+
+  test("per-call apiKey wins over settings and env", () => {
+    process.env.MAGNIFIC_API_KEY = "from-env";
+    expect(
+      resolveMagnificKey({
+        settings: { magnificApiKey: "from-settings" },
+        perCall: { apiKey: "from-call" },
+      }),
+    ).toBe("from-call");
+  });
+
+  test("settings wins over env", () => {
+    process.env.MAGNIFIC_API_KEY = "from-env";
+    expect(
+      resolveMagnificKey({ settings: { magnificApiKey: "from-settings" } }),
+    ).toBe("from-settings");
+  });
+
+  test("env is fallback when nothing else is set", () => {
+    process.env.MAGNIFIC_API_KEY = "from-env";
+    expect(resolveMagnificKey()).toBe("from-env");
+  });
+
+  test("returns null when no key is available", () => {
+    expect(resolveMagnificKey()).toBeNull();
+    expect(resolveMagnificKey({ perCall: { apiKey: "" } })).toBeNull();
+  });
+
+  test("ignores empty-string keys (gateway fallback)", () => {
+    expect(resolveMagnificKey({ settings: { magnificApiKey: "" } })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routing fork — BYOK direct vs Varg gateway
+// ---------------------------------------------------------------------------
+
+describe("varg.imageModel('magnific/...') routing", () => {
+  const ENV_BACKUP = process.env.MAGNIFIC_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.MAGNIFIC_API_KEY;
+  });
+  afterEach(() => {
+    if (ENV_BACKUP === undefined) delete process.env.MAGNIFIC_API_KEY;
+    else process.env.MAGNIFIC_API_KEY = ENV_BACKUP;
+  });
+
+  test("BYOK direct path: hits api.magnific.com with x-magnific-api-key", async () => {
+    const { calls, restore } = makeFetchHarness([
+      // submitTask → returns task_id
+      {
+        json: { task_id: "task-1", status: "IN_PROGRESS" },
+      },
+      // pollTask → COMPLETED
+      {
+        json: {
+          task_id: "task-1",
+          status: "COMPLETED",
+          generated: ["https://cdn.example/result.png"],
+        },
+      },
+      // download
+      { bytes: new Uint8Array([1, 2, 3, 4]) },
+    ]);
+
+    try {
+      const v = createVarg({
+        apiKey: "varg-key",
+        magnificApiKey: "magnific-byok-key",
+      });
+      const out = await v.imageModel("magnific/upscale-creative").doGenerate({
+        prompt: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: new Uint8Array([0, 1, 2, 3]),
+          },
+        ],
+        mask: undefined,
+        providerOptions: { magnific: { scale_factor: "4x" } },
+      });
+
+      expect(out.images).toHaveLength(1);
+      expect((out.images[0] as Uint8Array)[0]).toBe(1);
+
+      // submit + poll + download
+      expect(calls.length).toBe(3);
+      const submit = calls[0]!;
+      expect(submit.url).toBe("https://api.magnific.com/v1/ai/image-upscaler");
+      expect(submit.method).toBe("POST");
+      expect(submit.headers["x-magnific-api-key"]).toBe("magnific-byok-key");
+      // No Authorization Bearer header (that's the gateway path).
+      expect(submit.headers["authorization"]).toBeUndefined();
+      // Body covers every documented field.
+      expect(submit.body).toMatchObject({
+        scale_factor: "4x",
+        optimized_for: "standard",
+        creativity: 0,
+        hdr: 0,
+        resemblance: 0,
+        fractality: 0,
+        engine: "automatic",
+        filter_nsfw: false,
+      });
+
+      const poll = calls[1]!;
+      expect(poll.method).toBe("GET");
+      expect(poll.url).toBe(
+        "https://api.magnific.com/v1/ai/image-upscaler/task-1",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("gateway path: no BYOK key → POST to varg gateway with magnific/<leaf> model", async () => {
+    const { calls, restore } = makeFetchHarness([
+      // varg /image submit
+      {
+        json: {
+          job_id: "j1",
+          status: "completed",
+          output: { url: "https://cdn.example/r.png", media_type: "image/png" },
+        },
+      },
+      // download
+      { bytes: new Uint8Array([9, 8, 7]) },
+    ]);
+
+    try {
+      const v = createVarg({ apiKey: "varg-key" });
+      const out = await v.imageModel("magnific/mystic").doGenerate({
+        prompt: "a cat",
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {},
+      });
+
+      expect(out.images).toHaveLength(1);
+      const submit = calls[0]!;
+      expect(submit.url).toBe("https://api.varg.ai/v1/image");
+      expect(submit.headers["authorization"]).toBe("Bearer varg-key");
+      expect(submit.headers["x-magnific-api-key"]).toBeUndefined();
+      // Gateway gets the full namespaced model id verbatim.
+      expect(submit.body).toMatchObject({
+        model: "magnific/mystic",
+        prompt: "a cat",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  test("apiKey in providerOptions.magnific does NOT leak into the request body", async () => {
+    const { calls, restore } = makeFetchHarness([
+      { json: { task_id: "t-2", status: "IN_PROGRESS" } },
+      {
+        json: {
+          task_id: "t-2",
+          status: "COMPLETED",
+          generated: ["https://cdn.example/r.png"],
+        },
+      },
+      { bytes: new Uint8Array([1]) },
+    ]);
+
+    try {
+      const v = createVarg({ apiKey: "varg-key" });
+      await v.imageModel("magnific/relight").doGenerate({
+        prompt: "golden hour",
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: new Uint8Array([1, 2, 3]),
+          },
+        ],
+        mask: undefined,
+        providerOptions: {
+          magnific: {
+            apiKey: "secret-byok-key",
+            light_transfer_strength: 80,
+          },
+        },
+      });
+
+      const submit = calls[0]!;
+      expect(submit.headers["x-magnific-api-key"]).toBe("secret-byok-key");
+      expect(submit.body?.apiKey).toBeUndefined();
+      // Builder-produced field still present
+      expect(submit.body).toMatchObject({ light_transfer_strength: 80 });
+    } finally {
+      restore();
+    }
+  });
+
+  test("unknown magnific leaf throws NoSuchModelError on direct call", async () => {
+    process.env.MAGNIFIC_API_KEY = "key";
+    await expect(
+      createVarg().imageModel("magnific/nope").doGenerate({
+        prompt: "x",
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {},
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("synchronous remove-bg short-circuits without polling", async () => {
+    const { calls, restore } = makeFetchHarness([
+      // submit returns COMPLETED + generated immediately
+      {
+        json: {
+          task_id: "rb-1",
+          status: "COMPLETED",
+          generated: ["https://cdn.example/no-bg.png"],
+        },
+      },
+      // download
+      { bytes: new Uint8Array([5, 5]) },
+    ]);
+
+    try {
+      const v = createVarg({ magnificApiKey: "k" });
+      const out = await v.imageModel("magnific/remove-bg").doGenerate({
+        prompt: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [{ type: "url", url: "https://cdn.example/in.png" }],
+        mask: undefined,
+        providerOptions: {},
+      });
+      expect(out.images).toHaveLength(1);
+      expect(calls.length).toBe(2); // submit + download (NO poll)
+      expect(calls[0]!.url).toBe(
+        "https://api.magnific.com/v1/ai/beta/remove-background",
+      );
+      expect(calls[0]!.body).toEqual({
+        image_url: "https://cdn.example/in.png",
+      });
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-endpoint payload-shape tests — every property covered.
+// ---------------------------------------------------------------------------
+
+const baseImageOpts = (
+  override: Record<string, unknown> = {},
+): Parameters<typeof _internal_buildBody>[2] => ({
+  prompt: undefined,
+  n: 1,
+  size: undefined,
+  aspectRatio: undefined,
+  seed: undefined,
+  files: undefined,
+  mask: undefined,
+  providerOptions: {},
+  ...override,
+});
+
+const baseVideoOpts = (
+  override: Record<string, unknown> = {},
+): Parameters<typeof _internal_buildBody>[2] => ({
+  prompt: "",
+  n: 1,
+  resolution: undefined,
+  aspectRatio: undefined,
+  duration: undefined,
+  fps: undefined,
+  seed: undefined,
+  files: undefined,
+  providerOptions: {},
+  ...override,
+});
+
+const baseMusicOpts = (
+  override: Record<string, unknown> = {},
+): Parameters<typeof _internal_buildBody>[2] => ({
+  prompt: "",
+  duration: undefined,
+  providerOptions: {},
+  ...override,
+});
+
+const baseSpeechOpts = (
+  override: Record<string, unknown> = {},
+): Parameters<typeof _internal_buildBody>[2] => ({
+  text: "",
+  providerOptions: {},
+  ...override,
+});
+
+describe("payload builders — image gen", () => {
+  test("upscale-creative covers every documented field", async () => {
+    const body = await _internal_buildBody(
+      "magnific/upscale-creative",
+      "image",
+      baseImageOpts({
+        prompt: "high res",
+        files: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: new Uint8Array([0, 1, 2, 3]),
+          },
+        ],
+        providerOptions: {
+          magnific: {
+            scale_factor: "8x",
+            optimized_for: "films_n_photography",
+            creativity: 5,
+            hdr: 3,
+            resemblance: 2,
+            fractality: 4,
+            engine: "magnific_sharpy",
+            filter_nsfw: true,
+            webhook_url: "https://wh.example/cb",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "AAECAw==",
+      prompt: "high res",
+      scale_factor: "8x",
+      optimized_for: "films_n_photography",
+      creativity: 5,
+      hdr: 3,
+      resemblance: 2,
+      fractality: 4,
+      engine: "magnific_sharpy",
+      filter_nsfw: true,
+      webhook_url: "https://wh.example/cb",
+    });
+  });
+
+  test("upscale-precision covers every documented field", async () => {
+    const body = await _internal_buildBody(
+      "magnific/upscale-precision",
+      "image",
+      baseImageOpts({
+        files: [
+          {
+            type: "file",
+            mediaType: "image/jpeg",
+            data: new Uint8Array([1]),
+          },
+        ],
+        providerOptions: {
+          magnific: {
+            sharpen: 75,
+            smart_grain: 12,
+            ultra_detail: 40,
+            filter_nsfw: true,
+            webhook_url: "https://wh.example/cb",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "AQ==",
+      sharpen: 75,
+      smart_grain: 12,
+      ultra_detail: 40,
+      filter_nsfw: true,
+      webhook_url: "https://wh.example/cb",
+    });
+  });
+
+  test("relight covers every documented field including advanced_settings", async () => {
+    const body = await _internal_buildBody(
+      "magnific/relight",
+      "image",
+      baseImageOpts({
+        prompt: "golden hour",
+        files: [
+          { type: "file", mediaType: "image/png", data: new Uint8Array([0]) },
+        ],
+        providerOptions: {
+          magnific: {
+            transfer_light_from_reference_image: "ref-b64",
+            transfer_light_from_lightmap: undefined,
+            light_transfer_strength: 80,
+            interpolate_from_original: true,
+            change_background: false,
+            style: "contrasted_n_hdr",
+            preserve_details: false,
+            webhook_url: "https://wh.example/cb",
+            advanced_settings: {
+              whites: 60,
+              blacks: 40,
+              brightness: 55,
+              contrast: 65,
+              saturation: 70,
+              engine: "illusio",
+              transfer_light_a: "high_on_faces",
+              transfer_light_b: "smooth_in",
+              fixed_generation: true,
+            },
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "AA==",
+      prompt: "golden hour",
+      transfer_light_from_reference_image: "ref-b64",
+      light_transfer_strength: 80,
+      interpolate_from_original: true,
+      change_background: false,
+      style: "contrasted_n_hdr",
+      preserve_details: false,
+      advanced_settings: {
+        whites: 60,
+        blacks: 40,
+        brightness: 55,
+        contrast: 65,
+        saturation: 70,
+        engine: "illusio",
+        transfer_light_a: "high_on_faces",
+        transfer_light_b: "smooth_in",
+        fixed_generation: true,
+      },
+    });
+  });
+
+  test("style-transfer covers every documented field", async () => {
+    const body = await _internal_buildBody(
+      "magnific/style-transfer",
+      "image",
+      baseImageOpts({
+        files: [
+          { type: "file", mediaType: "image/png", data: new Uint8Array([0]) },
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: new Uint8Array([1, 2]),
+          },
+        ],
+        providerOptions: {
+          magnific: {
+            style_strength: 90,
+            structure_strength: 30,
+            is_portrait: true,
+            portrait_style: "super_pop",
+            portrait_beautifier: "beautify_face_max",
+            flavor: "gen_z",
+            engine: "definio",
+            fixed_generation: true,
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "AA==",
+      reference_image: "AQI=",
+      style_strength: 90,
+      structure_strength: 30,
+      is_portrait: true,
+      portrait_style: "super_pop",
+      portrait_beautifier: "beautify_face_max",
+      flavor: "gen_z",
+      engine: "definio",
+      fixed_generation: true,
+    });
+  });
+
+  test("remove-bg requires URL input", async () => {
+    const body = await _internal_buildBody(
+      "magnific/remove-bg",
+      "image",
+      baseImageOpts({
+        files: [{ type: "url", url: "https://cdn.example/in.png" }],
+      }),
+    );
+    expect(body).toEqual({ image_url: "https://cdn.example/in.png" });
+  });
+
+  test("expand covers every documented field", async () => {
+    const body = await _internal_buildBody(
+      "magnific/expand",
+      "image",
+      baseImageOpts({
+        prompt: "extend the sky",
+        files: [
+          { type: "file", mediaType: "image/png", data: new Uint8Array([0]) },
+        ],
+        providerOptions: {
+          magnific: {
+            left: 256,
+            right: 128,
+            top: 0,
+            bottom: 64,
+            webhook_url: "https://wh.example/cb",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "AA==",
+      prompt: "extend the sky",
+      left: 256,
+      right: 128,
+      top: 0,
+      bottom: 64,
+      webhook_url: "https://wh.example/cb",
+    });
+  });
+
+  test("mystic covers every documented field including styling", async () => {
+    const body = await _internal_buildBody(
+      "magnific/mystic",
+      "image",
+      baseImageOpts({
+        prompt: "futuristic city",
+        providerOptions: {
+          magnific: {
+            structure_reference: "struct-b64",
+            structure_strength: 70,
+            style_reference: "style-b64",
+            adherence: 60,
+            hdr: 80,
+            resolution: "4k",
+            aspect_ratio: "widescreen_16_9",
+            model: "super_real",
+            creative_detailing: 90,
+            engine: "magnific_sparkle",
+            fixed_generation: true,
+            filter_nsfw: false,
+            webhook_url: "https://wh.example/cb",
+            styling: {
+              styles: [{ name: "cinematic", strength: 120 }],
+              characters: [{ id: "char-1", strength: 80 }],
+              colors: [
+                { color: "#FF0000", weight: 0.4 },
+                { color: "#00FF00", weight: 0.6 },
+              ],
+            },
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "futuristic city",
+      structure_reference: "struct-b64",
+      structure_strength: 70,
+      style_reference: "style-b64",
+      adherence: 60,
+      hdr: 80,
+      resolution: "4k",
+      aspect_ratio: "widescreen_16_9",
+      model: "super_real",
+      creative_detailing: 90,
+      engine: "magnific_sparkle",
+      fixed_generation: true,
+      filter_nsfw: false,
+      styling: {
+        styles: [{ name: "cinematic", strength: 120 }],
+        characters: [{ id: "char-1", strength: 80 }],
+      },
+    });
+  });
+
+  test("flux-2-pro covers width/height/seed/prompt_upsampling and 4 input images", async () => {
+    const body = await _internal_buildBody(
+      "magnific/flux-2-pro",
+      "image",
+      baseImageOpts({
+        prompt: "a cat",
+        size: "1280x720",
+        seed: 42,
+        files: [
+          { type: "file", mediaType: "image/png", data: new Uint8Array([1]) },
+          { type: "file", mediaType: "image/png", data: new Uint8Array([2]) },
+        ],
+        providerOptions: {
+          magnific: {
+            prompt_upsampling: true,
+            input_image_3: "premade-3",
+            webhook_url: "https://wh.example/cb",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "a cat",
+      width: 1280,
+      height: 720,
+      seed: 42,
+      prompt_upsampling: true,
+      input_image: "AQ==",
+      input_image_2: "Ag==",
+      input_image_3: "premade-3",
+      webhook_url: "https://wh.example/cb",
+    });
+  });
+
+  test("flux-2-turbo emits image_size object and guidance_scale", async () => {
+    const body = await _internal_buildBody(
+      "magnific/flux-2-turbo",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        seed: 1,
+        size: "2048x2048",
+        providerOptions: {
+          magnific: {
+            guidance_scale: 4.5,
+            enable_safety_checker: false,
+            output_format: "jpeg",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      guidance_scale: 4.5,
+      seed: 1,
+      image_size: { width: 2048, height: 2048 },
+      enable_safety_checker: false,
+      output_format: "jpeg",
+    });
+  });
+
+  test("flux-2-klein covers safety_tolerance and 4 reference images", async () => {
+    const body = await _internal_buildBody(
+      "magnific/flux-2-klein",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        aspectRatio: "16:9",
+        providerOptions: {
+          magnific: {
+            resolution: "2k",
+            safety_tolerance: 4,
+            output_format: "png",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      aspect_ratio: "widescreen_16_9",
+      resolution: "2k",
+      safety_tolerance: 4,
+      output_format: "png",
+    });
+  });
+
+  test("flux-pro-v1.1 covers prompt_upsampling and safety_tolerance", async () => {
+    const body = await _internal_buildBody(
+      "magnific/flux-pro-v1.1",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        aspectRatio: "1:1",
+        seed: 7,
+        providerOptions: {
+          magnific: {
+            prompt_upsampling: true,
+            safety_tolerance: 5,
+            output_format: "png",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      prompt_upsampling: true,
+      seed: 7,
+      aspect_ratio: "square_1_1",
+      safety_tolerance: 5,
+      output_format: "png",
+    });
+  });
+
+  test("flux-dev forwards styling.effects and styling.colors", async () => {
+    const body = await _internal_buildBody(
+      "magnific/flux-dev",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        aspectRatio: "9:16",
+        providerOptions: {
+          magnific: {
+            styling: {
+              effects: {
+                color: "vibrant",
+                framing: "lowangle",
+                lightning: "dramatic",
+              },
+              colors: [{ color: "#abcdef", weight: 0.5 }],
+            },
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      aspect_ratio: "social_story_9_16",
+      styling: {
+        effects: {
+          color: "vibrant",
+          framing: "lowangle",
+          lightning: "dramatic",
+        },
+        colors: [{ color: "#abcdef", weight: 0.5 }],
+      },
+    });
+  });
+
+  test("hyperflux mirrors flux-dev fields", async () => {
+    const body = await _internal_buildBody(
+      "magnific/hyperflux",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        seed: 11,
+        aspectRatio: "1:1",
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      aspect_ratio: "square_1_1",
+      seed: 11,
+    });
+  });
+
+  test("seedream-4 covers guidance_scale", async () => {
+    const body = await _internal_buildBody(
+      "magnific/seedream-4",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        aspectRatio: "16:9",
+        providerOptions: { magnific: { guidance_scale: 5 } },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      aspect_ratio: "widescreen_16_9",
+      guidance_scale: 5,
+    });
+  });
+
+  test("seedream-v4.5 covers safety checker", async () => {
+    const body = await _internal_buildBody(
+      "magnific/seedream-v4.5",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        aspectRatio: "21:9",
+        providerOptions: { magnific: { enable_safety_checker: false } },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      aspect_ratio: "cinematic_21_9",
+      enable_safety_checker: false,
+    });
+  });
+
+  test("seedream-v4.5/edit emits prompt + reference_images[]", async () => {
+    const body = await _internal_buildBody(
+      "magnific/seedream-v4.5/edit",
+      "image",
+      baseImageOpts({
+        prompt: "make brighter",
+        files: [
+          { type: "file", mediaType: "image/png", data: new Uint8Array([5]) },
+          { type: "file", mediaType: "image/png", data: new Uint8Array([6]) },
+        ],
+        seed: 42,
+        providerOptions: {
+          magnific: {
+            aspect_ratio: "widescreen_16_9",
+            enable_safety_checker: false,
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "make brighter",
+      reference_images: ["BQ==", "Bg=="],
+      aspect_ratio: "widescreen_16_9",
+      seed: 42,
+      enable_safety_checker: false,
+    });
+  });
+
+  test("seedream-v4.5/edit rejects empty reference set", async () => {
+    await expect(
+      _internal_buildBody(
+        "magnific/seedream-v4.5/edit",
+        "image",
+        baseImageOpts({ prompt: "x" }),
+      ),
+    ).rejects.toThrow(/at least one reference image/);
+  });
+
+  test("z-image-turbo passes through providerOptions", async () => {
+    const body = await _internal_buildBody(
+      "magnific/z-image-turbo",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        seed: 99,
+      }),
+    );
+    expect(body).toMatchObject({ prompt: "x", seed: 99 });
+  });
+
+  test("runway-image covers ratio enum", async () => {
+    const body = await _internal_buildBody(
+      "magnific/runway-image",
+      "image",
+      baseImageOpts({
+        prompt: "x",
+        aspectRatio: "1:1",
+        seed: 3,
+      }),
+    );
+    expect(body).toMatchObject({ prompt: "x", ratio: "960:960", seed: 3 });
+  });
+});
+
+describe("payload builders — video", () => {
+  const fileImg = (b: number) => ({
+    type: "file" as const,
+    mediaType: "image/png",
+    data: new Uint8Array([b]),
+  });
+  const urlVid = (u: string) => ({ type: "url" as const, url: u });
+
+  test("kling-v2.1-pro covers all duration and motion-brush fields", async () => {
+    const body = await _internal_buildBody(
+      "magnific/kling-v2.1-pro",
+      "video",
+      baseVideoOpts({
+        prompt: "motion",
+        duration: 10,
+        files: [fileImg(0)],
+        providerOptions: {
+          magnific: {
+            image_tail: "tail-b64",
+            negative_prompt: "blur",
+            cfg_scale: 0.7,
+            static_mask: "mask-b64",
+            dynamic_masks: [{ x: 0, y: 0 }],
+            webhook_url: "https://wh.example/cb",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      duration: "10",
+      image: "AA==",
+      image_tail: "tail-b64",
+      prompt: "motion",
+      negative_prompt: "blur",
+      cfg_scale: 0.7,
+      static_mask: "mask-b64",
+      dynamic_masks: [{ x: 0, y: 0 }],
+    });
+  });
+
+  test("kling-v3-pro covers multi_prompt, elements, multi_shot, generate_audio", async () => {
+    const body = await _internal_buildBody(
+      "magnific/kling-v3-pro",
+      "video",
+      baseVideoOpts({
+        prompt: "main",
+        duration: 12,
+        files: [urlVid("https://cdn.example/start.png")],
+        providerOptions: {
+          magnific: {
+            multi_prompt: [
+              { prompt: "shot 1", duration: "5" },
+              { prompt: "shot 2", duration: "7" },
+            ],
+            elements: [
+              {
+                reference_image_urls: ["https://cdn.example/r1.png"],
+                frontal_image_url: "https://cdn.example/front.png",
+              },
+            ],
+            generate_audio: true,
+            multi_shot: true,
+            shot_type: "intelligent",
+            negative_prompt: "wobble",
+            cfg_scale: 0.6,
+            end_image_url: "https://cdn.example/end.png",
+          },
+        },
+        aspectRatio: "9:16",
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "main",
+      multi_prompt: [
+        { prompt: "shot 1", duration: "5" },
+        { prompt: "shot 2", duration: "7" },
+      ],
+      start_image_url: "https://cdn.example/start.png",
+      end_image_url: "https://cdn.example/end.png",
+      elements: [
+        {
+          reference_image_urls: ["https://cdn.example/r1.png"],
+          frontal_image_url: "https://cdn.example/front.png",
+        },
+      ],
+      generate_audio: true,
+      multi_shot: true,
+      shot_type: "intelligent",
+      aspect_ratio: "9:16",
+      duration: "12",
+      negative_prompt: "wobble",
+      cfg_scale: 0.6,
+    });
+  });
+
+  test("kling-motion-control requires both image_url and video_url", async () => {
+    const body = await _internal_buildBody(
+      "magnific/kling-motion-control",
+      "video",
+      baseVideoOpts({
+        prompt: "guide",
+        files: [
+          { type: "url", url: "https://cdn.example/char.png" },
+          { type: "url", url: "https://cdn.example/ref.mp4" },
+        ],
+        providerOptions: {
+          magnific: { character_orientation: "image", cfg_scale: 0.4 },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image_url: "https://cdn.example/char.png",
+      video_url: "https://cdn.example/ref.mp4",
+      character_orientation: "image",
+      cfg_scale: 0.4,
+    });
+  });
+
+  test("kling-o1-pro covers first_frame, last_frame, duration enum", async () => {
+    const body = await _internal_buildBody(
+      "magnific/kling-o1-pro",
+      "video",
+      baseVideoOpts({
+        prompt: "x",
+        files: [fileImg(0), fileImg(1)],
+        duration: 10,
+        aspectRatio: "9:16",
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      first_frame: "AA==",
+      last_frame: "AQ==",
+      aspect_ratio: "9:16",
+      duration: 10,
+    });
+  });
+
+  test("minimax-hailuo-02 covers prompt_optimizer and frame fields", async () => {
+    const body = await _internal_buildBody(
+      "magnific/minimax-hailuo-02",
+      "video",
+      baseVideoOpts({
+        prompt: "x",
+        files: [fileImg(0), fileImg(1)],
+        providerOptions: {
+          magnific: { prompt_optimizer: false },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      prompt_optimizer: false,
+      first_frame_image: "AA==",
+      last_frame_image: "AQ==",
+      duration: 6,
+    });
+  });
+
+  test("minimax-video-01-live requires URL input and supports prompt_optimizer", async () => {
+    const body = await _internal_buildBody(
+      "magnific/minimax-video-01-live",
+      "video",
+      baseVideoOpts({
+        prompt: "[Pan right]",
+        files: [{ type: "url", url: "https://cdn.example/x.png" }],
+      }),
+    );
+    expect(body).toMatchObject({
+      image_url: "https://cdn.example/x.png",
+      prompt: "[Pan right]",
+      prompt_optimizer: true,
+    });
+  });
+
+  test("wan-2.5-t2v covers enable_prompt_expansion and seed", async () => {
+    const body = await _internal_buildBody(
+      "magnific/wan-2.5-t2v",
+      "video",
+      baseVideoOpts({
+        prompt: "scene",
+        duration: 10,
+        seed: 12345,
+        providerOptions: {
+          magnific: {
+            negative_prompt: "wobble",
+            enable_prompt_expansion: false,
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "scene",
+      duration: "10",
+      negative_prompt: "wobble",
+      enable_prompt_expansion: false,
+      seed: 12345,
+    });
+  });
+
+  test("wan-2.5-i2v requires image URL", async () => {
+    const body = await _internal_buildBody(
+      "magnific/wan-2.5-i2v",
+      "video",
+      baseVideoOpts({
+        prompt: "scene",
+        files: [{ type: "url", url: "https://cdn.example/k.png" }],
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "https://cdn.example/k.png",
+      prompt: "scene",
+      duration: "5",
+      enable_prompt_expansion: true,
+    });
+  });
+
+  test("wan-2.6 covers size enum and shot_type", async () => {
+    const body = await _internal_buildBody(
+      "magnific/wan-2.6",
+      "video",
+      baseVideoOpts({
+        prompt: "scene",
+        files: [{ type: "url", url: "https://cdn.example/k.png" }],
+        providerOptions: {
+          magnific: {
+            size: "1080*1920",
+            shot_type: "multi",
+            seed: 7,
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "https://cdn.example/k.png",
+      prompt: "scene",
+      size: "1080*1920",
+      duration: "5",
+      shot_type: "multi",
+      seed: 7,
+    });
+  });
+
+  test("runway-gen4-turbo maps aspect ratio and duration", async () => {
+    const body = await _internal_buildBody(
+      "magnific/runway-gen4-turbo",
+      "video",
+      baseVideoOpts({
+        prompt: "x",
+        aspectRatio: "9:16",
+        duration: 5,
+        files: [fileImg(0)],
+        seed: 9,
+      }),
+    );
+    expect(body).toMatchObject({
+      image: "AA==",
+      prompt: "x",
+      duration: 5,
+      ratio: "720:1280",
+      seed: 9,
+    });
+  });
+
+  test("runway-act-two covers character + reference + body_control + expression_intensity", async () => {
+    const body = await _internal_buildBody(
+      "magnific/runway-act-two",
+      "video",
+      baseVideoOpts({
+        providerOptions: {
+          magnific: {
+            character: { type: "image", uri: "https://cdn.example/c.png" },
+            reference: { type: "video", uri: "https://cdn.example/p.mp4" },
+            body_control: false,
+            expression_intensity: 5,
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      character: { type: "image", uri: "https://cdn.example/c.png" },
+      reference: { type: "video", uri: "https://cdn.example/p.mp4" },
+      body_control: false,
+      expression_intensity: 5,
+      ratio: "1280:720",
+    });
+  });
+
+  test("ltx-2-pro covers resolution, duration enum, fps, generate_audio", async () => {
+    const body = await _internal_buildBody(
+      "magnific/ltx-2-pro",
+      "video",
+      baseVideoOpts({
+        prompt: "x",
+        duration: 10,
+        fps: 50,
+        providerOptions: {
+          magnific: { resolution: "2160p", generate_audio: true },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      resolution: "2160p",
+      duration: 10,
+      fps: 50,
+      generate_audio: true,
+    });
+  });
+
+  test("seedance-pro covers camera_fixed and aspect ratio", async () => {
+    const body = await _internal_buildBody(
+      "magnific/seedance-pro",
+      "video",
+      baseVideoOpts({
+        prompt: "x",
+        aspectRatio: "21:9",
+        files: [fileImg(0)],
+        providerOptions: {
+          magnific: { camera_fixed: true, frames_per_second: 24, seed: 42 },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      prompt: "x",
+      image: "AA==",
+      aspect_ratio: "film_horizontal_21_9",
+      camera_fixed: true,
+      frames_per_second: 24,
+      seed: 42,
+    });
+  });
+
+  test("pixverse covers style, resolution, duration, negative_prompt", async () => {
+    const body = await _internal_buildBody(
+      "magnific/pixverse",
+      "video",
+      baseVideoOpts({
+        prompt: "x",
+        files: [{ type: "url", url: "https://cdn.example/x.png" }],
+        duration: 8,
+        providerOptions: {
+          magnific: {
+            resolution: "1080p",
+            negative_prompt: "wobble",
+            style: "anime",
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image_url: "https://cdn.example/x.png",
+      prompt: "x",
+      resolution: "1080p",
+      duration: 8,
+      negative_prompt: "wobble",
+      style: "anime",
+    });
+  });
+
+  test("omnihuman-v1.5 requires both image and audio URLs", async () => {
+    const body = await _internal_buildBody(
+      "magnific/omnihuman-v1.5",
+      "video",
+      baseVideoOpts({
+        prompt: "speak naturally",
+        files: [
+          { type: "url", url: "https://cdn.example/face.png" },
+          { type: "url", url: "https://cdn.example/voice.mp3" },
+        ],
+        providerOptions: {
+          magnific: { turbo_mode: true, resolution: "720p" },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      image_url: "https://cdn.example/face.png",
+      audio_url: "https://cdn.example/voice.mp3",
+      prompt: "speak naturally",
+      turbo_mode: true,
+      resolution: "720p",
+    });
+  });
+
+  test("vfx covers all 8 filter types and conditional fields", async () => {
+    const body = await _internal_buildBody(
+      "magnific/vfx",
+      "video",
+      baseVideoOpts({
+        files: [urlVid("https://cdn.example/clip.mp4")],
+        fps: 30,
+        providerOptions: {
+          magnific: {
+            filter_type: 7,
+            bloom_filter_contrast: 1.4,
+            motion_filter_kernel_size: 9,
+            motion_filter_decay_factor: 0.8,
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      video: "https://cdn.example/clip.mp4",
+      filter_type: 7,
+      fps: 30,
+      bloom_filter_contrast: 1.4,
+      motion_filter_kernel_size: 9,
+      motion_filter_decay_factor: 0.8,
+    });
+  });
+});
+
+describe("payload builders — audio", () => {
+  test("music covers prompt, music_length_seconds, webhook_url", async () => {
+    const body = await _internal_buildBody(
+      "magnific/default",
+      "music",
+      baseMusicOpts({
+        prompt: "ambient piano",
+        duration: 60,
+        providerOptions: {
+          magnific: { webhook_url: "https://wh.example/cb" },
+        },
+      }),
+    );
+    expect(body).toEqual({
+      prompt: "ambient piano",
+      music_length_seconds: 60,
+      webhook_url: "https://wh.example/cb",
+    });
+  });
+
+  test("sound-effects covers text, duration, loop, prompt_influence", async () => {
+    const body = await _internal_buildBody(
+      "magnific/sound-effects",
+      "speech",
+      baseSpeechOpts({
+        text: "deep ominous rumble",
+        providerOptions: {
+          magnific: {
+            duration_seconds: 8.5,
+            loop: true,
+            prompt_influence: 0.7,
+            webhook_url: "https://wh.example/cb",
+          },
+        },
+      }),
+    );
+    expect(body).toEqual({
+      text: "deep ominous rumble",
+      duration_seconds: 8.5,
+      loop: true,
+      prompt_influence: 0.7,
+      webhook_url: "https://wh.example/cb",
+    });
+  });
+
+  test("audio-isolation covers description, audio xor video, bbox, fps, candidates, predict_spans", async () => {
+    const body = await _internal_buildBody(
+      "magnific/audio-isolation",
+      "speech",
+      baseSpeechOpts({
+        text: "isolated voice only",
+        providerOptions: {
+          magnific: {
+            audio: "https://cdn.example/a.mp3",
+            sample_fps: 4,
+            reranking_candidates: 5,
+            predict_spans: true,
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      description: "isolated voice only",
+      audio: "https://cdn.example/a.mp3",
+      x1: 0,
+      y1: 0,
+      x2: 0,
+      y2: 0,
+      sample_fps: 4,
+      reranking_candidates: 5,
+      predict_spans: true,
+    });
+  });
+
+  test("audio-isolation rejects passing both audio and video", async () => {
+    await expect(
+      _internal_buildBody(
+        "magnific/audio-isolation",
+        "speech",
+        baseSpeechOpts({
+          text: "x",
+          providerOptions: {
+            magnific: {
+              audio: "https://cdn.example/a.mp3",
+              video: "https://cdn.example/v.mp4",
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Passthrough behavior — providerOptions.magnific keys not in builder schema
+// flow through to the body without overwriting builder-produced keys.
+// ---------------------------------------------------------------------------
+
+describe("providerOptions.magnific passthrough", () => {
+  test("unknown keys flow through to body", async () => {
+    const body = await _internal_buildBody(
+      "magnific/upscale-creative",
+      "image",
+      baseImageOpts({
+        files: [
+          { type: "file", mediaType: "image/png", data: new Uint8Array([0]) },
+        ],
+        providerOptions: {
+          magnific: {
+            scale_factor: "4x",
+            future_field: "future-value",
+            another: { nested: 42 },
+          },
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      scale_factor: "4x",
+      future_field: "future-value",
+      another: { nested: 42 },
+    });
+  });
+
+  test("apiKey is stripped from body even on passthrough", async () => {
+    const body = await _internal_buildBody(
+      "magnific/upscale-creative",
+      "image",
+      baseImageOpts({
+        files: [
+          { type: "file", mediaType: "image/png", data: new Uint8Array([0]) },
+        ],
+        providerOptions: {
+          magnific: {
+            apiKey: "secret-byok",
+            scale_factor: "4x",
+          },
+        },
+      }),
+    );
+    expect(body.apiKey).toBeUndefined();
+    expect(body.scale_factor).toBe("4x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gateway fallback (no MAGNIFIC_API_KEY, no magnificApiKey setting)
+// ---------------------------------------------------------------------------
+
+describe("gateway fallback when no magnific key is available", () => {
+  const ENV_BACKUP = process.env.MAGNIFIC_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.MAGNIFIC_API_KEY;
+  });
+  afterEach(() => {
+    if (ENV_BACKUP === undefined) delete process.env.MAGNIFIC_API_KEY;
+    else process.env.MAGNIFIC_API_KEY = ENV_BACKUP;
+  });
+
+  test("routes through varg gateway when no magnific key exists", async () => {
+    const { calls, restore } = makeFetchHarness([
+      {
+        json: {
+          job_id: "gw-1",
+          status: "completed",
+          output: {
+            url: "https://cdn.example/gw.png",
+            media_type: "image/png",
+          },
+        },
+      },
+      { bytes: new Uint8Array([5, 6, 7]) },
+    ]);
+
+    try {
+      const v = createVarg({ apiKey: "varg-key" });
+      await v.imageModel("magnific/mystic").doGenerate({
+        prompt: "gateway test",
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {},
+      });
+
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      const submit = calls[0]!;
+      expect(submit.url).toContain("/v1/image");
+      expect(submit.url).not.toContain("api.magnific.com");
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Abort signal propagation
+// ---------------------------------------------------------------------------
+
+describe("abort signal propagation", () => {
+  const ENV_BACKUP = process.env.MAGNIFIC_API_KEY;
+
+  beforeEach(() => {
+    process.env.MAGNIFIC_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    if (ENV_BACKUP === undefined) delete process.env.MAGNIFIC_API_KEY;
+    else process.env.MAGNIFIC_API_KEY = ENV_BACKUP;
+  });
+
+  test("pre-aborted signal rejects during submit", async () => {
+    const { restore } = makeFetchHarness([
+      { json: { task_id: "t-1", status: "IN_PROGRESS" } },
+    ]);
+
+    try {
+      const ac = new AbortController();
+      ac.abort();
+
+      const v = createVarg({
+        apiKey: "varg-key",
+        magnificApiKey: "test-key",
+      });
+      await expect(
+        v.imageModel("magnific/mystic").doGenerate({
+          prompt: "abort test",
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          files: undefined,
+          mask: undefined,
+          providerOptions: {},
+          headers: {},
+          abortSignal: ac.signal,
+        }),
+      ).rejects.toThrow();
+    } finally {
+      restore();
+    }
+  });
+
+  test("abort during download rejects after successful submit+poll", async () => {
+    const ac = new AbortController();
+    let downloadFetchCalled = false;
+
+    const original = globalThis.fetch;
+    let callCount = 0;
+    // biome-ignore lint/suspicious/noExplicitAny: test harness
+    (globalThis as any).fetch = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      callCount++;
+      const url = typeof input === "string" ? input : input.toString();
+      if (callCount === 1) {
+        // submit — return completed immediately so we skip polling
+        return new Response(
+          JSON.stringify({
+            task_id: "t-dl",
+            status: "COMPLETED",
+            generated: ["https://cdn.example/result.png"],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      // download — abort before resolving
+      downloadFetchCalled = true;
+      ac.abort();
+      init?.signal?.throwIfAborted();
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    };
+
+    try {
+      const v = createVarg({
+        apiKey: "varg-key",
+        magnificApiKey: "test-key",
+      });
+      await expect(
+        v.imageModel("magnific/mystic").doGenerate({
+          prompt: "abort download test",
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          files: undefined,
+          mask: undefined,
+          providerOptions: {},
+          headers: {},
+          abortSignal: ac.signal,
+        }),
+      ).rejects.toThrow();
+      expect(downloadFetchCalled).toBe(true);
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: test harness
+      (globalThis as any).fetch = original;
+    }
+  });
+});

--- a/src/ai-sdk/providers/magnific.ts
+++ b/src/ai-sdk/providers/magnific.ts
@@ -1,0 +1,2017 @@
+/**
+ * Magnific provider — internal module powering `varg.imageModel("magnific/...")`,
+ * `varg.videoModel("magnific/...")`, `varg.musicModel("magnific/default")`, and
+ * `varg.speechModel("magnific/<sound-effects|audio-isolation>")`.
+ *
+ * Two execution paths share the same model maps and payload builders:
+ *
+ *   1. BYOK direct path  — when a Magnific key is resolvable, the call goes
+ *                          straight to api.magnific.com.
+ *   2. Varg gateway path — otherwise the model id is forwarded as-is to the
+ *                          Varg gateway, which holds Magnific credentials.
+ *
+ * This file exposes the BYOK direct entry points and the routing helpers used
+ * by `src/ai-sdk/providers/varg.ts`. It is intentionally NOT re-exported from
+ * `src/ai-sdk/index.ts` — Magnific is reached only through the `varg` provider.
+ *
+ * ─── Known live-tested gotchas (per 2026-05-06 verification run) ──────────
+ *
+ *   • POST /ai/beta/remove-background uses `application/x-www-form-urlencoded`
+ *     and returns a flat `{ url, high_resolution, preview, original }` shape
+ *     instead of `{ generated: [...] }`. Both handled below
+ *     (FORM_ENCODED_PATHS, extractGenerated).
+ *
+ *   • Several Kling endpoints POST to `…-pro` but POLL under the non-`-pro`
+ *     slug. Captured in POLL_PATH_OVERRIDES.
+ *
+ *   • Magnific can return `status: "FAILED"` with NO error detail. Empirically
+ *     this means input-compatibility rejection (e.g. unsupported video codec
+ *     for VFX, oversized image, format Magnific can't decode). The thrown
+ *     MagnificAPIError surfaces the capability path + task_id so users can
+ *     retry with a different input. Specific case verified live: VFX rejects
+ *     `commondatastorage.googleapis.com/.../ForBiggerJoyrides.mp4` regardless
+ *     of `filter_type` (1 or 2 both fail) — but `download.samplelib.com/.../
+ *     sample-5s.mp4` succeeds with both filters. Not an SDK bug; document the
+ *     class of failure and suggest a different input.
+ *
+ *   • `magnific/expand` (Flux Pro outpaint) requires ≥512px source images;
+ *     smaller inputs reach FAILED with no detail. Not enforced client-side
+ *     because the docs don't list a hard minimum.
+ *
+ *   • Endpoints with un-published schemas (Z-Image, Seedream-edit) had the
+ *     wrong path in our llms.txt-derived map; verified live and corrected.
+ *     `seedream-v4.5/edit` actually requires `reference_images: string[]`,
+ *     not a singular `image` field — the builder enforces this.
+ */
+
+import {
+  type ImageModelV3CallOptions,
+  type ImageModelV3File,
+  NoSuchModelError,
+  type SpeechModelV3CallOptions,
+} from "@ai-sdk/provider";
+import type { MusicModelV3CallOptions } from "../music-model";
+import type { VideoModelV3CallOptions } from "../video-model";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const MAGNIFIC_BASE_URL = "https://api.magnific.com/v1";
+export const MAGNIFIC_PREFIX = "magnific/";
+
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const MAGNIFIC_TIMEOUT_MS = (() => {
+  const raw = process.env.MAGNIFIC_TIMEOUT_MS;
+  if (!raw) return DEFAULT_TIMEOUT_MS;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TIMEOUT_MS;
+})();
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_BACKOFF = 1.5;
+const POLL_INTERVAL_CAP_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class MagnificAPIError extends Error {
+  constructor(
+    message: string,
+    public statusCode?: number,
+    public taskId?: string,
+  ) {
+    super(message);
+    this.name = "MagnificAPIError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Static model maps — keys are user-facing leaves under `magnific/<leaf>`,
+// values are the capability path appended to MAGNIFIC_BASE_URL.
+// ---------------------------------------------------------------------------
+
+export const IMAGE_MODELS: Record<string, string> = {
+  // Unique to Magnific
+  "upscale-creative": "ai/image-upscaler",
+  "upscale-precision": "ai/image-upscaler-precision",
+  relight: "ai/image-relight",
+  "style-transfer": "ai/image-style-transfer",
+  "remove-bg": "ai/beta/remove-background", // synchronous endpoint
+  expand: "ai/image-expand/flux-pro",
+  // Magnific image-gen (Mystic flagship + others)
+  mystic: "ai/mystic",
+  "flux-2-pro": "ai/text-to-image/flux-2-pro",
+  "flux-2-turbo": "ai/text-to-image/flux-2-turbo",
+  "flux-2-klein": "ai/text-to-image/flux-2-klein",
+  "flux-pro-v1.1": "ai/text-to-image/flux-pro-v1-1",
+  "flux-dev": "ai/text-to-image/flux-dev",
+  hyperflux: "ai/text-to-image/hyperflux",
+  "seedream-4": "ai/text-to-image/seedream-v4",
+  "seedream-v4.5": "ai/text-to-image/seedream-v4-5",
+  "seedream-v4.5/edit": "ai/text-to-image/seedream-v4-5-edit",
+  "z-image-turbo": "ai/text-to-image/z-image",
+  "runway-image": "ai/text-to-image/runway",
+};
+
+export const VIDEO_MODELS: Record<string, string> = {
+  "kling-v2.1-pro": "ai/image-to-video/kling-v2-1-pro",
+  "kling-v2.5-pro": "ai/image-to-video/kling-v2-5-pro",
+  "kling-v2.6-pro": "ai/image-to-video/kling-v2-6-pro",
+  "kling-motion-control": "ai/video/kling-v3-motion-control-pro",
+  "kling-o1-pro": "ai/image-to-video/kling-o1-pro",
+  "kling-v3-pro": "ai/video/kling-v3-pro",
+  "minimax-hailuo-02": "ai/image-to-video/minimax-hailuo-02-1080p",
+  "minimax-hailuo-2.3": "ai/image-to-video/minimax-hailuo-2-3-1080p",
+  "minimax-video-01-live": "ai/image-to-video/minimax-live",
+  "wan-2.5-t2v": "ai/text-to-video/wan-2-5-t2v-1080p",
+  "wan-2.5-i2v": "ai/image-to-video/wan-2-5-i2v-1080p",
+  "wan-2.6": "ai/image-to-video/wan-v2-6-1080p",
+  "runway-gen4-turbo": "ai/image-to-video/runway-gen4-turbo",
+  "runway-act-two": "ai/video/runway-act-two",
+  "ltx-2-pro": "ai/text-to-video/ltx-2-pro",
+  "seedance-pro": "ai/image-to-video/seedance-pro-1080p",
+  pixverse: "ai/image-to-video/pixverse-v5",
+  "omnihuman-v1.5": "ai/video/omni-human-1-5",
+  vfx: "ai/video/vfx",
+};
+
+export const MUSIC_MODELS: Record<string, string> = {
+  default: "ai/music-generation",
+};
+
+export const SPEECH_MODELS: Record<string, string> = {
+  "sound-effects": "ai/sound-effects",
+  "audio-isolation": "ai/audio-isolation",
+};
+
+const SYNCHRONOUS_PATHS = new Set<string>(["ai/beta/remove-background"]);
+
+/**
+ * Endpoints that require `application/x-www-form-urlencoded` instead of JSON.
+ * `remove-background/beta` is the only one we've found.
+ */
+const FORM_ENCODED_PATHS = new Set<string>(["ai/beta/remove-background"]);
+
+/**
+ * Endpoints whose polling URL differs from the POST URL. For these, polling
+ * uses `<override>/{task_id}` instead of `<post_path>/{task_id}`. Several Kling
+ * variants polled under the non-`-pro` slug; verified live 2026-05-06.
+ */
+const POLL_PATH_OVERRIDES: Record<string, string> = {
+  "ai/image-to-video/kling-v2-1-pro": "ai/image-to-video/kling-v2-1",
+  "ai/image-to-video/kling-v2-6-pro": "ai/image-to-video/kling-v2-6",
+  "ai/image-to-video/kling-o1-pro": "ai/image-to-video/kling-o1",
+  "ai/video/kling-v3-pro": "ai/video/kling-v3",
+};
+
+// ---------------------------------------------------------------------------
+// Namespace + key resolution
+// ---------------------------------------------------------------------------
+
+/** Strip the "magnific/" prefix and return the leaf, or null if not in namespace. */
+export function parseMagnificModelId(modelId: string): string | null {
+  return modelId.startsWith(MAGNIFIC_PREFIX)
+    ? modelId.slice(MAGNIFIC_PREFIX.length)
+    : null;
+}
+
+export interface MagnificKeyResolutionInput {
+  /** VargProviderSettings — `magnificApiKey` set at `createVarg({...})` time. */
+  settings?: { magnificApiKey?: string };
+  /** Per-call `options.providerOptions.magnific` — may carry an `apiKey`. */
+  perCall?: Record<string, unknown>;
+}
+
+/**
+ * Resolve a Magnific BYOK key. Precedence (highest first):
+ *   1. perCall.apiKey               (per-`doGenerate` override)
+ *   2. settings.magnificApiKey      (per-VargProvider override)
+ *   3. process.env.MAGNIFIC_API_KEY (default)
+ *
+ * Returns null when no key is available (caller falls back to gateway).
+ */
+export function resolveMagnificKey(
+  args: MagnificKeyResolutionInput = {},
+): string | null {
+  const fromCall =
+    typeof args.perCall?.apiKey === "string" && args.perCall.apiKey.length > 0
+      ? (args.perCall.apiKey as string)
+      : null;
+  if (fromCall) return fromCall;
+
+  const fromSettings = args.settings?.magnificApiKey;
+  if (fromSettings) return fromSettings;
+
+  const fromEnv = process.env.MAGNIFIC_API_KEY;
+  if (fromEnv) return fromEnv;
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+interface MagnificTaskShape {
+  task_id?: string;
+  status?: "CREATED" | "IN_PROGRESS" | "COMPLETED" | "FAILED";
+  generated?: string[];
+  has_nsfw?: boolean[];
+  error?: string | { message?: string };
+  message?: string;
+  data?: MagnificTaskShape;
+  // Shape variant returned by some synchronous endpoints (e.g. remove-bg).
+  url?: string;
+  high_resolution?: string;
+  preview?: string;
+  original?: string;
+}
+
+/** Pull output URLs from any of the shapes Magnific returns. */
+function extractGenerated(shape: MagnificTaskShape): string[] | null {
+  if (shape.generated?.length) return shape.generated;
+  // remove-bg shape: { url, high_resolution, preview, original }
+  const urls = [shape.high_resolution, shape.url, shape.preview].filter(
+    (u): u is string => typeof u === "string" && u.length > 0,
+  );
+  return urls.length ? urls : null;
+}
+
+function getHeaders(apiKey: string): Record<string, string> {
+  return {
+    "x-magnific-api-key": apiKey,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+}
+
+function unwrap(payload: unknown): MagnificTaskShape {
+  // Magnific wraps responses in { data: { ... } } per the polling docs;
+  // some endpoints return the object directly. Handle both.
+  if (payload && typeof payload === "object") {
+    const obj = payload as MagnificTaskShape;
+    if (obj.data && typeof obj.data === "object") return obj.data;
+    return obj;
+  }
+  return {};
+}
+
+async function readError(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as {
+      message?: string;
+      error?: { message?: string };
+    } | null;
+    return (
+      body?.error?.message ??
+      body?.message ??
+      `magnific returned ${response.status}`
+    );
+  } catch {
+    return `magnific returned ${response.status}`;
+  }
+}
+
+interface SubmitResult {
+  taskId: string | null; // null when endpoint is synchronous
+  finalUrls: string[] | null; // populated when synchronous or COMPLETED on submit
+}
+
+async function submitTask(
+  apiKey: string,
+  capabilityPath: string,
+  body: Record<string, unknown>,
+  baseUrl: string,
+  signal?: AbortSignal,
+): Promise<SubmitResult> {
+  const url = `${baseUrl}/${capabilityPath}`;
+  const isForm = FORM_ENCODED_PATHS.has(capabilityPath);
+  const headers: Record<string, string> = {
+    "x-magnific-api-key": apiKey,
+    Accept: "application/json",
+    "Content-Type": isForm
+      ? "application/x-www-form-urlencoded"
+      : "application/json",
+  };
+  const reqBody = isForm
+    ? new URLSearchParams(
+        Object.fromEntries(
+          Object.entries(body).map(([k, v]) => [k, String(v)]),
+        ),
+      ).toString()
+    : JSON.stringify(body);
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: reqBody,
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new MagnificAPIError(
+      `magnific submit ${capabilityPath} failed: ${await readError(response)}`,
+      response.status,
+    );
+  }
+
+  const data = unwrap(await response.json());
+  const generated = extractGenerated(data);
+
+  // Synchronous endpoint or cache hit
+  if (
+    SYNCHRONOUS_PATHS.has(capabilityPath) ||
+    (data.status === "COMPLETED" && generated?.length)
+  ) {
+    if (!generated?.length) {
+      throw new MagnificAPIError(
+        `magnific ${capabilityPath} returned no output URLs`,
+      );
+    }
+    return { taskId: data.task_id ?? null, finalUrls: generated };
+  }
+
+  if (!data.task_id) {
+    throw new MagnificAPIError(
+      `magnific ${capabilityPath} response missing task_id`,
+    );
+  }
+  return { taskId: data.task_id, finalUrls: null };
+}
+
+async function pollTask(
+  apiKey: string,
+  capabilityPath: string,
+  taskId: string,
+  baseUrl: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const pollPath = POLL_PATH_OVERRIDES[capabilityPath] ?? capabilityPath;
+  const url = `${baseUrl}/${pollPath}/${taskId}`;
+  const startedAt = Date.now();
+  let interval = POLL_INTERVAL_MS;
+
+  while (Date.now() - startedAt < MAGNIFIC_TIMEOUT_MS) {
+    if (signal?.aborted) {
+      throw new MagnificAPIError(
+        `magnific task ${taskId} aborted`,
+        undefined,
+        taskId,
+      );
+    }
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: getHeaders(apiKey),
+      signal,
+    });
+    if (!response.ok) {
+      throw new MagnificAPIError(
+        `magnific poll ${taskId} failed: ${await readError(response)}`,
+        response.status,
+        taskId,
+      );
+    }
+
+    const data = unwrap(await response.json());
+    if (data.status === "COMPLETED") {
+      const generated = extractGenerated(data);
+      if (!generated?.length) {
+        throw new MagnificAPIError(
+          `magnific task ${taskId} completed but no output URLs`,
+          undefined,
+          taskId,
+        );
+      }
+      return generated;
+    }
+    if (data.status === "FAILED") {
+      const rawMsg =
+        typeof data.error === "string"
+          ? data.error
+          : (data.error?.message ?? "unknown");
+      // Magnific often returns FAILED with no detail when an input is
+      // incompatible (unsupported video codec, image too small for Flux Pro
+      // outpaint, etc.). Make that actionable for the caller.
+      const friendly =
+        rawMsg === "unknown"
+          ? "no error detail. Magnific commonly returns this when the input is incompatible (e.g. unsupported video codec or resolution, image too small for the endpoint, or unsupported format). Try a different input."
+          : rawMsg;
+      throw new MagnificAPIError(
+        `magnific ${capabilityPath} task ${taskId} failed: ${friendly}`,
+        undefined,
+        taskId,
+      );
+    }
+
+    await new Promise((r) => setTimeout(r, interval));
+    interval = Math.min(interval * POLL_BACKOFF, POLL_INTERVAL_CAP_MS);
+  }
+
+  throw new MagnificAPIError(
+    `magnific task ${taskId} timed out after ${MAGNIFIC_TIMEOUT_MS}ms`,
+    undefined,
+    taskId,
+  );
+}
+
+async function executeTask(
+  apiKey: string,
+  capabilityPath: string,
+  body: Record<string, unknown>,
+  options: { baseUrl?: string; signal?: AbortSignal } = {},
+): Promise<{ urls: string[] }> {
+  const baseUrl = options.baseUrl ?? MAGNIFIC_BASE_URL;
+  const submitted = await submitTask(
+    apiKey,
+    capabilityPath,
+    body,
+    baseUrl,
+    options.signal,
+  );
+  if (submitted.finalUrls) return { urls: submitted.finalUrls };
+  if (!submitted.taskId) {
+    throw new MagnificAPIError(
+      `magnific ${capabilityPath}: no task_id and no output`,
+    );
+  }
+  const urls = await pollTask(
+    apiKey,
+    capabilityPath,
+    submitted.taskId,
+    baseUrl,
+    options.signal,
+  );
+  return { urls };
+}
+
+async function downloadToBytes(
+  url: string,
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new MagnificAPIError(
+      `failed to download magnific output ${url}: ${response.status}`,
+      response.status,
+    );
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function inferMime(url: string): string {
+  try {
+    const ext = new URL(url).pathname.split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "png":
+        return "image/png";
+      case "jpg":
+      case "jpeg":
+        return "image/jpeg";
+      case "webp":
+        return "image/webp";
+      case "gif":
+        return "image/gif";
+      case "mp4":
+        return "video/mp4";
+      case "webm":
+        return "video/webm";
+      case "mov":
+        return "video/quicktime";
+      case "mp3":
+        return "audio/mpeg";
+      case "wav":
+        return "audio/wav";
+      case "ogg":
+        return "audio/ogg";
+      case "m4a":
+        return "audio/mp4";
+      default:
+        return "application/octet-stream";
+    }
+  } catch {
+    return "application/octet-stream";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File handling
+// ---------------------------------------------------------------------------
+
+interface InlineFile {
+  /** Raw base64 (no `data:` prefix). */
+  base64: string;
+  /** URL form when the input was already a URL; null when only base64 is available. */
+  url: string | null;
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  // Bun + Node both support Buffer; fall back to a manual loop for completeness.
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: btoa available in Bun runtime
+  return (globalThis as any).btoa(binary);
+}
+
+async function fetchToBase64(
+  url: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new MagnificAPIError(
+      `failed to fetch input ${url}: ${response.status}`,
+      response.status,
+    );
+  }
+  return uint8ToBase64(new Uint8Array(await response.arrayBuffer()));
+}
+
+/**
+ * Convert a V3 file part (URL or binary) into both forms for endpoints that
+ * accept either. Endpoints that strictly require a URL should read `url` and
+ * throw if null; endpoints that strictly require base64 read `base64`.
+ *
+ * For URL inputs we DO NOT pre-fetch the bytes — only resolve to base64 when
+ * the caller explicitly asks via {@link toBase64}.
+ */
+function fileToInline(
+  file: ImageModelV3File | undefined | null,
+): InlineFile | null {
+  if (!file) return null;
+  if (file.type === "url") {
+    return { base64: "", url: file.url };
+  }
+  // type === "file"
+  const data = file.data;
+  if (typeof data === "string") {
+    return { base64: data, url: null };
+  }
+  return { base64: uint8ToBase64(data), url: null };
+}
+
+/** Resolve to a base64 string regardless of input form (fetches URLs). */
+async function toBase64(
+  file: ImageModelV3File,
+  signal?: AbortSignal,
+): Promise<string> {
+  const inline = fileToInline(file);
+  if (!inline) {
+    throw new MagnificAPIError("missing input file");
+  }
+  if (inline.base64) return inline.base64;
+  if (inline.url) return fetchToBase64(inline.url, signal);
+  throw new MagnificAPIError("input file resolved to neither base64 nor URL");
+}
+
+/** Resolve to a URL regardless of input form (errors on binary inputs). */
+function toUrl(file: ImageModelV3File): string {
+  const inline = fileToInline(file);
+  if (!inline?.url) {
+    throw new MagnificAPIError(
+      "this magnific endpoint requires a URL input (publicly accessible). Pass `{ type: 'url', url: '...' }`.",
+    );
+  }
+  return inline.url;
+}
+
+/**
+ * Drop undefined entries from a body. Magnific accepts missing keys as
+ * "use default"; sending null/undefined explicitly causes some endpoints to
+ * reject the request.
+ */
+function prune(body: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Builder context
+// ---------------------------------------------------------------------------
+
+interface BuilderCtx {
+  /** Full `options.providerOptions.magnific` (apiKey already stripped). */
+  providerOpts: Record<string, unknown>;
+  signal?: AbortSignal;
+}
+
+type ImageBuilder = (
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+) => Promise<Record<string, unknown>>;
+type VideoBuilder = (
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+) => Promise<Record<string, unknown>>;
+type MusicBuilder = (
+  opts: MusicModelV3CallOptions,
+  ctx: BuilderCtx,
+) => Promise<Record<string, unknown>>;
+type SpeechBuilder = (
+  opts: SpeechModelV3CallOptions,
+  ctx: BuilderCtx,
+) => Promise<Record<string, unknown>>;
+
+function po<T>(ctx: BuilderCtx, key: string, fallback: T): T {
+  const v = ctx.providerOpts[key];
+  return v === undefined ? fallback : (v as T);
+}
+
+function poOpt<T>(ctx: BuilderCtx, key: string): T | undefined {
+  return ctx.providerOpts[key] as T | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Image builders — every property from the docs covered
+// ---------------------------------------------------------------------------
+
+async function buildUpscaleCreative(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  if (!opts.files?.[0]) {
+    throw new MagnificAPIError(
+      "magnific/upscale-creative requires an input image",
+    );
+  }
+  return prune({
+    image: await toBase64(opts.files[0]),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+    scale_factor: po(ctx, "scale_factor", "2x"),
+    optimized_for: po(ctx, "optimized_for", "standard"),
+    prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
+    creativity: po(ctx, "creativity", 0),
+    hdr: po(ctx, "hdr", 0),
+    resemblance: po(ctx, "resemblance", 0),
+    fractality: po(ctx, "fractality", 0),
+    engine: po(ctx, "engine", "automatic"),
+    filter_nsfw: po(ctx, "filter_nsfw", false),
+  });
+}
+
+async function buildUpscalePrecision(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  if (!opts.files?.[0]) {
+    throw new MagnificAPIError(
+      "magnific/upscale-precision requires an input image",
+    );
+  }
+  return prune({
+    image: await toBase64(opts.files[0]),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+    sharpen: po(ctx, "sharpen", 50),
+    smart_grain: po(ctx, "smart_grain", 7),
+    ultra_detail: po(ctx, "ultra_detail", 30),
+    filter_nsfw: po(ctx, "filter_nsfw", false),
+  });
+}
+
+async function buildRelight(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  if (!opts.files?.[0]) {
+    throw new MagnificAPIError("magnific/relight requires an input image");
+  }
+  const advUser = (ctx.providerOpts.advanced_settings ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const advanced_settings = prune({
+    whites: advUser.whites ?? 50,
+    blacks: advUser.blacks ?? 50,
+    brightness: advUser.brightness ?? 50,
+    contrast: advUser.contrast ?? 50,
+    saturation: advUser.saturation ?? 50,
+    engine: advUser.engine ?? "automatic",
+    transfer_light_a: advUser.transfer_light_a ?? "automatic",
+    transfer_light_b: advUser.transfer_light_b ?? "automatic",
+    fixed_generation: advUser.fixed_generation ?? false,
+  });
+  return prune({
+    image: await toBase64(opts.files[0]),
+    prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
+    transfer_light_from_reference_image: poOpt<string>(
+      ctx,
+      "transfer_light_from_reference_image",
+    ),
+    transfer_light_from_lightmap: poOpt<string>(
+      ctx,
+      "transfer_light_from_lightmap",
+    ),
+    light_transfer_strength: po(ctx, "light_transfer_strength", 100),
+    interpolate_from_original: po(ctx, "interpolate_from_original", false),
+    change_background: po(ctx, "change_background", true),
+    style: po(ctx, "style", "standard"),
+    preserve_details: po(ctx, "preserve_details", true),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+    advanced_settings,
+  });
+}
+
+async function buildStyleTransfer(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  if (!opts.files?.[0]) {
+    throw new MagnificAPIError(
+      "magnific/style-transfer requires an input image",
+    );
+  }
+  const referenceFromOpts = opts.files?.[1];
+  const referenceFromCtx = poOpt<string>(ctx, "reference_image");
+  const reference =
+    referenceFromCtx ??
+    (referenceFromOpts ? await toBase64(referenceFromOpts) : undefined);
+  if (!reference) {
+    throw new MagnificAPIError(
+      "magnific/style-transfer requires a reference image (pass as second file or providerOptions.magnific.reference_image)",
+    );
+  }
+  return prune({
+    image: await toBase64(opts.files[0]),
+    reference_image: reference,
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+    prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
+    style_strength: po(ctx, "style_strength", 100),
+    structure_strength: po(ctx, "structure_strength", 50),
+    is_portrait: po(ctx, "is_portrait", false),
+    portrait_style: po(ctx, "portrait_style", "standard"),
+    portrait_beautifier: poOpt<string>(ctx, "portrait_beautifier"),
+    flavor: po(ctx, "flavor", "faithful"),
+    engine: po(ctx, "engine", "balanced"),
+    fixed_generation: po(ctx, "fixed_generation", false),
+  });
+}
+
+async function buildRemoveBg(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  if (!opts.files?.[0]) {
+    throw new MagnificAPIError("magnific/remove-bg requires an input image");
+  }
+  // The remove-bg endpoint strictly requires a URL — Magnific does not accept
+  // base64 here. If the user passes a binary file, fall back to providerOpts
+  // override or throw.
+  const overrideUrl = poOpt<string>(ctx, "image_url");
+  const url = overrideUrl ?? toUrl(opts.files[0]);
+  return prune({ image_url: url });
+}
+
+async function buildExpand(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  if (!opts.files?.[0]) {
+    throw new MagnificAPIError("magnific/expand requires an input image");
+  }
+  return prune({
+    image: await toBase64(opts.files[0]),
+    prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+    left: poOpt<number>(ctx, "left"),
+    right: poOpt<number>(ctx, "right"),
+    top: poOpt<number>(ctx, "top"),
+    bottom: poOpt<number>(ctx, "bottom"),
+  });
+}
+
+async function buildMystic(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+    structure_reference: poOpt<string>(ctx, "structure_reference"),
+    structure_strength: po(ctx, "structure_strength", 50),
+    style_reference: poOpt<string>(ctx, "style_reference"),
+    adherence: po(ctx, "adherence", 50),
+    hdr: po(ctx, "hdr", 50),
+    resolution: po(ctx, "resolution", "2k"),
+    aspect_ratio: po(ctx, "aspect_ratio", "square_1_1"),
+    model: po(ctx, "model", "realism"),
+    creative_detailing: po(ctx, "creative_detailing", 33),
+    engine: po(ctx, "engine", "automatic"),
+    fixed_generation: po(ctx, "fixed_generation", false),
+    filter_nsfw: po(ctx, "filter_nsfw", true),
+    styling: poOpt<unknown>(ctx, "styling"),
+  });
+}
+
+async function buildFlux2Pro(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const inputs = opts.files ?? [];
+  const collectInput = async (i: number): Promise<string | undefined> =>
+    inputs[i] ? await toBase64(inputs[i]!) : undefined;
+
+  const sizeFromV3 = parseSize(opts.size);
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/flux-2-pro"),
+    width: po(ctx, "width", sizeFromV3?.width ?? 1024),
+    height: po(ctx, "height", sizeFromV3?.height ?? 768),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    prompt_upsampling: po(ctx, "prompt_upsampling", false),
+    input_image: poOpt<string>(ctx, "input_image") ?? (await collectInput(0)),
+    input_image_2:
+      poOpt<string>(ctx, "input_image_2") ?? (await collectInput(1)),
+    input_image_3:
+      poOpt<string>(ctx, "input_image_3") ?? (await collectInput(2)),
+    input_image_4:
+      poOpt<string>(ctx, "input_image_4") ?? (await collectInput(3)),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildFlux2Turbo(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const sizeFromV3 = parseSize(opts.size);
+  const userImageSize = poOpt<{ width?: number; height?: number }>(
+    ctx,
+    "image_size",
+  );
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/flux-2-turbo"),
+    guidance_scale: po(ctx, "guidance_scale", 2.5),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    image_size: prune({
+      width: userImageSize?.width ?? sizeFromV3?.width ?? 1024,
+      height: userImageSize?.height ?? sizeFromV3?.height ?? 1024,
+    }),
+    enable_safety_checker: po(ctx, "enable_safety_checker", true),
+    output_format: po(ctx, "output_format", "png"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildFlux2Klein(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const inputs = opts.files ?? [];
+  const collectInput = async (i: number): Promise<string | undefined> =>
+    inputs[i] ? await toBase64(inputs[i]!) : undefined;
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/flux-2-klein"),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToMagnific(opts.aspectRatio) ?? "square_1_1",
+    ),
+    resolution: po(ctx, "resolution", "1k"),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    input_image: poOpt<string>(ctx, "input_image") ?? (await collectInput(0)),
+    input_image_2:
+      poOpt<string>(ctx, "input_image_2") ?? (await collectInput(1)),
+    input_image_3:
+      poOpt<string>(ctx, "input_image_3") ?? (await collectInput(2)),
+    input_image_4:
+      poOpt<string>(ctx, "input_image_4") ?? (await collectInput(3)),
+    safety_tolerance: po(ctx, "safety_tolerance", 2),
+    output_format: poOpt<string>(ctx, "output_format"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildFluxProV11(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/flux-pro-v1.1"),
+    prompt_upsampling: po(ctx, "prompt_upsampling", false),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToMagnific(opts.aspectRatio) ?? "square_1_1",
+    ),
+    safety_tolerance: po(ctx, "safety_tolerance", 2),
+    output_format: poOpt<string>(ctx, "output_format"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildFluxDev(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToMagnific(opts.aspectRatio) ?? "square_1_1",
+    ),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    styling: poOpt<unknown>(ctx, "styling"),
+  });
+}
+
+async function buildHyperflux(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  // Same shape as flux-dev.
+  return buildFluxDev(opts, ctx);
+}
+
+async function buildSeedream4(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/seedream-4"),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToMagnific(opts.aspectRatio) ?? "square_1_1",
+    ),
+    guidance_scale: po(ctx, "guidance_scale", 2.5),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildSeedreamV45(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/seedream-v4.5"),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToMagnific(opts.aspectRatio) ?? "square_1_1",
+    ),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    enable_safety_checker: po(ctx, "enable_safety_checker", true),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildSeedreamV45Edit(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  // Schema confirmed via live probe (2026-05-06):
+  //   POST /v1/ai/text-to-image/seedream-v4-5-edit
+  //   required: prompt, reference_images (array of base64, 1–5 items)
+  //   optional: aspect_ratio, seed, enable_safety_checker, webhook_url
+  const refsFromOpts = opts.files ?? [];
+  const refsFromCtx = poOpt<string[]>(ctx, "reference_images");
+  const reference_images =
+    refsFromCtx ??
+    (await Promise.all(refsFromOpts.slice(0, 5).map((f) => toBase64(f))));
+  if (!reference_images.length) {
+    throw new MagnificAPIError(
+      "magnific/seedream-v4.5/edit requires at least one reference image (pass via files[] or providerOptions.magnific.reference_images)",
+    );
+  }
+  if (reference_images.length > 5) {
+    throw new MagnificAPIError(
+      "magnific/seedream-v4.5/edit accepts at most 5 reference images",
+    );
+  }
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/seedream-v4.5/edit"),
+    reference_images,
+    aspect_ratio:
+      poOpt<string>(ctx, "aspect_ratio") ??
+      v3AspectRatioToMagnific(opts.aspectRatio),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    enable_safety_checker: poOpt<boolean>(ctx, "enable_safety_checker"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildZImageTurbo(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  // Schema not currently published; same passthrough policy as seedream edit.
+  return prune({
+    prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    aspect_ratio:
+      poOpt<string>(ctx, "aspect_ratio") ??
+      v3AspectRatioToMagnific(opts.aspectRatio),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildRunwayImage(
+  opts: ImageModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/runway-image"),
+    ratio: po(
+      ctx,
+      "ratio",
+      v3AspectRatioToRunway(opts.aspectRatio) ?? "1024:1024",
+    ),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+const IMAGE_BUILDERS: Record<string, ImageBuilder> = {
+  "upscale-creative": buildUpscaleCreative,
+  "upscale-precision": buildUpscalePrecision,
+  relight: buildRelight,
+  "style-transfer": buildStyleTransfer,
+  "remove-bg": buildRemoveBg,
+  expand: buildExpand,
+  mystic: buildMystic,
+  "flux-2-pro": buildFlux2Pro,
+  "flux-2-turbo": buildFlux2Turbo,
+  "flux-2-klein": buildFlux2Klein,
+  "flux-pro-v1.1": buildFluxProV11,
+  "flux-dev": buildFluxDev,
+  hyperflux: buildHyperflux,
+  "seedream-4": buildSeedream4,
+  "seedream-v4.5": buildSeedreamV45,
+  "seedream-v4.5/edit": buildSeedreamV45Edit,
+  "z-image-turbo": buildZImageTurbo,
+  "runway-image": buildRunwayImage,
+};
+
+// ---------------------------------------------------------------------------
+// Video builders
+// ---------------------------------------------------------------------------
+
+async function buildKlingV21Pro(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const image = opts.files?.[0]
+    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(opts.files[0])))
+    : poOpt<string>(ctx, "image");
+  return prune({
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, ["5", "10"]),
+    ),
+    image,
+    image_tail: poOpt<string>(ctx, "image_tail"),
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    negative_prompt: poOpt<string>(ctx, "negative_prompt"),
+    cfg_scale: po(ctx, "cfg_scale", 0.5),
+    static_mask: poOpt<string>(ctx, "static_mask"),
+    dynamic_masks: poOpt<unknown[]>(ctx, "dynamic_masks"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildKlingV25Pro(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const image = opts.files?.[0]
+    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(opts.files[0])))
+    : poOpt<string>(ctx, "image");
+  return prune({
+    image,
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    negative_prompt: poOpt<string>(ctx, "negative_prompt"),
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, ["5", "10"]),
+    ),
+    cfg_scale: po(ctx, "cfg_scale", 0.5),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildKlingV26Pro(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const image = opts.files?.[0]
+    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(opts.files[0])))
+    : poOpt<string>(ctx, "image");
+  return prune({
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    image,
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, ["5", "10"]),
+    ),
+    negative_prompt: poOpt<string>(ctx, "negative_prompt"),
+    cfg_scale: po(ctx, "cfg_scale", 0.5),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToKlingV26(opts.aspectRatio) ?? "widescreen_16_9",
+    ),
+    generate_audio: poOpt<boolean>(ctx, "generate_audio"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildKlingMotionControl(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const imageFile = opts.files?.find((f) => isImageFile(f));
+  const videoFile = opts.files?.find((f) => isVideoFile(f));
+  const image_url =
+    poOpt<string>(ctx, "image_url") ??
+    (imageFile ? toUrl(imageFile) : undefined);
+  const video_url =
+    poOpt<string>(ctx, "video_url") ??
+    (videoFile ? toUrl(videoFile) : undefined);
+  if (!image_url || !video_url) {
+    throw new MagnificAPIError(
+      "magnific/kling-motion-control requires both an image (image_url) and a reference video (video_url)",
+    );
+  }
+  return prune({
+    image_url,
+    video_url,
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    character_orientation: po(ctx, "character_orientation", "video"),
+    cfg_scale: po(ctx, "cfg_scale", 0.5),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildKlingO1Pro(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const inputs = opts.files ?? [];
+  const first = inputs[0]
+    ? (poOpt<string>(ctx, "first_frame") ?? (await toBase64Or(inputs[0])))
+    : poOpt<string>(ctx, "first_frame");
+  const last = inputs[1]
+    ? (poOpt<string>(ctx, "last_frame") ?? (await toBase64Or(inputs[1])))
+    : poOpt<string>(ctx, "last_frame");
+  return prune({
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    first_frame: first,
+    last_frame: last,
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToColon(opts.aspectRatio) ?? "16:9",
+    ),
+    duration: po(ctx, "duration", durationToInt(opts.duration, 5, [5, 10])),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildKlingV3Pro(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const startInput = opts.files?.[0];
+  const start_image_url = startInput
+    ? (poOpt<string>(ctx, "start_image_url") ?? toUrl(startInput))
+    : poOpt<string>(ctx, "start_image_url");
+  return prune({
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    multi_prompt: poOpt<unknown[]>(ctx, "multi_prompt"),
+    start_image_url,
+    end_image_url: poOpt<string>(ctx, "end_image_url"),
+    elements: poOpt<unknown[]>(ctx, "elements"),
+    generate_audio: po(ctx, "generate_audio", true),
+    multi_shot: po(ctx, "multi_shot", false),
+    shot_type: po(ctx, "shot_type", "customize"),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToColon(opts.aspectRatio) ?? "16:9",
+    ),
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, [
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+      ]),
+    ),
+    negative_prompt: po(
+      ctx,
+      "negative_prompt",
+      "blur, distort, and low quality",
+    ),
+    cfg_scale: po(ctx, "cfg_scale", 0.5),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildMinimaxHailuo02(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const first = opts.files?.[0]
+    ? (poOpt<string>(ctx, "first_frame_image") ??
+      (await toBase64Or(opts.files[0])))
+    : poOpt<string>(ctx, "first_frame_image");
+  const last = opts.files?.[1]
+    ? (poOpt<string>(ctx, "last_frame_image") ??
+      (await toBase64Or(opts.files[1])))
+    : poOpt<string>(ctx, "last_frame_image");
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/minimax-hailuo-02"),
+    prompt_optimizer: po(ctx, "prompt_optimizer", true),
+    first_frame_image: first,
+    last_frame_image: last,
+    duration: po(ctx, "duration", 6),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildMinimaxHailuo23(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  // Same shape as hailuo-02.
+  return buildMinimaxHailuo02(opts, ctx);
+}
+
+async function buildMinimaxLive(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const file = opts.files?.[0];
+  const image_url =
+    poOpt<string>(ctx, "image_url") ?? (file ? toUrl(file) : undefined);
+  if (!image_url) {
+    throw new MagnificAPIError(
+      "magnific/minimax-video-01-live requires a source image URL",
+    );
+  }
+  return prune({
+    image_url,
+    prompt: requirePrompt(opts.prompt, "magnific/minimax-video-01-live"),
+    prompt_optimizer: po(ctx, "prompt_optimizer", true),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildWan25T2V(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/wan-2.5-t2v"),
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, ["5", "10"]),
+    ),
+    negative_prompt: poOpt<string>(ctx, "negative_prompt"),
+    enable_prompt_expansion: po(ctx, "enable_prompt_expansion", true),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildWan25I2V(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const file = opts.files?.[0];
+  const image = poOpt<string>(ctx, "image") ?? (file ? toUrl(file) : undefined);
+  if (!image) {
+    throw new MagnificAPIError(
+      "magnific/wan-2.5-i2v requires a keyframe image URL",
+    );
+  }
+  return prune({
+    image,
+    prompt: requirePrompt(opts.prompt, "magnific/wan-2.5-i2v"),
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, ["5", "10"]),
+    ),
+    negative_prompt: poOpt<string>(ctx, "negative_prompt"),
+    enable_prompt_expansion: po(ctx, "enable_prompt_expansion", true),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildWan26(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const file = opts.files?.[0];
+  const image = poOpt<string>(ctx, "image") ?? (file ? toUrl(file) : undefined);
+  if (!image) {
+    throw new MagnificAPIError(
+      "magnific/wan-2.6 requires a keyframe image URL",
+    );
+  }
+  return prune({
+    image,
+    prompt: requirePrompt(opts.prompt, "magnific/wan-2.6"),
+    size: po(ctx, "size", "1920*1080"),
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, ["5", "10", "15"]),
+    ),
+    negative_prompt: poOpt<string>(ctx, "negative_prompt"),
+    enable_prompt_expansion: po(ctx, "enable_prompt_expansion", false),
+    shot_type: po(ctx, "shot_type", "single"),
+    seed: opts.seed ?? po(ctx, "seed", -1),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildRunwayGen4Turbo(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const file = opts.files?.[0];
+  const image = file
+    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(file)))
+    : poOpt<string>(ctx, "image");
+  if (!image) {
+    throw new MagnificAPIError(
+      "magnific/runway-gen4-turbo requires a reference image",
+    );
+  }
+  return prune({
+    image,
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    duration: po(ctx, "duration", durationToInt(opts.duration, 10, [5, 10])),
+    ratio: po(
+      ctx,
+      "ratio",
+      v3AspectRatioToRunway(opts.aspectRatio) ?? "1280:720",
+    ),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildRunwayActTwo(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const character = poOpt<{ type: string; uri: string }>(ctx, "character");
+  const reference = poOpt<{ type: "video"; uri: string }>(ctx, "reference");
+  // Fallback: derive from files when the user passes them positionally.
+  const charFile = opts.files?.[0];
+  const refFile = opts.files?.[1];
+  const characterFinal =
+    character ??
+    (charFile
+      ? {
+          type: isVideoFile(charFile) ? "video" : "image",
+          uri: toUrl(charFile),
+        }
+      : undefined);
+  const referenceFinal =
+    reference ?? (refFile ? { type: "video", uri: toUrl(refFile) } : undefined);
+  if (!characterFinal || !referenceFinal) {
+    throw new MagnificAPIError(
+      "magnific/runway-act-two requires both `character` and `reference` (pass via providerOptions or as files[0]=character, files[1]=reference video)",
+    );
+  }
+  return prune({
+    character: characterFinal,
+    reference: referenceFinal,
+    body_control: po(ctx, "body_control", true),
+    expression_intensity: po(ctx, "expression_intensity", 3),
+    ratio: po(
+      ctx,
+      "ratio",
+      v3AspectRatioToRunway(opts.aspectRatio) ?? "1280:720",
+    ),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildLtx2Pro(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/ltx-2-pro"),
+    resolution: po(ctx, "resolution", "1080p"),
+    duration: po(ctx, "duration", durationToInt(opts.duration, 6, [6, 8, 10])),
+    fps: po(ctx, "fps", opts.fps ?? 25),
+    generate_audio: po(ctx, "generate_audio", false),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildSeedancePro(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const file = opts.files?.[0];
+  const image = file
+    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(file)))
+    : poOpt<string>(ctx, "image");
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/seedance-pro"),
+    image,
+    duration: po(
+      ctx,
+      "duration",
+      durationToString(opts.duration, 5, ["5", "10"]),
+    ),
+    camera_fixed: po(ctx, "camera_fixed", false),
+    aspect_ratio: po(
+      ctx,
+      "aspect_ratio",
+      v3AspectRatioToMagnificVideo(opts.aspectRatio) ?? "widescreen_16_9",
+    ),
+    frames_per_second: po(ctx, "frames_per_second", opts.fps ?? 24),
+    seed: opts.seed ?? po(ctx, "seed", -1),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildPixverse(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const file = opts.files?.[0];
+  const image_url =
+    poOpt<string>(ctx, "image_url") ?? (file ? toUrl(file) : undefined);
+  if (!image_url) {
+    throw new MagnificAPIError("magnific/pixverse requires a source image URL");
+  }
+  return prune({
+    image_url,
+    prompt: requirePrompt(opts.prompt, "magnific/pixverse"),
+    resolution: poOpt<string>(ctx, "resolution"),
+    duration: po(ctx, "duration", durationToInt(opts.duration, 5, [5, 8])),
+    negative_prompt: po(ctx, "negative_prompt", ""),
+    style: poOpt<string>(ctx, "style"),
+    seed: opts.seed ?? poOpt<number>(ctx, "seed"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildOmnihuman15(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const imageFile = opts.files?.find(isImageFile);
+  const audioFile = opts.files?.find(isAudioFile);
+  const image_url =
+    poOpt<string>(ctx, "image_url") ??
+    (imageFile ? toUrl(imageFile) : undefined);
+  const audio_url =
+    poOpt<string>(ctx, "audio_url") ??
+    (audioFile ? toUrl(audioFile) : undefined);
+  if (!image_url || !audio_url) {
+    throw new MagnificAPIError(
+      "magnific/omnihuman-v1.5 requires both an image URL and an audio URL",
+    );
+  }
+  return prune({
+    image_url,
+    audio_url,
+    prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
+    turbo_mode: po(ctx, "turbo_mode", false),
+    resolution: po(ctx, "resolution", "1080p"),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+/**
+ * VFX — apply 1 of 8 video filters.
+ *
+ * Heads-up: Magnific's VFX pipeline silently rejects some valid-looking MP4s
+ * with `status: FAILED` and no error detail (verified live with Google's
+ * `commondatastorage.googleapis.com/.../ForBiggerJoyrides.mp4` — fails with
+ * both filter_type=1 and 2). Other public MP4s (e.g.
+ * `download.samplelib.com/mp4/sample-5s.mp4`) work fine. If a VFX task fails
+ * with no detail, it is almost always the source video, not the filter — try
+ * a different MP4 / re-encode.
+ */
+async function buildVfx(
+  opts: VideoModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const file = opts.files?.[0];
+  const video = poOpt<string>(ctx, "video") ?? (file ? toUrl(file) : undefined);
+  if (!video) {
+    throw new MagnificAPIError("magnific/vfx requires a source video URL");
+  }
+  return prune({
+    video,
+    filter_type: po(ctx, "filter_type", 1),
+    fps: po(ctx, "fps", opts.fps ?? 24),
+    bloom_filter_contrast: poOpt<number>(ctx, "bloom_filter_contrast"),
+    motion_filter_kernel_size: poOpt<number>(ctx, "motion_filter_kernel_size"),
+    motion_filter_decay_factor: poOpt<number>(
+      ctx,
+      "motion_filter_decay_factor",
+    ),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+const VIDEO_BUILDERS: Record<string, VideoBuilder> = {
+  "kling-v2.1-pro": buildKlingV21Pro,
+  "kling-v2.5-pro": buildKlingV25Pro,
+  "kling-v2.6-pro": buildKlingV26Pro,
+  "kling-motion-control": buildKlingMotionControl,
+  "kling-o1-pro": buildKlingO1Pro,
+  "kling-v3-pro": buildKlingV3Pro,
+  "minimax-hailuo-02": buildMinimaxHailuo02,
+  "minimax-hailuo-2.3": buildMinimaxHailuo23,
+  "minimax-video-01-live": buildMinimaxLive,
+  "wan-2.5-t2v": buildWan25T2V,
+  "wan-2.5-i2v": buildWan25I2V,
+  "wan-2.6": buildWan26,
+  "runway-gen4-turbo": buildRunwayGen4Turbo,
+  "runway-act-two": buildRunwayActTwo,
+  "ltx-2-pro": buildLtx2Pro,
+  "seedance-pro": buildSeedancePro,
+  pixverse: buildPixverse,
+  "omnihuman-v1.5": buildOmnihuman15,
+  vfx: buildVfx,
+};
+
+// ---------------------------------------------------------------------------
+// Music + Speech builders
+// ---------------------------------------------------------------------------
+
+async function buildMusic(
+  opts: MusicModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const length =
+    poOpt<number>(ctx, "music_length_seconds") ?? opts.duration ?? 30;
+  return prune({
+    prompt: requirePrompt(opts.prompt, "magnific/music"),
+    music_length_seconds: length,
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+const MUSIC_BUILDERS: Record<string, MusicBuilder> = {
+  default: buildMusic,
+};
+
+async function buildSoundEffects(
+  opts: SpeechModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const text = opts.text ?? poOpt<string>(ctx, "text");
+  if (!text) {
+    throw new MagnificAPIError(
+      "magnific/sound-effects requires `text` (the effect description)",
+    );
+  }
+  const duration = poOpt<number>(ctx, "duration_seconds");
+  if (duration === undefined) {
+    throw new MagnificAPIError(
+      "magnific/sound-effects requires `providerOptions.magnific.duration_seconds` (0.5–22)",
+    );
+  }
+  return prune({
+    text,
+    duration_seconds: duration,
+    loop: po(ctx, "loop", false),
+    prompt_influence: po(ctx, "prompt_influence", 0.3),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+async function buildAudioIsolation(
+  opts: SpeechModelV3CallOptions,
+  ctx: BuilderCtx,
+): Promise<Record<string, unknown>> {
+  const description = poOpt<string>(ctx, "description") ?? opts.text;
+  if (!description) {
+    throw new MagnificAPIError(
+      "magnific/audio-isolation requires a `description` (in providerOptions.magnific or as the speech model `text`)",
+    );
+  }
+  const audio = poOpt<string>(ctx, "audio");
+  const video = poOpt<string>(ctx, "video");
+  if (!audio && !video) {
+    throw new MagnificAPIError(
+      "magnific/audio-isolation requires either `audio` or `video` (URL or base64)",
+    );
+  }
+  if (audio && video) {
+    throw new MagnificAPIError(
+      "magnific/audio-isolation rejects both `audio` and `video` — provide exactly one",
+    );
+  }
+  return prune({
+    description,
+    audio,
+    video,
+    x1: po(ctx, "x1", 0),
+    y1: po(ctx, "y1", 0),
+    x2: po(ctx, "x2", 0),
+    y2: po(ctx, "y2", 0),
+    sample_fps: po(ctx, "sample_fps", 2),
+    reranking_candidates: po(ctx, "reranking_candidates", 1),
+    predict_spans: po(ctx, "predict_spans", false),
+    webhook_url: poOpt<string>(ctx, "webhook_url"),
+  });
+}
+
+const SPEECH_BUILDERS: Record<string, SpeechBuilder> = {
+  "sound-effects": buildSoundEffects,
+  "audio-isolation": buildAudioIsolation,
+};
+
+// ---------------------------------------------------------------------------
+// Per-modality direct entry points (called from VargXxxModel under BYOK)
+// ---------------------------------------------------------------------------
+
+interface DirectCallOptions {
+  baseUrl?: string;
+  signal?: AbortSignal;
+}
+
+interface DirectResult {
+  data: Uint8Array;
+  mediaType: string;
+  url: string;
+}
+
+function extractMagnificProviderOpts(
+  providerOptions:
+    | Record<string, Record<string, unknown> | undefined>
+    | undefined,
+): Record<string, unknown> {
+  // providerOptions is keyed by provider name; pull the magnific bucket if present.
+  const bucket = (providerOptions?.magnific ?? {}) as Record<string, unknown>;
+  // Strip apiKey before sending — never forward credentials in the body.
+  const { apiKey: _apiKey, ...rest } = bucket;
+  void _apiKey;
+  return rest;
+}
+
+function assembleBody(
+  explicit: Record<string, unknown>,
+  providerOpts: Record<string, unknown>,
+): Record<string, unknown> {
+  // Passthrough first, explicit second — the builder's keys win for fields it
+  // produced; unknown-to-builder keys flow through unchanged.
+  return prune({ ...providerOpts, ...explicit });
+}
+
+export async function magnificDirectImage(
+  leaf: string,
+  apiKey: string,
+  opts: ImageModelV3CallOptions,
+  options: DirectCallOptions = {},
+): Promise<DirectResult> {
+  const path = IMAGE_MODELS[leaf];
+  const builder = IMAGE_BUILDERS[leaf];
+  if (!path || !builder) {
+    throw new NoSuchModelError({
+      modelId: `${MAGNIFIC_PREFIX}${leaf}`,
+      modelType: "imageModel",
+    });
+  }
+  const providerOpts = extractMagnificProviderOpts(opts.providerOptions);
+  const explicit = await builder(opts, {
+    providerOpts,
+    signal: options.signal,
+  });
+  const body = assembleBody(explicit, providerOpts);
+  const { urls } = await executeTask(apiKey, path, body, options);
+  const url = urls[0]!;
+  return {
+    data: await downloadToBytes(url, options.signal),
+    mediaType: inferMime(url),
+    url,
+  };
+}
+
+export async function magnificDirectVideo(
+  leaf: string,
+  apiKey: string,
+  opts: VideoModelV3CallOptions,
+  options: DirectCallOptions = {},
+): Promise<DirectResult> {
+  const path = VIDEO_MODELS[leaf];
+  const builder = VIDEO_BUILDERS[leaf];
+  if (!path || !builder) {
+    throw new NoSuchModelError({
+      modelId: `${MAGNIFIC_PREFIX}${leaf}`,
+      modelType: "videoModel" as never,
+    });
+  }
+  const providerOpts = extractMagnificProviderOpts(opts.providerOptions);
+  const explicit = await builder(opts, {
+    providerOpts,
+    signal: options.signal,
+  });
+  const body = assembleBody(explicit, providerOpts);
+  const { urls } = await executeTask(apiKey, path, body, options);
+  const url = urls[0]!;
+  return {
+    data: await downloadToBytes(url, options.signal),
+    mediaType: inferMime(url),
+    url,
+  };
+}
+
+export async function magnificDirectMusic(
+  leaf: string,
+  apiKey: string,
+  opts: MusicModelV3CallOptions,
+  options: DirectCallOptions = {},
+): Promise<DirectResult> {
+  const path = MUSIC_MODELS[leaf];
+  const builder = MUSIC_BUILDERS[leaf];
+  if (!path || !builder) {
+    throw new NoSuchModelError({
+      modelId: `${MAGNIFIC_PREFIX}${leaf}`,
+      modelType: "musicModel" as never,
+    });
+  }
+  const providerOpts = extractMagnificProviderOpts(opts.providerOptions);
+  const explicit = await builder(opts, {
+    providerOpts,
+    signal: options.signal,
+  });
+  const body = assembleBody(explicit, providerOpts);
+  const { urls } = await executeTask(apiKey, path, body, options);
+  const url = urls[0]!;
+  return {
+    data: await downloadToBytes(url, options.signal),
+    mediaType: inferMime(url),
+    url,
+  };
+}
+
+export async function magnificDirectSpeech(
+  leaf: string,
+  apiKey: string,
+  opts: SpeechModelV3CallOptions,
+  options: DirectCallOptions = {},
+): Promise<DirectResult> {
+  const path = SPEECH_MODELS[leaf];
+  const builder = SPEECH_BUILDERS[leaf];
+  if (!path || !builder) {
+    throw new NoSuchModelError({
+      modelId: `${MAGNIFIC_PREFIX}${leaf}`,
+      modelType: "speechModel",
+    });
+  }
+  const providerOpts = extractMagnificProviderOpts(opts.providerOptions);
+  const explicit = await builder(opts, {
+    providerOpts,
+    signal: options.signal,
+  });
+  const body = assembleBody(explicit, providerOpts);
+  const { urls } = await executeTask(apiKey, path, body, options);
+  const url = urls[0]!;
+  return {
+    data: await downloadToBytes(url, options.signal),
+    mediaType: inferMime(url),
+    url,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Build helpers (size, aspect ratio, mime detection, duration)
+// ---------------------------------------------------------------------------
+
+function parseSize(
+  size: ImageModelV3CallOptions["size"],
+): { width: number; height: number } | null {
+  if (!size) return null;
+  const [w, h] = size.split("x");
+  const width = Number.parseInt(w ?? "", 10);
+  const height = Number.parseInt(h ?? "", 10);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return null;
+  return { width, height };
+}
+
+function v3AspectRatioToMagnific(
+  ratio: ImageModelV3CallOptions["aspectRatio"],
+): string | null {
+  if (!ratio) return null;
+  const map: Record<string, string> = {
+    "1:1": "square_1_1",
+    "16:9": "widescreen_16_9",
+    "9:16": "social_story_9_16",
+    "2:3": "portrait_2_3",
+    "3:4": "traditional_3_4",
+    "1:2": "vertical_1_2",
+    "2:1": "horizontal_2_1",
+    "4:5": "social_post_4_5",
+    "3:2": "standard_3_2",
+    "4:3": "classic_4_3",
+    "21:9": "cinematic_21_9",
+  };
+  return map[ratio] ?? null;
+}
+
+function v3AspectRatioToMagnificVideo(
+  ratio: VideoModelV3CallOptions["aspectRatio"],
+): string | null {
+  if (!ratio) return null;
+  const map: Record<string, string> = {
+    "21:9": "film_horizontal_21_9",
+    "16:9": "widescreen_16_9",
+    "4:3": "classic_4_3",
+    "1:1": "square_1_1",
+    "3:4": "traditional_3_4",
+    "9:16": "social_story_9_16",
+    "9:21": "film_vertical_9_21",
+  };
+  return map[ratio] ?? null;
+}
+
+function v3AspectRatioToColon(
+  ratio: VideoModelV3CallOptions["aspectRatio"],
+): string | null {
+  if (!ratio) return null;
+  if (["16:9", "9:16", "1:1"].includes(ratio)) return ratio;
+  return null;
+}
+
+function v3AspectRatioToKlingV26(
+  ratio: VideoModelV3CallOptions["aspectRatio"],
+): string | null {
+  if (!ratio) return null;
+  const map: Record<string, string> = {
+    "16:9": "widescreen_16_9",
+    "9:16": "social_story_9_16",
+    "1:1": "square_1_1",
+  };
+  return map[ratio] ?? null;
+}
+
+function v3AspectRatioToRunway(
+  ratio: VideoModelV3CallOptions["aspectRatio"],
+): string | null {
+  if (!ratio) return null;
+  const map: Record<string, string> = {
+    "16:9": "1280:720",
+    "9:16": "720:1280",
+    "1:1": "960:960",
+    "4:3": "1440:1080",
+    "3:4": "1080:1440",
+  };
+  return map[ratio] ?? null;
+}
+
+function durationToString(
+  v: number | undefined,
+  fallback: number,
+  allowed: string[],
+): string {
+  const target = v ?? fallback;
+  const targetStr = String(Math.round(target));
+  return allowed.includes(targetStr)
+    ? targetStr
+    : (allowed[0] ?? String(fallback));
+}
+
+function durationToInt(
+  v: number | undefined,
+  fallback: number,
+  allowed: number[],
+): number {
+  const target = v ?? fallback;
+  return allowed.reduce((prev, curr) =>
+    Math.abs(curr - target) < Math.abs(prev - target) ? curr : prev,
+  );
+}
+
+function requirePrompt(prompt: string | undefined, modelId: string): string {
+  if (!prompt) {
+    throw new MagnificAPIError(`${modelId} requires a non-empty prompt`);
+  }
+  return prompt;
+}
+
+function isImageFile(file: ImageModelV3File): boolean {
+  if (file.type === "url") {
+    const url = file.url.toLowerCase();
+    return /\.(jpg|jpeg|png|webp|gif)(\?|$)/.test(url);
+  }
+  return file.mediaType.startsWith("image/");
+}
+
+function isVideoFile(file: ImageModelV3File): boolean {
+  if (file.type === "url") {
+    const url = file.url.toLowerCase();
+    return /\.(mp4|mov|webm|m4v|avi)(\?|$)/.test(url);
+  }
+  return file.mediaType.startsWith("video/");
+}
+
+function isAudioFile(file: ImageModelV3File): boolean {
+  if (file.type === "url") {
+    const url = file.url.toLowerCase();
+    return /\.(mp3|wav|ogg|m4a|aac|flac)(\?|$)/.test(url);
+  }
+  return file.mediaType.startsWith("audio/");
+}
+
+/**
+ * Resolve a file to base64, or return its URL when the endpoint accepts both.
+ * Used by builders whose docs say "URL or base64".
+ */
+async function toBase64Or(
+  file: ImageModelV3File,
+  signal?: AbortSignal,
+): Promise<string> {
+  if (file.type === "url") return file.url;
+  return toBase64(file, signal);
+}
+
+// ---------------------------------------------------------------------------
+// Public introspection helpers
+// ---------------------------------------------------------------------------
+
+export function listMagnificModels(): {
+  image: string[];
+  video: string[];
+  music: string[];
+  speech: string[];
+} {
+  const wrap = (m: Record<string, string>) =>
+    Object.keys(m).map((k) => `${MAGNIFIC_PREFIX}${k}`);
+  return {
+    image: wrap(IMAGE_MODELS),
+    video: wrap(VIDEO_MODELS),
+    music: wrap(MUSIC_MODELS),
+    speech: wrap(SPEECH_MODELS),
+  };
+}
+
+/** Test-only: introspect the builder for a given namespaced id. */
+export function _internal_buildBody(
+  modelId: string,
+  modality: "image" | "video" | "music" | "speech",
+  // biome-ignore lint/suspicious/noExplicitAny: test introspection
+  opts: any,
+): Promise<Record<string, unknown>> {
+  const leaf = parseMagnificModelId(modelId);
+  if (!leaf) throw new Error(`not a magnific model: ${modelId}`);
+  const providerOpts = extractMagnificProviderOpts(opts.providerOptions);
+  const ctx: BuilderCtx = { providerOpts };
+  switch (modality) {
+    case "image": {
+      const b = IMAGE_BUILDERS[leaf];
+      if (!b) throw new Error(`unknown magnific image leaf: ${leaf}`);
+      return b(opts, ctx).then((x) => assembleBody(x, providerOpts));
+    }
+    case "video": {
+      const b = VIDEO_BUILDERS[leaf];
+      if (!b) throw new Error(`unknown magnific video leaf: ${leaf}`);
+      return b(opts, ctx).then((x) => assembleBody(x, providerOpts));
+    }
+    case "music": {
+      const b = MUSIC_BUILDERS[leaf];
+      if (!b) throw new Error(`unknown magnific music leaf: ${leaf}`);
+      return b(opts, ctx).then((x) => assembleBody(x, providerOpts));
+    }
+    case "speech": {
+      const b = SPEECH_BUILDERS[leaf];
+      if (!b) throw new Error(`unknown magnific speech leaf: ${leaf}`);
+      return b(opts, ctx).then((x) => assembleBody(x, providerOpts));
+    }
+  }
+}

--- a/src/ai-sdk/providers/magnific.ts
+++ b/src/ai-sdk/providers/magnific.ts
@@ -644,7 +644,7 @@ async function buildUpscaleCreative(
     );
   }
   return prune({
-    image: await toBase64(opts.files[0]),
+    image: await toBase64(opts.files[0], ctx.signal),
     webhook_url: poOpt<string>(ctx, "webhook_url"),
     scale_factor: po(ctx, "scale_factor", "2x"),
     optimized_for: po(ctx, "optimized_for", "standard"),
@@ -668,7 +668,7 @@ async function buildUpscalePrecision(
     );
   }
   return prune({
-    image: await toBase64(opts.files[0]),
+    image: await toBase64(opts.files[0], ctx.signal),
     webhook_url: poOpt<string>(ctx, "webhook_url"),
     sharpen: po(ctx, "sharpen", 50),
     smart_grain: po(ctx, "smart_grain", 7),
@@ -700,7 +700,7 @@ async function buildRelight(
     fixed_generation: advUser.fixed_generation ?? false,
   });
   return prune({
-    image: await toBase64(opts.files[0]),
+    image: await toBase64(opts.files[0], ctx.signal),
     prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
     transfer_light_from_reference_image: poOpt<string>(
       ctx,
@@ -733,14 +733,16 @@ async function buildStyleTransfer(
   const referenceFromCtx = poOpt<string>(ctx, "reference_image");
   const reference =
     referenceFromCtx ??
-    (referenceFromOpts ? await toBase64(referenceFromOpts) : undefined);
+    (referenceFromOpts
+      ? await toBase64(referenceFromOpts, ctx.signal)
+      : undefined);
   if (!reference) {
     throw new MagnificAPIError(
       "magnific/style-transfer requires a reference image (pass as second file or providerOptions.magnific.reference_image)",
     );
   }
   return prune({
-    image: await toBase64(opts.files[0]),
+    image: await toBase64(opts.files[0], ctx.signal),
     reference_image: reference,
     webhook_url: poOpt<string>(ctx, "webhook_url"),
     prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
@@ -778,7 +780,7 @@ async function buildExpand(
     throw new MagnificAPIError("magnific/expand requires an input image");
   }
   return prune({
-    image: await toBase64(opts.files[0]),
+    image: await toBase64(opts.files[0], ctx.signal),
     prompt: opts.prompt ?? poOpt<string>(ctx, "prompt"),
     webhook_url: poOpt<string>(ctx, "webhook_url"),
     left: poOpt<number>(ctx, "left"),
@@ -817,7 +819,7 @@ async function buildFlux2Pro(
 ): Promise<Record<string, unknown>> {
   const inputs = opts.files ?? [];
   const collectInput = async (i: number): Promise<string | undefined> =>
-    inputs[i] ? await toBase64(inputs[i]!) : undefined;
+    inputs[i] ? await toBase64(inputs[i]!, ctx.signal) : undefined;
 
   const sizeFromV3 = parseSize(opts.size);
   return prune({
@@ -866,7 +868,7 @@ async function buildFlux2Klein(
 ): Promise<Record<string, unknown>> {
   const inputs = opts.files ?? [];
   const collectInput = async (i: number): Promise<string | undefined> =>
-    inputs[i] ? await toBase64(inputs[i]!) : undefined;
+    inputs[i] ? await toBase64(inputs[i]!, ctx.signal) : undefined;
   return prune({
     prompt: requirePrompt(opts.prompt, "magnific/flux-2-klein"),
     aspect_ratio: po(
@@ -977,9 +979,14 @@ async function buildSeedreamV45Edit(
   //   optional: aspect_ratio, seed, enable_safety_checker, webhook_url
   const refsFromOpts = opts.files ?? [];
   const refsFromCtx = poOpt<string[]>(ctx, "reference_images");
+  if (!refsFromCtx && refsFromOpts.length > 5) {
+    throw new MagnificAPIError(
+      "magnific/seedream-v4.5/edit accepts at most 5 reference images",
+    );
+  }
   const reference_images =
     refsFromCtx ??
-    (await Promise.all(refsFromOpts.slice(0, 5).map((f) => toBase64(f))));
+    (await Promise.all(refsFromOpts.map((f) => toBase64(f, ctx.signal))));
   if (!reference_images.length) {
     throw new MagnificAPIError(
       "magnific/seedream-v4.5/edit requires at least one reference image (pass via files[] or providerOptions.magnific.reference_images)",
@@ -1063,7 +1070,8 @@ async function buildKlingV21Pro(
   ctx: BuilderCtx,
 ): Promise<Record<string, unknown>> {
   const image = opts.files?.[0]
-    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(opts.files[0])))
+    ? (poOpt<string>(ctx, "image") ??
+      (await toBase64Or(opts.files[0], ctx.signal)))
     : poOpt<string>(ctx, "image");
   return prune({
     duration: po(
@@ -1087,7 +1095,8 @@ async function buildKlingV25Pro(
   ctx: BuilderCtx,
 ): Promise<Record<string, unknown>> {
   const image = opts.files?.[0]
-    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(opts.files[0])))
+    ? (poOpt<string>(ctx, "image") ??
+      (await toBase64Or(opts.files[0], ctx.signal)))
     : poOpt<string>(ctx, "image");
   return prune({
     image,
@@ -1108,7 +1117,8 @@ async function buildKlingV26Pro(
   ctx: BuilderCtx,
 ): Promise<Record<string, unknown>> {
   const image = opts.files?.[0]
-    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(opts.files[0])))
+    ? (poOpt<string>(ctx, "image") ??
+      (await toBase64Or(opts.files[0], ctx.signal)))
     : poOpt<string>(ctx, "image");
   return prune({
     prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
@@ -1163,10 +1173,12 @@ async function buildKlingO1Pro(
 ): Promise<Record<string, unknown>> {
   const inputs = opts.files ?? [];
   const first = inputs[0]
-    ? (poOpt<string>(ctx, "first_frame") ?? (await toBase64Or(inputs[0])))
+    ? (poOpt<string>(ctx, "first_frame") ??
+      (await toBase64Or(inputs[0], ctx.signal)))
     : poOpt<string>(ctx, "first_frame");
   const last = inputs[1]
-    ? (poOpt<string>(ctx, "last_frame") ?? (await toBase64Or(inputs[1])))
+    ? (poOpt<string>(ctx, "last_frame") ??
+      (await toBase64Or(inputs[1], ctx.signal)))
     : poOpt<string>(ctx, "last_frame");
   return prune({
     prompt: opts.prompt || poOpt<string>(ctx, "prompt"),
@@ -1239,11 +1251,11 @@ async function buildMinimaxHailuo02(
 ): Promise<Record<string, unknown>> {
   const first = opts.files?.[0]
     ? (poOpt<string>(ctx, "first_frame_image") ??
-      (await toBase64Or(opts.files[0])))
+      (await toBase64Or(opts.files[0], ctx.signal)))
     : poOpt<string>(ctx, "first_frame_image");
   const last = opts.files?.[1]
     ? (poOpt<string>(ctx, "last_frame_image") ??
-      (await toBase64Or(opts.files[1])))
+      (await toBase64Or(opts.files[1], ctx.signal)))
     : poOpt<string>(ctx, "last_frame_image");
   return prune({
     prompt: requirePrompt(opts.prompt, "magnific/minimax-hailuo-02"),
@@ -1361,7 +1373,7 @@ async function buildRunwayGen4Turbo(
 ): Promise<Record<string, unknown>> {
   const file = opts.files?.[0];
   const image = file
-    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(file)))
+    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(file, ctx.signal)))
     : poOpt<string>(ctx, "image");
   if (!image) {
     throw new MagnificAPIError(
@@ -1442,7 +1454,7 @@ async function buildSeedancePro(
 ): Promise<Record<string, unknown>> {
   const file = opts.files?.[0];
   const image = file
-    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(file)))
+    ? (poOpt<string>(ctx, "image") ?? (await toBase64Or(file, ctx.signal)))
     : poOpt<string>(ctx, "image");
   return prune({
     prompt: requirePrompt(opts.prompt, "magnific/seedance-pro"),

--- a/src/ai-sdk/providers/varg.ts
+++ b/src/ai-sdk/providers/varg.ts
@@ -11,6 +11,14 @@ import {
 } from "@ai-sdk/provider";
 import type { MusicModelV3, MusicModelV3CallOptions } from "../music-model";
 import type { VideoModelV3, VideoModelV3CallOptions } from "../video-model";
+import {
+  magnificDirectImage,
+  magnificDirectMusic,
+  magnificDirectSpeech,
+  magnificDirectVideo,
+  parseMagnificModelId,
+  resolveMagnificKey,
+} from "./magnific";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -19,6 +27,20 @@ import type { VideoModelV3, VideoModelV3CallOptions } from "../video-model";
 export interface VargProviderSettings {
   apiKey?: string;
   baseUrl?: string;
+  /**
+   * BYOK Magnific API key. When set, calls to `varg.imageModel("magnific/...")`,
+   * `videoModel`, `musicModel`, and `speechModel` go directly to api.magnific.com
+   * with this key instead of being forwarded to the Varg gateway.
+   *
+   * Precedence (highest first):
+   *   1. `options.providerOptions.magnific.apiKey` on the call
+   *   2. this `magnificApiKey`
+   *   3. `process.env.MAGNIFIC_API_KEY`
+   *   4. (none) → call goes to Varg gateway
+   */
+  magnificApiKey?: string;
+  /** Optional override for the Magnific API base URL (testing). */
+  magnificBaseUrl?: string;
 }
 
 export interface VargProvider extends ProviderV3 {
@@ -209,14 +231,49 @@ class VargVideoModel implements VideoModelV3 {
   readonly maxVideosPerCall = 1;
   private baseUrl: string;
   private apiKey: string;
+  private settings: VargProviderSettings;
 
-  constructor(modelId: string, baseUrl: string, apiKey: string) {
+  constructor(
+    modelId: string,
+    baseUrl: string,
+    apiKey: string,
+    settings: VargProviderSettings,
+  ) {
     this.modelId = modelId;
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
+    this.settings = settings;
   }
 
   async doGenerate(options: VideoModelV3CallOptions) {
+    // Magnific BYOK fast path — bypass the Varg gateway when a Magnific key is
+    // resolvable. When no key is available, fall through to the gateway and let
+    // it forward "magnific/<leaf>" upstream.
+    const magnificLeaf = parseMagnificModelId(this.modelId);
+    if (magnificLeaf !== null) {
+      const byok = resolveMagnificKey({
+        settings: this.settings,
+        perCall: options.providerOptions?.magnific as
+          | Record<string, unknown>
+          | undefined,
+      });
+      if (byok) {
+        const result = await magnificDirectVideo(magnificLeaf, byok, options, {
+          baseUrl: this.settings.magnificBaseUrl,
+          signal: options.abortSignal,
+        });
+        return {
+          videos: [result.data],
+          warnings: [] as SharedV3Warning[],
+          response: {
+            timestamp: new Date(),
+            modelId: this.modelId,
+            headers: undefined,
+          },
+        };
+      }
+    }
+
     const warnings: SharedV3Warning[] = [];
     const params: Record<string, unknown> = {
       model: this.modelId,
@@ -271,14 +328,47 @@ class VargImageModel implements ImageModelV3 {
   readonly maxImagesPerCall = 1;
   private baseUrl: string;
   private apiKey: string;
+  private settings: VargProviderSettings;
 
-  constructor(modelId: string, baseUrl: string, apiKey: string) {
+  constructor(
+    modelId: string,
+    baseUrl: string,
+    apiKey: string,
+    settings: VargProviderSettings,
+  ) {
     this.modelId = modelId;
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
+    this.settings = settings;
   }
 
   async doGenerate(options: ImageModelV3CallOptions) {
+    // Magnific BYOK fast path — see VargVideoModel for the contract.
+    const magnificLeaf = parseMagnificModelId(this.modelId);
+    if (magnificLeaf !== null) {
+      const byok = resolveMagnificKey({
+        settings: this.settings,
+        perCall: options.providerOptions?.magnific as
+          | Record<string, unknown>
+          | undefined,
+      });
+      if (byok) {
+        const result = await magnificDirectImage(magnificLeaf, byok, options, {
+          baseUrl: this.settings.magnificBaseUrl,
+          signal: options.abortSignal,
+        });
+        return {
+          images: [result.data],
+          warnings: [] as SharedV3Warning[],
+          response: {
+            timestamp: new Date(),
+            modelId: this.modelId,
+            headers: undefined,
+          },
+        };
+      }
+    }
+
     const warnings: SharedV3Warning[] = [];
     const params: Record<string, unknown> = {
       model: this.modelId,
@@ -328,14 +418,42 @@ class VargSpeechModel implements SpeechModelV3 {
   readonly modelId: string;
   private baseUrl: string;
   private apiKey: string;
+  private settings: VargProviderSettings;
 
-  constructor(modelId: string, baseUrl: string, apiKey: string) {
+  constructor(
+    modelId: string,
+    baseUrl: string,
+    apiKey: string,
+    settings: VargProviderSettings,
+  ) {
     this.modelId = modelId;
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
+    this.settings = settings;
   }
 
   async doGenerate(options: SpeechModelV3CallOptions) {
+    // Magnific BYOK fast path
+    const magnificLeaf = parseMagnificModelId(this.modelId);
+    if (magnificLeaf !== null) {
+      const byok = resolveMagnificKey({
+        settings: this.settings,
+        perCall: options.providerOptions?.magnific as
+          | Record<string, unknown>
+          | undefined,
+      });
+      if (byok) {
+        const result = await magnificDirectSpeech(magnificLeaf, byok, options, {
+          baseUrl: this.settings.magnificBaseUrl,
+        });
+        return {
+          audio: result.data,
+          warnings: [] as SharedV3Warning[],
+          response: { timestamp: new Date(), modelId: this.modelId },
+        };
+      }
+    }
+
     const warnings: SharedV3Warning[] = [];
     const params: Record<string, unknown> = {
       model: this.modelId,
@@ -363,14 +481,46 @@ class VargMusicModel implements MusicModelV3 {
   readonly modelId: string;
   private baseUrl: string;
   private apiKey: string;
+  private settings: VargProviderSettings;
 
-  constructor(modelId: string, baseUrl: string, apiKey: string) {
+  constructor(
+    modelId: string,
+    baseUrl: string,
+    apiKey: string,
+    settings: VargProviderSettings,
+  ) {
     this.modelId = modelId;
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
+    this.settings = settings;
   }
 
   async doGenerate(options: MusicModelV3CallOptions) {
+    // Magnific BYOK fast path
+    const magnificLeaf = parseMagnificModelId(this.modelId);
+    if (magnificLeaf !== null) {
+      const byok = resolveMagnificKey({
+        settings: this.settings,
+        perCall: options.providerOptions?.magnific as
+          | Record<string, unknown>
+          | undefined,
+      });
+      if (byok) {
+        const result = await magnificDirectMusic(magnificLeaf, byok, options, {
+          baseUrl: this.settings.magnificBaseUrl,
+        });
+        return {
+          audio: result.data,
+          warnings: [] as SharedV3Warning[],
+          response: {
+            timestamp: new Date(),
+            modelId: this.modelId,
+            headers: undefined,
+          },
+        };
+      }
+    }
+
     const warnings: SharedV3Warning[] = [];
     const params: Record<string, unknown> = {
       model: this.modelId,
@@ -403,10 +553,14 @@ export function createVarg(settings: VargProviderSettings = {}): VargProvider {
 
   return {
     specificationVersion: "v3",
-    videoModel: (modelId) => new VargVideoModel(modelId, baseUrl, apiKey),
-    imageModel: (modelId) => new VargImageModel(modelId, baseUrl, apiKey),
-    speechModel: (modelId) => new VargSpeechModel(modelId, baseUrl, apiKey),
-    musicModel: (modelId) => new VargMusicModel(modelId, baseUrl, apiKey),
+    videoModel: (modelId) =>
+      new VargVideoModel(modelId, baseUrl, apiKey, settings),
+    imageModel: (modelId) =>
+      new VargImageModel(modelId, baseUrl, apiKey, settings),
+    speechModel: (modelId) =>
+      new VargSpeechModel(modelId, baseUrl, apiKey, settings),
+    musicModel: (modelId) =>
+      new VargMusicModel(modelId, baseUrl, apiKey, settings),
     languageModel(modelId: string): LanguageModelV3 {
       throw new NoSuchModelError({ modelId, modelType: "languageModel" });
     },

--- a/src/ai-sdk/providers/varg.ts
+++ b/src/ai-sdk/providers/varg.ts
@@ -445,6 +445,7 @@ class VargSpeechModel implements SpeechModelV3 {
       if (byok) {
         const result = await magnificDirectSpeech(magnificLeaf, byok, options, {
           baseUrl: this.settings.magnificBaseUrl,
+          signal: options.abortSignal,
         });
         return {
           audio: result.data,
@@ -508,6 +509,7 @@ class VargMusicModel implements MusicModelV3 {
       if (byok) {
         const result = await magnificDirectMusic(magnificLeaf, byok, options, {
           baseUrl: this.settings.magnificBaseUrl,
+          signal: options.abortSignal,
         });
         return {
           audio: result.data,

--- a/src/definitions/actions/image.ts
+++ b/src/definitions/actions/image.ts
@@ -8,6 +8,7 @@ import { imageSizeSchema } from "../../core/schema/shared";
 import type { ActionDefinition, ZodSchema } from "../../core/schema/types";
 import { falProvider } from "../../providers/fal";
 import { higgsfieldProvider } from "../../providers/higgsfield";
+import { magnificProvider } from "../../providers/magnific";
 import { storageProvider } from "../../providers/storage";
 
 // Input schema with Zod
@@ -17,9 +18,15 @@ const imageInputSchema = z.object({
     .default("landscape_4_3")
     .describe("Image size/aspect ratio"),
   provider: z
-    .enum(["fal", "higgsfield"])
+    .enum(["fal", "higgsfield", "magnific"])
     .default("fal")
     .describe("Generation provider"),
+  model: z
+    .string()
+    .optional()
+    .describe(
+      "Provider-specific model name. For magnific: mystic (default), flux-2-pro, flux-2-turbo, flux-2-klein, flux-pro-v1.1, flux-dev, hyperflux, seedream-4, seedream-v4.5, runway-image.",
+    ),
 });
 
 // Output schema with Zod
@@ -50,12 +57,20 @@ export const definition: ActionDefinition<typeof schema> = {
       when: { provider: "higgsfield" },
       priority: 10,
     },
+    {
+      target: "magnific/mystic",
+      when: { provider: "magnific" },
+      priority: 5,
+    },
   ],
   execute: async (inputs) => {
-    const { prompt, size, provider } = inputs;
+    const { prompt, size, provider, model } = inputs;
 
     if (provider === "higgsfield") {
       return generateWithSoul(prompt);
+    }
+    if (provider === "magnific") {
+      return generateWithMagnific(prompt, { size, model });
     }
 
     return generateWithFal(prompt, { imageSize: size });
@@ -120,6 +135,76 @@ export async function generateWithSoul(
   }
 
   return { imageUrl, uploaded };
+}
+
+export async function generateWithMagnific(
+  prompt: string,
+  options: { size?: string; model?: string; upload?: boolean } = {},
+): Promise<ImageGenerationResult> {
+  const model = options.model || "mystic";
+  console.log(`[image] generating with magnific/${model}`);
+
+  // Map of v1 models → capability path. The Layer A surface
+  // (varg.imageModel("magnific/...")) covers these too; here we use the Layer B
+  // provider directly so the CLI doesn't depend on the AI-SDK module.
+  const paths: Record<string, string> = {
+    mystic: "ai/mystic",
+    "flux-2-pro": "ai/text-to-image/flux-2-pro",
+    "flux-2-turbo": "ai/text-to-image/flux-2-turbo",
+    "flux-2-klein": "ai/text-to-image/flux-2-klein",
+    "flux-pro-v1.1": "ai/text-to-image/flux-pro-v1-1",
+    "flux-dev": "ai/text-to-image/flux-dev",
+    hyperflux: "ai/text-to-image/hyperflux",
+    "seedream-4": "ai/text-to-image/seedream-v4",
+    "seedream-v4.5": "ai/text-to-image/seedream-v4-5",
+    "runway-image": "ai/text-to-image/runway",
+  };
+  const path = paths[model];
+  if (!path) {
+    throw new Error(
+      `[image] unknown magnific model "${model}". Available: ${Object.keys(paths).join(", ")}`,
+    );
+  }
+
+  // Map varg's imageSize enum into Magnific's aspect_ratio enum where possible.
+  const aspect = mapImageSizeToMagnific(options.size);
+  const body: Record<string, unknown> = { prompt };
+  const ACCEPTS_ASPECT_RATIO = new Set([
+    "flux-2-klein",
+    "flux-pro-v1.1",
+    "flux-dev",
+    "hyperflux",
+    "seedream-4",
+    "seedream-v4.5",
+    "mystic",
+  ]);
+  if (aspect && ACCEPTS_ASPECT_RATIO.has(model)) body.aspect_ratio = aspect;
+
+  const result = await magnificProvider.runImage(path, body);
+  const imageUrl = result.url;
+
+  let uploaded: string | undefined;
+  if (options.upload) {
+    const timestamp = Date.now();
+    const objectKey = `images/magnific/${timestamp}.png`;
+    uploaded = await storageProvider.uploadFromUrl(imageUrl, objectKey);
+    console.log(`[image] uploaded to ${uploaded}`);
+  }
+
+  return { imageUrl, uploaded };
+}
+
+function mapImageSizeToMagnific(size?: string): string | undefined {
+  if (!size) return undefined;
+  const map: Record<string, string> = {
+    square_hd: "square_1_1",
+    square: "square_1_1",
+    portrait_4_3: "traditional_3_4",
+    portrait_16_9: "social_story_9_16",
+    landscape_4_3: "classic_4_3",
+    landscape_16_9: "widescreen_16_9",
+  };
+  return map[size];
 }
 
 export default definition;

--- a/src/definitions/actions/index.ts
+++ b/src/definitions/actions/index.ts
@@ -49,8 +49,21 @@ export type { ImageGenerationResult } from "./image";
 export {
   definition as image,
   generateWithFal,
+  generateWithMagnific,
   generateWithSoul,
 } from "./image";
+// Magnific actions
+export {
+  allMagnificActionDefinitions,
+  expandDefinition as magnificExpand,
+  isolateAudioDefinition as magnificIsolateAudio,
+  relightDefinition as magnificRelight,
+  removeBgDefinition as magnificRemoveBg,
+  restyleDefinition as magnificRestyle,
+  sfxDefinition as magnificSfx,
+  upscaleDefinition as magnificUpscale,
+  vfxDefinition as magnificVfx,
+} from "./magnific-actions";
 export type { GenerateMusicOptions, MusicResult } from "./music";
 // Music generation
 export { definition as music, generateMusic } from "./music";
@@ -101,6 +114,7 @@ import {
 } from "./edit";
 import { definition as grokEditDefinition } from "./grok-edit";
 import { definition as imageDefinition } from "./image";
+import { allMagnificActionDefinitions } from "./magnific-actions";
 import { definition as musicDefinition } from "./music";
 import { definition as qwenAnglesDefinition } from "./qwen-angles";
 import { definition as syncDefinition } from "./sync";
@@ -127,4 +141,5 @@ export const allActions = [
   transitionDefinition,
   removeDefinition,
   uploadDefinition,
+  ...allMagnificActionDefinitions,
 ];

--- a/src/definitions/actions/magnific-actions.ts
+++ b/src/definitions/actions/magnific-actions.ts
@@ -1,0 +1,511 @@
+/**
+ * Magnific CLI actions — short verbs that map 1:1 to Magnific capabilities.
+ *
+ * Each action's Zod input schema mirrors the underlying Magnific endpoint
+ * schema verbatim (every field, every default, every enum). The `execute`
+ * function calls `magnificProvider` directly — Layer B always uses BYOK
+ * (`MAGNIFIC_API_KEY`).
+ *
+ * Actions:
+ *   - upscale         (creative + precision modes)
+ *   - relight
+ *   - restyle         (style transfer)
+ *   - remove-bg
+ *   - expand
+ *   - sfx             (sound effects)
+ *   - isolate-audio
+ *   - vfx             (video filters)
+ */
+
+import { z } from "zod";
+import type { ActionDefinition, ZodSchema } from "../../core/schema/types";
+import { magnificProvider } from "../../providers/magnific";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const urlOrPathSchema = z
+  .string()
+  .describe("URL or local file path (encoded as base64 by the SDK)");
+
+const singleUrlOutput = z.object({ url: z.string() });
+type SingleUrlOutput = typeof singleUrlOutput;
+
+async function readBase64(input: string): Promise<string> {
+  if (/^https?:\/\//i.test(input)) {
+    const r = await fetch(input);
+    if (!r.ok) {
+      throw new Error(`failed to fetch ${input}: ${r.status}`);
+    }
+    return Buffer.from(await r.arrayBuffer()).toString("base64");
+  }
+  // local file — Bun.file gives us an arrayBuffer
+  const file = Bun.file(input);
+  if (!(await file.exists())) {
+    throw new Error(`file not found: ${input}`);
+  }
+  return Buffer.from(await file.arrayBuffer()).toString("base64");
+}
+
+// ---------------------------------------------------------------------------
+// upscale
+// ---------------------------------------------------------------------------
+
+const upscaleInput = z.object({
+  image: urlOrPathSchema,
+  mode: z
+    .enum(["creative", "precision"])
+    .default("creative")
+    .describe("Upscaler engine"),
+  // Creative-mode fields
+  scale_factor: z.enum(["2x", "4x", "8x", "16x"]).default("2x"),
+  optimized_for: z
+    .enum([
+      "standard",
+      "soft_portraits",
+      "hard_portraits",
+      "art_n_illustration",
+      "videogame_assets",
+      "nature_n_landscapes",
+      "films_n_photography",
+      "3d_renders",
+      "science_fiction_n_horror",
+    ])
+    .default("standard"),
+  prompt: z.string().optional(),
+  creativity: z.number().int().min(-10).max(10).default(0),
+  hdr: z.number().int().min(-10).max(10).default(0),
+  resemblance: z.number().int().min(-10).max(10).default(0),
+  fractality: z.number().int().min(-10).max(10).default(0),
+  engine: z
+    .enum([
+      "automatic",
+      "magnific_illusio",
+      "magnific_sharpy",
+      "magnific_sparkle",
+    ])
+    .default("automatic"),
+  // Precision-mode fields
+  sharpen: z.number().int().min(0).max(100).default(50),
+  smart_grain: z.number().int().min(0).max(100).default(7),
+  ultra_detail: z.number().int().min(0).max(100).default(30),
+  // Common
+  filter_nsfw: z.boolean().default(false),
+  webhook_url: z.string().url().optional(),
+});
+
+export const upscaleDefinition: ActionDefinition<
+  ZodSchema<typeof upscaleInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "upscale",
+  description: "Upscale an image using Magnific (creative or precision mode).",
+  schema: { input: upscaleInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) => {
+    const image = await readBase64(inputs.image);
+    if (inputs.mode === "precision") {
+      return magnificProvider.upscalePrecision({
+        image,
+        sharpen: inputs.sharpen,
+        smart_grain: inputs.smart_grain,
+        ultra_detail: inputs.ultra_detail,
+        filter_nsfw: inputs.filter_nsfw,
+        webhook_url: inputs.webhook_url,
+      });
+    }
+    return magnificProvider.upscaleCreative({
+      image,
+      scale_factor: inputs.scale_factor,
+      optimized_for: inputs.optimized_for,
+      prompt: inputs.prompt,
+      creativity: inputs.creativity,
+      hdr: inputs.hdr,
+      resemblance: inputs.resemblance,
+      fractality: inputs.fractality,
+      engine: inputs.engine,
+      filter_nsfw: inputs.filter_nsfw,
+      webhook_url: inputs.webhook_url,
+    });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// relight
+// ---------------------------------------------------------------------------
+
+const relightAdvanced = z
+  .object({
+    whites: z.number().int().min(0).max(100).default(50),
+    blacks: z.number().int().min(0).max(100).default(50),
+    brightness: z.number().int().min(0).max(100).default(50),
+    contrast: z.number().int().min(0).max(100).default(50),
+    saturation: z.number().int().min(0).max(100).default(50),
+    engine: z
+      .enum([
+        "automatic",
+        "balanced",
+        "cool",
+        "real",
+        "illusio",
+        "fairy",
+        "colorful_anime",
+        "hard_transform",
+        "softy",
+      ])
+      .default("automatic"),
+    transfer_light_a: z
+      .enum(["automatic", "low", "medium", "normal", "high", "high_on_faces"])
+      .default("automatic"),
+    transfer_light_b: z
+      .enum([
+        "automatic",
+        "composition",
+        "straight",
+        "smooth_in",
+        "smooth_out",
+        "smooth_both",
+        "reverse_both",
+        "soft_in",
+        "soft_out",
+        "soft_mid",
+        "strong_mid",
+        "style_shift",
+        "strong_shift",
+      ])
+      .default("automatic"),
+    fixed_generation: z.boolean().default(false),
+  })
+  .partial();
+
+const relightInput = z.object({
+  image: urlOrPathSchema,
+  prompt: z.string().optional(),
+  reference_image: urlOrPathSchema.optional(),
+  lightmap: urlOrPathSchema.optional(),
+  light_transfer_strength: z.number().int().min(0).max(100).default(100),
+  interpolate_from_original: z.boolean().default(false),
+  change_background: z.boolean().default(true),
+  style: z
+    .enum([
+      "standard",
+      "darker_but_realistic",
+      "clean",
+      "smooth",
+      "brighter",
+      "contrasted_n_hdr",
+      "just_composition",
+    ])
+    .default("standard"),
+  preserve_details: z.boolean().default(true),
+  advanced_settings: relightAdvanced.optional(),
+  webhook_url: z.string().url().optional(),
+});
+
+export const relightDefinition: ActionDefinition<
+  ZodSchema<typeof relightInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "relight",
+  description:
+    "Change the lighting of an image via prompt, reference image, or custom lightmap.",
+  schema: { input: relightInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) => {
+    if (inputs.reference_image && inputs.lightmap) {
+      throw new Error(
+        "relight: pass either --reference-image OR --lightmap, not both",
+      );
+    }
+    return magnificProvider.relight({
+      image: await readBase64(inputs.image),
+      prompt: inputs.prompt,
+      transfer_light_from_reference_image: inputs.reference_image
+        ? await readBase64(inputs.reference_image)
+        : undefined,
+      transfer_light_from_lightmap: inputs.lightmap
+        ? await readBase64(inputs.lightmap)
+        : undefined,
+      light_transfer_strength: inputs.light_transfer_strength,
+      interpolate_from_original: inputs.interpolate_from_original,
+      change_background: inputs.change_background,
+      style: inputs.style,
+      preserve_details: inputs.preserve_details,
+      advanced_settings: inputs.advanced_settings,
+      webhook_url: inputs.webhook_url,
+    });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// restyle (style transfer)
+// ---------------------------------------------------------------------------
+
+const restyleInput = z.object({
+  image: urlOrPathSchema,
+  reference_image: urlOrPathSchema,
+  prompt: z.string().optional(),
+  style_strength: z.number().int().min(0).max(100).default(100),
+  structure_strength: z.number().int().min(0).max(100).default(50),
+  is_portrait: z.boolean().default(false),
+  portrait_style: z.enum(["standard", "pop", "super_pop"]).default("standard"),
+  portrait_beautifier: z
+    .enum(["beautify_face", "beautify_face_max"])
+    .optional(),
+  flavor: z
+    .enum([
+      "faithful",
+      "gen_z",
+      "psychedelia",
+      "detaily",
+      "clear",
+      "donotstyle",
+      "donotstyle_sharp",
+    ])
+    .default("faithful"),
+  engine: z
+    .enum([
+      "balanced",
+      "definio",
+      "illusio",
+      "3d_cartoon",
+      "colorful_anime",
+      "caricature",
+      "real",
+      "super_real",
+      "softy",
+    ])
+    .default("balanced"),
+  fixed_generation: z.boolean().default(false),
+  webhook_url: z.string().url().optional(),
+});
+
+export const restyleDefinition: ActionDefinition<
+  ZodSchema<typeof restyleInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "restyle",
+  description:
+    "Apply a reference image's style to a source image (Magnific Style Transfer).",
+  schema: { input: restyleInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) =>
+    magnificProvider.styleTransfer({
+      image: await readBase64(inputs.image),
+      reference_image: await readBase64(inputs.reference_image),
+      prompt: inputs.prompt,
+      style_strength: inputs.style_strength,
+      structure_strength: inputs.structure_strength,
+      is_portrait: inputs.is_portrait,
+      portrait_style: inputs.portrait_style,
+      portrait_beautifier: inputs.portrait_beautifier,
+      flavor: inputs.flavor,
+      engine: inputs.engine,
+      fixed_generation: inputs.fixed_generation,
+      webhook_url: inputs.webhook_url,
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// remove-bg
+// ---------------------------------------------------------------------------
+
+const removeBgInput = z.object({
+  image_url: z
+    .string()
+    .url()
+    .describe("Publicly accessible URL of the source image (JPG/PNG ≤20MB)"),
+});
+
+export const removeBgDefinition: ActionDefinition<
+  ZodSchema<typeof removeBgInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "remove-bg",
+  description:
+    "Remove image background (Magnific Beta — synchronous, requires a URL input).",
+  schema: { input: removeBgInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) =>
+    magnificProvider.removeBackground({ image_url: inputs.image_url }),
+};
+
+// ---------------------------------------------------------------------------
+// expand
+// ---------------------------------------------------------------------------
+
+const expandInput = z.object({
+  image: urlOrPathSchema,
+  prompt: z.string().optional(),
+  left: z.number().int().min(0).max(2048).optional(),
+  right: z.number().int().min(0).max(2048).optional(),
+  top: z.number().int().min(0).max(2048).optional(),
+  bottom: z.number().int().min(0).max(2048).optional(),
+  webhook_url: z.string().url().optional(),
+});
+
+export const expandDefinition: ActionDefinition<
+  ZodSchema<typeof expandInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "expand",
+  description: "Outpaint an image (Magnific Image Expand / Flux Pro).",
+  schema: { input: expandInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) =>
+    magnificProvider.expand({
+      image: await readBase64(inputs.image),
+      prompt: inputs.prompt,
+      left: inputs.left,
+      right: inputs.right,
+      top: inputs.top,
+      bottom: inputs.bottom,
+      webhook_url: inputs.webhook_url,
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// sfx (sound effects)
+// ---------------------------------------------------------------------------
+
+const sfxInput = z.object({
+  text: z.string().max(2500).describe("Effect description"),
+  duration_seconds: z.number().min(0.5).max(22),
+  loop: z.boolean().default(false),
+  prompt_influence: z.number().min(0).max(1).default(0.3),
+  webhook_url: z.string().url().optional(),
+});
+
+export const sfxDefinition: ActionDefinition<
+  ZodSchema<typeof sfxInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "sfx",
+  description: "Generate a sound effect from a text description (Magnific).",
+  schema: { input: sfxInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) =>
+    magnificProvider.soundEffects({
+      text: inputs.text,
+      duration_seconds: inputs.duration_seconds,
+      loop: inputs.loop,
+      prompt_influence: inputs.prompt_influence,
+      webhook_url: inputs.webhook_url,
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// isolate-audio
+// ---------------------------------------------------------------------------
+
+const isolateAudioInput = z
+  .object({
+    description: z.string().max(2500),
+    audio: urlOrPathSchema.optional(),
+    video: urlOrPathSchema.optional(),
+    x1: z.number().int().min(0).default(0),
+    y1: z.number().int().min(0).default(0),
+    x2: z.number().int().min(0).default(0),
+    y2: z.number().int().min(0).default(0),
+    sample_fps: z.number().min(1).max(5).default(2),
+    reranking_candidates: z.number().int().min(1).max(8).default(1),
+    predict_spans: z.boolean().default(false),
+    webhook_url: z.string().url().optional(),
+  })
+  .refine((v) => Boolean(v.audio) !== Boolean(v.video), {
+    message: "exactly one of `audio` or `video` is required",
+  });
+
+export const isolateAudioDefinition: ActionDefinition<
+  ZodSchema<typeof isolateAudioInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "isolate-audio",
+  description:
+    "Isolate a described sound from an audio or video input (Magnific Audio Isolation).",
+  schema: { input: isolateAudioInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) => {
+    const audio = inputs.audio
+      ? /^https?:\/\//i.test(inputs.audio)
+        ? inputs.audio
+        : await readBase64(inputs.audio)
+      : undefined;
+    const video = inputs.video
+      ? /^https?:\/\//i.test(inputs.video)
+        ? inputs.video
+        : await readBase64(inputs.video)
+      : undefined;
+    return magnificProvider.audioIsolation({
+      description: inputs.description,
+      audio,
+      video,
+      x1: inputs.x1,
+      y1: inputs.y1,
+      x2: inputs.x2,
+      y2: inputs.y2,
+      sample_fps: inputs.sample_fps,
+      reranking_candidates: inputs.reranking_candidates,
+      predict_spans: inputs.predict_spans,
+      webhook_url: inputs.webhook_url,
+    });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// vfx (video filters)
+// ---------------------------------------------------------------------------
+
+const vfxInput = z.object({
+  video: z.string().url().describe("Publicly accessible video URL"),
+  filter_type: z
+    .number()
+    .int()
+    .min(1)
+    .max(8)
+    .default(1)
+    .describe(
+      "Effect type 1=film grain, 2=motion blur, 3..6, 7=bloom, 8=anamorphic",
+    ),
+  fps: z.number().int().min(1).max(60).default(24),
+  bloom_filter_contrast: z.number().optional(),
+  motion_filter_kernel_size: z.number().int().optional(),
+  motion_filter_decay_factor: z.number().optional(),
+  webhook_url: z.string().url().optional(),
+});
+
+export const vfxDefinition: ActionDefinition<
+  ZodSchema<typeof vfxInput, SingleUrlOutput>
+> = {
+  type: "action",
+  name: "vfx",
+  description: "Apply a video filter (Magnific VFX — 1 of 8 effect types).",
+  schema: { input: vfxInput, output: singleUrlOutput },
+  routes: [],
+  execute: async (inputs) =>
+    magnificProvider.vfx({
+      video: inputs.video,
+      filter_type: inputs.filter_type,
+      fps: inputs.fps,
+      bloom_filter_contrast: inputs.bloom_filter_contrast,
+      motion_filter_kernel_size: inputs.motion_filter_kernel_size,
+      motion_filter_decay_factor: inputs.motion_filter_decay_factor,
+      webhook_url: inputs.webhook_url,
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// Aggregate
+// ---------------------------------------------------------------------------
+
+export const allMagnificActionDefinitions = [
+  upscaleDefinition,
+  relightDefinition,
+  restyleDefinition,
+  removeBgDefinition,
+  expandDefinition,
+  sfxDefinition,
+  isolateAudioDefinition,
+  vfxDefinition,
+];

--- a/src/definitions/actions/magnific-actions.ts
+++ b/src/definitions/actions/magnific-actions.ts
@@ -34,7 +34,19 @@ type SingleUrlOutput = typeof singleUrlOutput;
 
 async function readBase64(input: string): Promise<string> {
   if (/^https?:\/\//i.test(input)) {
-    const r = await fetch(input);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 15_000);
+    let r: Response;
+    try {
+      r = await fetch(input, { signal: controller.signal });
+    } catch (err) {
+      clearTimeout(timer);
+      if (err instanceof DOMException && err.name === "AbortError") {
+        throw new Error(`fetch timed out for ${input}`);
+      }
+      throw err;
+    }
+    clearTimeout(timer);
     if (!r.ok) {
       throw new Error(`failed to fetch ${input}: ${r.status}`);
     }

--- a/src/definitions/models/flux.ts
+++ b/src/definitions/models/flux.ts
@@ -48,11 +48,12 @@ export const definition: ModelDefinition<typeof schema> = {
   name: "flux",
   description:
     "Flux Pro image generation model for high-quality images from text",
-  providers: ["fal", "replicate"],
+  providers: ["fal", "replicate", "magnific"],
   defaultProvider: "fal",
   providerModels: {
     fal: "fal-ai/flux-pro/v1.1",
     replicate: "black-forest-labs/flux-1.1-pro",
+    magnific: "ai/text-to-image/flux-pro-v1-1",
   },
   schema,
   pricing: {

--- a/src/definitions/models/index.ts
+++ b/src/definitions/models/index.ts
@@ -22,6 +22,20 @@ export {
 } from "./kling";
 export { definition as llama } from "./llama";
 export { definition as ltxA2v } from "./ltx-a2v";
+export {
+  allMagnificDefinitions,
+  magnificAudioIsolationDefinition,
+  magnificExpandDefinition,
+  magnificMusicDefinition,
+  magnificMysticDefinition,
+  magnificRelightDefinition,
+  magnificRemoveBgDefinition,
+  magnificSoundEffectsDefinition,
+  magnificStyleTransferDefinition,
+  magnificUpscaleCreativeDefinition,
+  magnificUpscalePrecisionDefinition,
+  magnificVfxDefinition,
+} from "./magnific";
 export { definition as nanoBanana2 } from "./nano-banana-2";
 export { definition as nanoBananaPro } from "./nano-banana-pro";
 export { definition as omnihuman } from "./omnihuman";
@@ -58,6 +72,7 @@ import {
 } from "./kling";
 import { definition as llamaDefinition } from "./llama";
 import { definition as ltxA2vDefinition } from "./ltx-a2v";
+import { allMagnificDefinitions } from "./magnific";
 import { definition as nanoBanana2Definition } from "./nano-banana-2";
 import { definition as nanoBananaProDefinition } from "./nano-banana-pro";
 import { definition as omnihumanDefinition } from "./omnihuman";
@@ -108,6 +123,7 @@ export const allModels = [
   sonautoDefinition,
   llamaDefinition,
   heygenAvatarDefinition,
+  ...allMagnificDefinitions,
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/definitions/models/kling.ts
+++ b/src/definitions/models/kling.ts
@@ -48,11 +48,12 @@ export const definition: ModelDefinition<typeof schema> = {
   name: "kling",
   description:
     "Kling video generation model for high-quality video from text or image",
-  providers: ["fal", "replicate"],
+  providers: ["fal", "replicate", "magnific"],
   defaultProvider: "fal",
   providerModels: {
     fal: "fal-ai/kling-video/o3/pro",
     replicate: "fofr/kling-v1.5",
+    magnific: "ai/video/kling-v3-pro",
   },
   schema,
   pricing: {

--- a/src/definitions/models/magnific.ts
+++ b/src/definitions/models/magnific.ts
@@ -1,0 +1,707 @@
+/**
+ * Magnific model definitions — every documented field on every endpoint is
+ * declared in the Zod schema, with the correct default, enum, and range. The
+ * action layer maps CLI flags 1:1 to these fields.
+ *
+ * The capability path is in `providerModels.magnific`; the Layer B provider
+ * (`src/providers/magnific.ts`) routes to that path.
+ */
+
+import { z } from "zod";
+import type { ModelDefinition, ZodSchema } from "../../core/schema/types";
+
+// ---------------------------------------------------------------------------
+// Shared enums + helpers
+// ---------------------------------------------------------------------------
+
+const aspectRatioImageSchema = z.enum([
+  "square_1_1",
+  "widescreen_16_9",
+  "social_story_9_16",
+  "portrait_2_3",
+  "traditional_3_4",
+  "vertical_1_2",
+  "horizontal_2_1",
+  "social_post_4_5",
+  "standard_3_2",
+  "classic_4_3",
+  "cinematic_21_9",
+]);
+
+const colorWeightSchema = z.object({
+  color: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/)
+    .describe("Hex color #RRGGBB"),
+  weight: z.number().min(0.05).max(1.0).describe("Color weight 0.05–1.0"),
+});
+
+const stylingColorsSchema = z
+  .array(colorWeightSchema)
+  .min(1)
+  .max(5)
+  .describe("Dominant color palette (1–5 colors)");
+
+const webhookUrlSchema = z
+  .string()
+  .url()
+  .optional()
+  .describe("Optional callback URL for async status notifications");
+
+// Common output: a single URL.
+const singleUrlOutput = z.object({
+  url: z.string().describe("URL of the generated asset"),
+  uploaded: z.string().optional().describe("Object key after R2 upload"),
+});
+
+// Some endpoints return multiple URLs (Mystic).
+const multiUrlOutput = z.object({
+  urls: z.array(z.string()),
+  has_nsfw: z.array(z.boolean()).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Image Upscaler — Creative
+// ---------------------------------------------------------------------------
+
+const upscaleCreativeInputSchema = z.object({
+  image: z
+    .string()
+    .describe("Source image URL or local path (encoded as base64 by the SDK)"),
+  scale_factor: z
+    .enum(["2x", "4x", "8x", "16x"])
+    .default("2x")
+    .describe("Upscaling multiplier (output ≤25.3M pixels)"),
+  optimized_for: z
+    .enum([
+      "standard",
+      "soft_portraits",
+      "hard_portraits",
+      "art_n_illustration",
+      "videogame_assets",
+      "nature_n_landscapes",
+      "films_n_photography",
+      "3d_renders",
+      "science_fiction_n_horror",
+    ])
+    .default("standard")
+    .describe("Style optimization preset"),
+  prompt: z
+    .string()
+    .optional()
+    .describe(
+      "Guidance prompt; reusing the original prompt improves AI-image upscales",
+    ),
+  creativity: z
+    .number()
+    .int()
+    .min(-10)
+    .max(10)
+    .default(0)
+    .describe("AI creativity level (-10..10)"),
+  hdr: z
+    .number()
+    .int()
+    .min(-10)
+    .max(10)
+    .default(0)
+    .describe("Detail intensity (-10..10)"),
+  resemblance: z
+    .number()
+    .int()
+    .min(-10)
+    .max(10)
+    .default(0)
+    .describe("Resemblance to original (-10..10)"),
+  fractality: z
+    .number()
+    .int()
+    .min(-10)
+    .max(10)
+    .default(0)
+    .describe("Prompt strength per pixel (-10..10)"),
+  engine: z
+    .enum([
+      "automatic",
+      "magnific_illusio",
+      "magnific_sharpy",
+      "magnific_sparkle",
+    ])
+    .default("automatic")
+    .describe("Magnific model engine"),
+  filter_nsfw: z.boolean().default(false).describe("Filter NSFW content"),
+  webhook_url: webhookUrlSchema,
+});
+
+const upscaleCreativeSchema: ZodSchema<
+  typeof upscaleCreativeInputSchema,
+  typeof singleUrlOutput
+> = { input: upscaleCreativeInputSchema, output: singleUrlOutput };
+
+export const magnificUpscaleCreativeDefinition: ModelDefinition<
+  typeof upscaleCreativeSchema
+> = {
+  type: "model",
+  name: "magnific/upscale-creative",
+  description:
+    "Magnific creative upscaler — prompt-guided 2x/4x/8x/16x upscaling with style presets and creativity controls.",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/image-upscaler" },
+  schema: upscaleCreativeSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Image Upscaler — Precision
+// ---------------------------------------------------------------------------
+
+const upscalePrecisionInputSchema = z.object({
+  image: z.string().describe("Source image URL or local path"),
+  sharpen: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .default(50)
+    .describe("Sharpening 0–100"),
+  smart_grain: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .default(7)
+    .describe("Smart grain 0–100"),
+  ultra_detail: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .default(30)
+    .describe("Ultra-detail 0–100"),
+  filter_nsfw: z.boolean().default(false).describe("Filter NSFW content"),
+  webhook_url: webhookUrlSchema,
+});
+
+const upscalePrecisionSchema: ZodSchema<
+  typeof upscalePrecisionInputSchema,
+  typeof singleUrlOutput
+> = { input: upscalePrecisionInputSchema, output: singleUrlOutput };
+
+export const magnificUpscalePrecisionDefinition: ModelDefinition<
+  typeof upscalePrecisionSchema
+> = {
+  type: "model",
+  name: "magnific/upscale-precision",
+  description:
+    "Magnific precision upscaler — high-fidelity sharpening, grain, and ultra-detail enhancement.",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/image-upscaler-precision" },
+  schema: upscalePrecisionSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Image Relight
+// ---------------------------------------------------------------------------
+
+const relightAdvancedSchema = z
+  .object({
+    whites: z.number().int().min(0).max(100).default(50),
+    blacks: z.number().int().min(0).max(100).default(50),
+    brightness: z.number().int().min(0).max(100).default(50),
+    contrast: z.number().int().min(0).max(100).default(50),
+    saturation: z.number().int().min(0).max(100).default(50),
+    engine: z
+      .enum([
+        "automatic",
+        "balanced",
+        "cool",
+        "real",
+        "illusio",
+        "fairy",
+        "colorful_anime",
+        "hard_transform",
+        "softy",
+      ])
+      .default("automatic"),
+    transfer_light_a: z
+      .enum(["automatic", "low", "medium", "normal", "high", "high_on_faces"])
+      .default("automatic"),
+    transfer_light_b: z
+      .enum([
+        "automatic",
+        "composition",
+        "straight",
+        "smooth_in",
+        "smooth_out",
+        "smooth_both",
+        "reverse_both",
+        "soft_in",
+        "soft_out",
+        "soft_mid",
+        "strong_mid",
+        "style_shift",
+        "strong_shift",
+      ])
+      .default("automatic"),
+    fixed_generation: z.boolean().default(false),
+  })
+  .partial()
+  .describe("Advanced relight controls (all optional)");
+
+const relightInputSchema = z.object({
+  image: z.string().describe("Source image (URL or base64)"),
+  prompt: z
+    .string()
+    .optional()
+    .describe("Guidance prompt; supports `(aspect:1-1.4)` syntax"),
+  transfer_light_from_reference_image: z
+    .string()
+    .optional()
+    .describe("Reference image (mutually exclusive with lightmap)"),
+  transfer_light_from_lightmap: z
+    .string()
+    .optional()
+    .describe("Custom lightmap (mutually exclusive with reference)"),
+  light_transfer_strength: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .default(100)
+    .describe("Transfer intensity 0–100"),
+  interpolate_from_original: z.boolean().default(false),
+  change_background: z.boolean().default(true),
+  style: z
+    .enum([
+      "standard",
+      "darker_but_realistic",
+      "clean",
+      "smooth",
+      "brighter",
+      "contrasted_n_hdr",
+      "just_composition",
+    ])
+    .default("standard")
+    .describe("Visual style preset"),
+  preserve_details: z.boolean().default(true),
+  advanced_settings: relightAdvancedSchema.optional(),
+  webhook_url: webhookUrlSchema,
+});
+
+const relightSchema: ZodSchema<
+  typeof relightInputSchema,
+  typeof singleUrlOutput
+> = {
+  input: relightInputSchema,
+  output: singleUrlOutput,
+};
+
+export const magnificRelightDefinition: ModelDefinition<typeof relightSchema> =
+  {
+    type: "model",
+    name: "magnific/relight",
+    description:
+      "Magnific Relight — change image lighting via prompt, reference image, or custom lightmap.",
+    providers: ["magnific"],
+    defaultProvider: "magnific",
+    providerModels: { magnific: "ai/image-relight" },
+    schema: relightSchema,
+  };
+
+// ---------------------------------------------------------------------------
+// Image Style Transfer
+// ---------------------------------------------------------------------------
+
+const styleTransferInputSchema = z.object({
+  image: z.string().describe("Source image"),
+  reference_image: z.string().describe("Style-reference image"),
+  prompt: z.string().optional(),
+  style_strength: z.number().int().min(0).max(100).default(100),
+  structure_strength: z.number().int().min(0).max(100).default(50),
+  is_portrait: z.boolean().default(false),
+  portrait_style: z.enum(["standard", "pop", "super_pop"]).default("standard"),
+  portrait_beautifier: z
+    .enum(["beautify_face", "beautify_face_max"])
+    .optional(),
+  flavor: z
+    .enum([
+      "faithful",
+      "gen_z",
+      "psychedelia",
+      "detaily",
+      "clear",
+      "donotstyle",
+      "donotstyle_sharp",
+    ])
+    .default("faithful"),
+  engine: z
+    .enum([
+      "balanced",
+      "definio",
+      "illusio",
+      "3d_cartoon",
+      "colorful_anime",
+      "caricature",
+      "real",
+      "super_real",
+      "softy",
+    ])
+    .default("balanced"),
+  fixed_generation: z.boolean().default(false),
+  webhook_url: webhookUrlSchema,
+});
+
+const styleTransferSchema: ZodSchema<
+  typeof styleTransferInputSchema,
+  typeof singleUrlOutput
+> = { input: styleTransferInputSchema, output: singleUrlOutput };
+
+export const magnificStyleTransferDefinition: ModelDefinition<
+  typeof styleTransferSchema
+> = {
+  type: "model",
+  name: "magnific/style-transfer",
+  description:
+    "Magnific Style Transfer — apply a reference image's style with engine + flavor controls.",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/image-style-transfer" },
+  schema: styleTransferSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Remove Background (synchronous)
+// ---------------------------------------------------------------------------
+
+const removeBgInputSchema = z.object({
+  image_url: z
+    .string()
+    .url()
+    .describe(
+      "Publicly accessible URL of the source image (JPG/PNG ≤20MB; preview ≤0.25MP, full ≤25MP)",
+    ),
+});
+
+const removeBgSchema: ZodSchema<
+  typeof removeBgInputSchema,
+  typeof singleUrlOutput
+> = { input: removeBgInputSchema, output: singleUrlOutput };
+
+export const magnificRemoveBgDefinition: ModelDefinition<
+  typeof removeBgSchema
+> = {
+  type: "model",
+  name: "magnific/remove-bg",
+  description:
+    "Magnific background removal (synchronous endpoint, output URLs valid for 5 min).",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/beta/remove-background" },
+  schema: removeBgSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Image Expand (Flux Pro outpaint)
+// ---------------------------------------------------------------------------
+
+const expandInputSchema = z.object({
+  image: z.string().describe("Source image"),
+  prompt: z.string().optional().describe("Expansion guidance"),
+  left: z.number().int().min(0).max(2048).optional(),
+  right: z.number().int().min(0).max(2048).optional(),
+  top: z.number().int().min(0).max(2048).optional(),
+  bottom: z.number().int().min(0).max(2048).optional(),
+  webhook_url: webhookUrlSchema,
+});
+
+const expandSchema: ZodSchema<
+  typeof expandInputSchema,
+  typeof singleUrlOutput
+> = {
+  input: expandInputSchema,
+  output: singleUrlOutput,
+};
+
+export const magnificExpandDefinition: ModelDefinition<typeof expandSchema> = {
+  type: "model",
+  name: "magnific/expand",
+  description:
+    "Magnific outpaint — extend image canvas (per-edge px controls).",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/image-expand/flux-pro" },
+  schema: expandSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Mystic image generation
+// ---------------------------------------------------------------------------
+
+const mysticStylingSchema = z
+  .object({
+    styles: z
+      .array(
+        z.object({
+          name: z.string().describe("Style name (from /v1/ai/loras)"),
+          strength: z
+            .number()
+            .min(0)
+            .max(200)
+            .default(100)
+            .describe("Style intensity 0–200"),
+        }),
+      )
+      .max(1)
+      .optional(),
+    characters: z
+      .array(
+        z.object({
+          id: z.string().describe("Character ID (from /v1/ai/loras)"),
+          strength: z.number().min(0).max(200).default(100),
+        }),
+      )
+      .max(1)
+      .optional(),
+    colors: stylingColorsSchema.optional(),
+  })
+  .partial()
+  .describe("Mystic styling: styles, characters, colors");
+
+const mysticInputSchema = z.object({
+  prompt: z.string().optional().describe("Image description"),
+  structure_reference: z
+    .string()
+    .optional()
+    .describe("Base64 image to influence shape/structure"),
+  structure_strength: z.number().int().min(0).max(100).default(50),
+  style_reference: z
+    .string()
+    .optional()
+    .describe("Base64 image to influence style"),
+  adherence: z.number().int().min(0).max(100).default(50),
+  hdr: z.number().int().min(0).max(100).default(50),
+  resolution: z.enum(["1k", "2k", "4k"]).default("2k"),
+  aspect_ratio: aspectRatioImageSchema.default("square_1_1"),
+  model: z
+    .enum([
+      "zen",
+      "flexible",
+      "fluid",
+      "realism",
+      "super_real",
+      "editorial_portraits",
+    ])
+    .default("realism"),
+  creative_detailing: z.number().int().min(0).max(100).default(33),
+  engine: z
+    .enum([
+      "automatic",
+      "magnific_illusio",
+      "magnific_sharpy",
+      "magnific_sparkle",
+    ])
+    .default("automatic"),
+  fixed_generation: z.boolean().default(false),
+  filter_nsfw: z.boolean().default(true),
+  styling: mysticStylingSchema.optional(),
+  webhook_url: webhookUrlSchema,
+});
+
+const mysticSchema: ZodSchema<typeof mysticInputSchema, typeof multiUrlOutput> =
+  {
+    input: mysticInputSchema,
+    output: multiUrlOutput,
+  };
+
+export const magnificMysticDefinition: ModelDefinition<typeof mysticSchema> = {
+  type: "model",
+  name: "magnific/mystic",
+  description:
+    "Magnific Mystic — flagship image generation with LoRAs and color palettes.",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/mystic" },
+  schema: mysticSchema,
+};
+
+// ---------------------------------------------------------------------------
+// VFX (video filters)
+// ---------------------------------------------------------------------------
+
+const vfxInputSchema = z.object({
+  video: z.string().url().describe("Publicly accessible video URL"),
+  filter_type: z
+    .number()
+    .int()
+    .min(1)
+    .max(8)
+    .default(1)
+    .describe("Effect type (1=film grain through 8=anamorphic lens)"),
+  fps: z.number().int().min(1).max(60).default(24),
+  bloom_filter_contrast: z
+    .number()
+    .optional()
+    .describe("Glow intensity (filter_type=7 only)"),
+  motion_filter_kernel_size: z
+    .number()
+    .int()
+    .optional()
+    .describe("Blur strength (filter_type=2 only)"),
+  motion_filter_decay_factor: z
+    .number()
+    .optional()
+    .describe("Blur falloff (filter_type=2 only)"),
+  webhook_url: webhookUrlSchema,
+});
+
+const vfxSchema: ZodSchema<typeof vfxInputSchema, typeof singleUrlOutput> = {
+  input: vfxInputSchema,
+  output: singleUrlOutput,
+};
+
+export const magnificVfxDefinition: ModelDefinition<typeof vfxSchema> = {
+  type: "model",
+  name: "magnific/vfx",
+  description:
+    "Magnific VFX — apply 1 of 8 film/motion/anamorphic effects to a video.",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/video/vfx" },
+  schema: vfxSchema,
+};
+
+// ---------------------------------------------------------------------------
+// Audio: music, sound effects, audio isolation
+// ---------------------------------------------------------------------------
+
+const musicInputSchema = z.object({
+  prompt: z
+    .string()
+    .max(2500)
+    .describe("Genre/mood/instruments/tempo description"),
+  music_length_seconds: z
+    .number()
+    .int()
+    .min(10)
+    .max(240)
+    .describe("Track length 10–240s"),
+  webhook_url: webhookUrlSchema,
+});
+
+const musicSchema: ZodSchema<typeof musicInputSchema, typeof singleUrlOutput> =
+  {
+    input: musicInputSchema,
+    output: singleUrlOutput,
+  };
+
+export const magnificMusicDefinition: ModelDefinition<typeof musicSchema> = {
+  type: "model",
+  name: "magnific/music",
+  description: "Magnific music generation (10–240s tracks).",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/music-generation" },
+  schema: musicSchema,
+};
+
+const soundEffectsInputSchema = z.object({
+  text: z.string().max(2500).describe("Effect description"),
+  duration_seconds: z.number().min(0.5).max(22).describe("Length 0.5–22s"),
+  loop: z.boolean().default(false),
+  prompt_influence: z
+    .number()
+    .min(0)
+    .max(1)
+    .default(0.3)
+    .describe("Prompt influence on output 0–1"),
+  webhook_url: webhookUrlSchema,
+});
+
+const soundEffectsSchema: ZodSchema<
+  typeof soundEffectsInputSchema,
+  typeof singleUrlOutput
+> = { input: soundEffectsInputSchema, output: singleUrlOutput };
+
+export const magnificSoundEffectsDefinition: ModelDefinition<
+  typeof soundEffectsSchema
+> = {
+  type: "model",
+  name: "magnific/sound-effects",
+  description: "Magnific sound effects generation (0.5–22s, optional looping).",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/sound-effects" },
+  schema: soundEffectsSchema,
+};
+
+const audioIsolationInputSchema = z
+  .object({
+    description: z.string().max(2500).describe("Sound to isolate"),
+    audio: z
+      .string()
+      .optional()
+      .describe("Source audio URL or base64 (WAV/MP3/FLAC/OGG/M4A)"),
+    video: z
+      .string()
+      .optional()
+      .describe("Source video URL or base64 (MP4/MOV/WEBM/AVI)"),
+    x1: z.number().int().min(0).default(0).describe("BBox left (video only)"),
+    y1: z.number().int().min(0).default(0).describe("BBox top (video only)"),
+    x2: z.number().int().min(0).default(0).describe("BBox right (video only)"),
+    y2: z.number().int().min(0).default(0).describe("BBox bottom (video only)"),
+    sample_fps: z
+      .number()
+      .min(1)
+      .max(5)
+      .default(2)
+      .describe("Frame sampling rate 1–5"),
+    reranking_candidates: z
+      .number()
+      .int()
+      .min(1)
+      .max(8)
+      .default(1)
+      .describe("Quality vs latency 1–8"),
+    predict_spans: z.boolean().default(false),
+    webhook_url: webhookUrlSchema,
+  })
+  .refine((v) => Boolean(v.audio) !== Boolean(v.video), {
+    message: "exactly one of `audio` or `video` is required",
+  });
+
+const audioIsolationSchema: ZodSchema<
+  typeof audioIsolationInputSchema,
+  typeof singleUrlOutput
+> = { input: audioIsolationInputSchema, output: singleUrlOutput };
+
+export const magnificAudioIsolationDefinition: ModelDefinition<
+  typeof audioIsolationSchema
+> = {
+  type: "model",
+  name: "magnific/audio-isolation",
+  description:
+    "Magnific Audio Isolation — extract a described sound from audio or video.",
+  providers: ["magnific"],
+  defaultProvider: "magnific",
+  providerModels: { magnific: "ai/audio-isolation" },
+  schema: audioIsolationSchema,
+};
+
+// ---------------------------------------------------------------------------
+// All Magnific unique-capability model definitions for index registration.
+// ---------------------------------------------------------------------------
+
+export const allMagnificDefinitions = [
+  magnificUpscaleCreativeDefinition,
+  magnificUpscalePrecisionDefinition,
+  magnificRelightDefinition,
+  magnificStyleTransferDefinition,
+  magnificRemoveBgDefinition,
+  magnificExpandDefinition,
+  magnificMysticDefinition,
+  magnificVfxDefinition,
+  magnificMusicDefinition,
+  magnificSoundEffectsDefinition,
+  magnificAudioIsolationDefinition,
+];

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -100,6 +100,22 @@ export {
   SoulQuality,
   SoulSize,
 } from "./higgsfield";
+// Magnific provider (image upscale/relight/style/expand + Mystic image gen + audio + video)
+export {
+  MagnificProvider,
+  magnificAudioIsolation,
+  magnificExpand,
+  magnificMusic,
+  magnificMystic,
+  magnificProvider,
+  magnificRelight,
+  magnificRemoveBackground,
+  magnificSoundEffects,
+  magnificStyleTransfer,
+  magnificUpscaleCreative,
+  magnificUpscalePrecision,
+  magnificVfx,
+} from "./magnific";
 // PiAPI provider (Seedance video generation)
 export { PiAPIProvider, piapiProvider } from "./piapi";
 // Replicate provider (video/image generation)
@@ -133,6 +149,7 @@ import { fireworksProvider } from "./fireworks";
 import { groqProvider } from "./groq";
 import { heygenProvider } from "./heygen";
 import { higgsfieldProvider } from "./higgsfield";
+import { magnificProvider } from "./magnific";
 import { piapiProvider } from "./piapi";
 import { replicateProvider } from "./replicate";
 import { storageProvider } from "./storage";
@@ -147,5 +164,6 @@ providers.register(fireworksProvider);
 providers.register(higgsfieldProvider);
 providers.register(heygenProvider);
 providers.register(piapiProvider);
+providers.register(magnificProvider);
 providers.register(ffmpegProvider);
 providers.register(storageProvider);

--- a/src/providers/magnific.ts
+++ b/src/providers/magnific.ts
@@ -1,0 +1,295 @@
+/**
+ * Magnific provider (CLI / declarative side).
+ *
+ * Talks directly to api.magnific.com using the user's `MAGNIFIC_API_KEY`. Used
+ * by `src/definitions/actions/{upscale,relight,restyle,remove-bg,expand,sfx,
+ * isolate-audio,vfx}.ts` and the Magnific entries on `image`/`video`/`music`/
+ * `sync` actions.
+ *
+ * The AI-SDK side at `src/ai-sdk/providers/magnific.ts` shares the same
+ * concepts (HTTP shape, capability paths, polling) but has its own runtime to
+ * stay independent of `BaseProvider` and the global registry.
+ */
+
+import type { JobStatusUpdate, ProviderConfig } from "../core/schema/types";
+import { BaseProvider } from "./base";
+
+const MAGNIFIC_BASE_URL = "https://api.magnific.com/v1";
+
+interface MagnificTaskResponse {
+  task_id?: string;
+  status?: "CREATED" | "IN_PROGRESS" | "COMPLETED" | "FAILED";
+  generated?: string[];
+  has_nsfw?: boolean[];
+  error?: string | { message?: string };
+  message?: string;
+  data?: MagnificTaskResponse;
+}
+
+const SYNCHRONOUS_PATHS = new Set<string>(["ai/beta/remove-background"]);
+
+const FORM_ENCODED_PATHS = new Set<string>(["ai/beta/remove-background"]);
+
+const POLL_PATH_OVERRIDES: Record<string, string> = {
+  "ai/image-to-video/kling-v2-1-pro": "ai/image-to-video/kling-v2-1",
+  "ai/image-to-video/kling-v2-6-pro": "ai/image-to-video/kling-v2-6",
+  "ai/image-to-video/kling-o1-pro": "ai/image-to-video/kling-o1",
+  "ai/video/kling-v3-pro": "ai/video/kling-v3",
+};
+
+function unwrap(payload: unknown): MagnificTaskResponse {
+  if (payload && typeof payload === "object") {
+    const obj = payload as MagnificTaskResponse;
+    if (obj.data && typeof obj.data === "object") return obj.data;
+    return obj;
+  }
+  return {};
+}
+
+export class MagnificProvider extends BaseProvider {
+  readonly name = "magnific";
+  private apiKey: string;
+  private baseUrl: string;
+  /**
+   * Map of task_id → capability path. Polling needs the path to construct
+   * the GET URL (mirrors fal.ts's `jobModels` trick).
+   */
+  private taskCapabilities = new Map<string, string>();
+  /** task_id → generated[] when an endpoint completed synchronously on submit. */
+  private syncResults = new Map<string, string[]>();
+
+  constructor(config?: ProviderConfig) {
+    super({
+      timeout: 30 * 60 * 1000, // 30 min — video can be slow
+      ...config,
+    });
+    this.apiKey = config?.apiKey || process.env.MAGNIFIC_API_KEY || "";
+    this.baseUrl = config?.baseUrl || MAGNIFIC_BASE_URL;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      "x-magnific-api-key": this.apiKey,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+  }
+
+  /**
+   * Submit a task. `model` is the capability path (e.g. "ai/image-upscaler").
+   * For synchronous endpoints (remove-bg) the result is captured immediately
+   * and `getStatus`/`getResult` return it without another network round-trip.
+   */
+  async submit(
+    model: string,
+    inputs: Record<string, unknown>,
+    _config?: ProviderConfig,
+  ): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error(
+        "magnific: missing MAGNIFIC_API_KEY (set the env var or pass it to the provider config)",
+      );
+    }
+    const path = model.startsWith("ai/") ? model : `ai/${model}`;
+    const url = `${this.baseUrl}/${path}`;
+    const isForm = FORM_ENCODED_PATHS.has(path);
+    const headers: Record<string, string> = {
+      "x-magnific-api-key": this.apiKey,
+      Accept: "application/json",
+      "Content-Type": isForm
+        ? "application/x-www-form-urlencoded"
+        : "application/json",
+    };
+    const body = isForm
+      ? new URLSearchParams(
+          Object.fromEntries(
+            Object.entries(inputs).map(([k, v]) => [k, String(v)]),
+          ),
+        ).toString()
+      : JSON.stringify(inputs);
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `magnific submit ${path} failed (${response.status}): ${text}`,
+      );
+    }
+    const data = unwrap(await response.json());
+
+    // Synchronous endpoint or cache hit
+    if (
+      SYNCHRONOUS_PATHS.has(path) ||
+      (data.status === "COMPLETED" && data.generated?.length)
+    ) {
+      const taskId = data.task_id ?? crypto.randomUUID();
+      this.taskCapabilities.set(taskId, path);
+      this.syncResults.set(taskId, data.generated ?? []);
+      return taskId;
+    }
+
+    if (!data.task_id) {
+      throw new Error(`magnific ${path} response missing task_id`);
+    }
+    this.taskCapabilities.set(data.task_id, path);
+    return data.task_id;
+  }
+
+  async getStatus(jobId: string): Promise<JobStatusUpdate> {
+    if (this.syncResults.has(jobId)) {
+      return {
+        status: "completed",
+        output: { generated: this.syncResults.get(jobId) },
+      };
+    }
+    const path = this.taskCapabilities.get(jobId);
+    if (!path) {
+      throw new Error(`magnific: unknown task id ${jobId}`);
+    }
+    const pollPath = POLL_PATH_OVERRIDES[path] ?? path;
+    const url = `${this.baseUrl}/${pollPath}/${jobId}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: this.headers(),
+    });
+    if (!response.ok) {
+      throw new Error(`magnific poll ${jobId} failed (${response.status})`);
+    }
+    const data = unwrap(await response.json());
+    const statusMap: Record<string, JobStatusUpdate["status"]> = {
+      CREATED: "queued",
+      IN_PROGRESS: "processing",
+      COMPLETED: "completed",
+      FAILED: "failed",
+    };
+    const rawErr =
+      typeof data.error === "string" ? data.error : data.error?.message;
+    // See src/ai-sdk/providers/magnific.ts — Magnific often returns FAILED
+    // with no detail; make that actionable for the user.
+    const friendlyErr =
+      data.status === "FAILED" && (!rawErr || rawErr === "unknown")
+        ? `magnific ${path} failed with no error detail. This commonly indicates an input incompatibility (unsupported video codec/resolution, image too small for the endpoint, or unsupported format). Try a different input.`
+        : rawErr;
+    return {
+      status: statusMap[data.status ?? ""] ?? "processing",
+      output: { generated: data.generated, has_nsfw: data.has_nsfw },
+      error: friendlyErr,
+    };
+  }
+
+  async getResult(jobId: string): Promise<unknown> {
+    if (this.syncResults.has(jobId)) {
+      const generated = this.syncResults.get(jobId);
+      this.taskCapabilities.delete(jobId);
+      this.syncResults.delete(jobId);
+      return { generated };
+    }
+    const status = await this.getStatus(jobId);
+    this.taskCapabilities.delete(jobId);
+    this.syncResults.delete(jobId);
+    return status.output;
+  }
+
+  /**
+   * Submit + wait for completion. Returns the raw `generated[]` URL list.
+   */
+  async runAndWait(
+    capabilityPath: string,
+    inputs: Record<string, unknown>,
+    options: { maxWait?: number; pollInterval?: number } = {},
+  ): Promise<string[]> {
+    const jobId = await this.submit(capabilityPath, inputs);
+    const result = (await this.waitForCompletion(jobId, {
+      maxWait: options.maxWait ?? this.config.timeout ?? 30 * 60 * 1000,
+      pollInterval: options.pollInterval ?? 5000,
+    })) as { generated?: string[] } | undefined;
+    return result?.generated ?? [];
+  }
+
+  // -------------------------------------------------------------------------
+  // High-level convenience methods (one per unique-to-magnific capability)
+  // -------------------------------------------------------------------------
+
+  upscaleCreative(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/image-upscaler", args);
+  }
+  upscalePrecision(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/image-upscaler-precision", args);
+  }
+  relight(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/image-relight", args);
+  }
+  styleTransfer(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/image-style-transfer", args);
+  }
+  removeBackground(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/beta/remove-background", args);
+  }
+  expand(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/image-expand/flux-pro", args);
+  }
+  mystic(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/mystic", args);
+  }
+  music(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/music-generation", args);
+  }
+  soundEffects(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/sound-effects", args);
+  }
+  audioIsolation(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/audio-isolation", args);
+  }
+  vfx(args: Record<string, unknown>): Promise<{ url: string }> {
+    return this.runAndFirst("ai/video/vfx", args);
+  }
+
+  /** Generic helper for any image model. */
+  async runImage(
+    capabilityPath: string,
+    args: Record<string, unknown>,
+  ): Promise<{ url: string }> {
+    return this.runAndFirst(capabilityPath, args);
+  }
+
+  private async runAndFirst(
+    capabilityPath: string,
+    inputs: Record<string, unknown>,
+  ): Promise<{ url: string }> {
+    const urls = await this.runAndWait(capabilityPath, inputs);
+    const url = urls[0];
+    if (!url) {
+      throw new Error(`magnific ${capabilityPath} completed but no output URL`);
+    }
+    return { url };
+  }
+}
+
+export const magnificProvider = new MagnificProvider();
+
+// Convenience re-exports (mirror fal.ts:832-861 style)
+export const magnificUpscaleCreative = (args: Record<string, unknown>) =>
+  magnificProvider.upscaleCreative(args);
+export const magnificUpscalePrecision = (args: Record<string, unknown>) =>
+  magnificProvider.upscalePrecision(args);
+export const magnificRelight = (args: Record<string, unknown>) =>
+  magnificProvider.relight(args);
+export const magnificStyleTransfer = (args: Record<string, unknown>) =>
+  magnificProvider.styleTransfer(args);
+export const magnificRemoveBackground = (args: Record<string, unknown>) =>
+  magnificProvider.removeBackground(args);
+export const magnificExpand = (args: Record<string, unknown>) =>
+  magnificProvider.expand(args);
+export const magnificMystic = (args: Record<string, unknown>) =>
+  magnificProvider.mystic(args);
+export const magnificMusic = (args: Record<string, unknown>) =>
+  magnificProvider.music(args);
+export const magnificSoundEffects = (args: Record<string, unknown>) =>
+  magnificProvider.soundEffects(args);
+export const magnificAudioIsolation = (args: Record<string, unknown>) =>
+  magnificProvider.audioIsolation(args);
+export const magnificVfx = (args: Record<string, unknown>) =>
+  magnificProvider.vfx(args);

--- a/src/providers/magnific.ts
+++ b/src/providers/magnific.ts
@@ -202,11 +202,16 @@ export class MagnificProvider extends BaseProvider {
     options: { maxWait?: number; pollInterval?: number } = {},
   ): Promise<string[]> {
     const jobId = await this.submit(capabilityPath, inputs);
-    const result = (await this.waitForCompletion(jobId, {
-      maxWait: options.maxWait ?? this.config.timeout ?? 30 * 60 * 1000,
-      pollInterval: options.pollInterval ?? 5000,
-    })) as { generated?: string[] } | undefined;
-    return result?.generated ?? [];
+    try {
+      const result = (await this.waitForCompletion(jobId, {
+        maxWait: options.maxWait ?? this.config.timeout ?? 30 * 60 * 1000,
+        pollInterval: options.pollInterval ?? 5000,
+      })) as { generated?: string[] } | undefined;
+      return result?.generated ?? [];
+    } finally {
+      this.taskCapabilities.delete(jobId);
+      this.syncResults.delete(jobId);
+    }
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds Magnific as a new provider across both the AI-SDK layer (BYOK direct path to api.magnific.com) and the CLI layer (BaseProvider-based with submit/poll lifecycle). Includes 18 image models, 19 video models, music generation, and 2 speech models. Also adds 8 dedicated Magnific actions (upscale, relight, restyle, remove-bg, expand, sfx, isolate-audio, vfx) and 12+ model definitions.

## Why

Magnific offers unique capabilities (creative/precision upscaling, relighting, style transfer, background removal, outpainting, VFX) not available through existing providers, plus access to third-party models (Kling, Wan, Runway, Minimax, Seedance, etc.) via a single API key.

## How to test

- `bun test src/ai-sdk/providers/magnific.test.ts` — 58 tests covering routing, payload shape, gateway fallback, abort propagation, and apiKey scrubbing
- `bunx tsc --noEmit 2>&1 | grep magnific` — no type errors from magnific files
- Optional live smoke: `bun run src/cli/index.ts run image --provider magnific --prompt "sunset over ocean" --quiet` (requires `MAGNIFIC_API_KEY`)

## Checklist

- [x] Code follows existing style
- [x] Tested locally with `bun test`
- [x] No breaking changes