### PR TITLE
fix: guard speech/music generation against missing audio

### DIFF
--- a/src/react/renderers/music.ts
+++ b/src/react/renderers/music.ts
@@ -51,9 +51,9 @@ export async function renderMusic(
 
     if (!audio?.uint8Array) {
       throw new Error(
-        `Music generation returned no audio (model=${modelId}). ` +
-          `This usually means a stale/incompatible render cache entry was reconstructed ` +
-          `without an 'audio' field, or the gateway/provider returned an empty response.`,
+        `We couldn't generate the background music for this video (music model "${modelId}"). ` +
+          `The audio came back empty. Please try again — if it keeps happening, ` +
+          `try a different music model or adjust the prompt.`,
       );
     }
 

--- a/src/react/renderers/music.ts
+++ b/src/react/renderers/music.ts
@@ -49,6 +49,14 @@ export async function renderMusic(
 
     if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
 
+    if (!audio?.uint8Array) {
+      throw new Error(
+        `Music generation returned no audio (model=${modelId}). ` +
+          `This usually means a stale/incompatible render cache entry was reconstructed ` +
+          `without an 'audio' field, or the gateway/provider returned an empty response.`,
+      );
+    }
+
     const mediaType =
       (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 

--- a/src/react/renderers/speech.ts
+++ b/src/react/renderers/speech.ts
@@ -53,6 +53,14 @@ export async function renderSpeech(
 
     if (taskId && ctx.progress) completeTask(ctx.progress, taskId);
 
+    if (!audio?.uint8Array) {
+      throw new Error(
+        `Speech generation returned no audio (model=${modelId}). ` +
+          `This usually means a stale/incompatible render cache entry was reconstructed ` +
+          `without an 'audio' field, or the gateway/provider returned an empty response.`,
+      );
+    }
+
     const mediaType =
       (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 

--- a/src/react/renderers/speech.ts
+++ b/src/react/renderers/speech.ts
@@ -55,9 +55,9 @@ export async function renderSpeech(
 
     if (!audio?.uint8Array) {
       throw new Error(
-        `Speech generation returned no audio (model=${modelId}). ` +
-          `This usually means a stale/incompatible render cache entry was reconstructed ` +
-          `without an 'audio' field, or the gateway/provider returned an empty response.`,
+        `We couldn't generate the voiceover for this scene (speech model "${modelId}"). ` +
+          `The audio came back empty. Please try again — if it keeps happening, ` +
+          `try a different voice or speech model.`,
       );
     }
 

--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -475,6 +475,15 @@ export async function resolveSpeechElement(
     cacheKey,
   });
 
+  const modelId = typeof model === "string" ? model : model.modelId;
+  if (!audio?.uint8Array) {
+    throw new Error(
+      `Speech generation returned no audio (model=${modelId}). ` +
+        `This usually means a stale/incompatible render cache entry was reconstructed ` +
+        `without an 'audio' field, or the gateway/provider returned an empty response.`,
+    );
+  }
+
   const mediaType = (audio as { mediaType?: string }).mediaType ?? "audio/mpeg";
 
   const file = File.fromGenerated({

--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -478,9 +478,9 @@ export async function resolveSpeechElement(
   const modelId = typeof model === "string" ? model : model.modelId;
   if (!audio?.uint8Array) {
     throw new Error(
-      `Speech generation returned no audio (model=${modelId}). ` +
-        `This usually means a stale/incompatible render cache entry was reconstructed ` +
-        `without an 'audio' field, or the gateway/provider returned an empty response.`,
+      `We couldn't generate the voiceover for this scene (speech model "${modelId}"). ` +
+        `The audio came back empty. Please try again — if it keeps happening, ` +
+        `try a different voice or speech model.`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Add explicit guards in `resolveSpeechElement` (await `Speech` path), `renderSpeech`, and `renderMusic` that throw a clear, actionable error when `generateSpeech`/`generateMusic` returns no audio.
- Replaces the opaque `undefined is not an object (evaluating 'audio.mediaType')` crash with a message naming the model and the likely cause (stale/incompatible cache entry or empty provider response).

## Context
A stale `render:cache` entry reconstructed without an `{ audio }` wrapper made `const { audio } = await generateSpeech(...)` undefined, crashing on `audio.mediaType`. The render-side cache shape is fixed separately (vargHQ/render#97); this PR is the defensive guard so any future missing-audio case fails loudly instead of silently.

## Changes
- `src/react/resolve.ts` — guard after `getCachedGenerateSpeech()`
- `src/react/renderers/speech.ts` — guard after `ctx.generateSpeech()`
- `src/react/renderers/music.ts` — guard after `ctx.generateMusic()`

## Test plan
- `tsc --noEmit` clean
- Existing speech/music renderers behave unchanged on valid audio