### PR TITLE
fix: caption timing in trimmed clips, in-flight resolve dedup, idempotency keys

### DIFF
--- a/src/ai-sdk/providers/varg-idempotency.test.ts
+++ b/src/ai-sdk/providers/varg-idempotency.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { computeIdempotencyKey } from "./varg";
+
+describe("computeIdempotencyKey", () => {
+  test("same params produce the same key (retry references the same job)", () => {
+    const params = { model: "kling-v3", prompt: "sunset", duration: 6 };
+    expect(computeIdempotencyKey("video", params)).toBe(
+      computeIdempotencyKey("video", { ...params }),
+    );
+  });
+
+  test("key ordering does not matter (canonical serialization)", () => {
+    const a = { model: "kling-v3", prompt: "sunset", duration: 6 };
+    const b = { duration: 6, prompt: "sunset", model: "kling-v3" };
+    expect(computeIdempotencyKey("video", a)).toBe(
+      computeIdempotencyKey("video", b),
+    );
+  });
+
+  test("nested object ordering does not matter", () => {
+    const a = {
+      prompt: "x",
+      provider_options: { fal: { generate_audio: true, resolution: "720p" } },
+    };
+    const b = {
+      provider_options: { fal: { resolution: "720p", generate_audio: true } },
+      prompt: "x",
+    };
+    expect(computeIdempotencyKey("video", a)).toBe(
+      computeIdempotencyKey("video", b),
+    );
+  });
+
+  test("different params produce different keys", () => {
+    expect(computeIdempotencyKey("video", { prompt: "sunset" })).not.toBe(
+      computeIdempotencyKey("video", { prompt: "sunrise" }),
+    );
+  });
+
+  test("different capabilities produce different keys", () => {
+    expect(computeIdempotencyKey("video", { prompt: "x" })).not.toBe(
+      computeIdempotencyKey("image", { prompt: "x" }),
+    );
+  });
+
+  test("array order matters (images order is semantic)", () => {
+    expect(computeIdempotencyKey("image", { images: ["a", "b"] })).not.toBe(
+      computeIdempotencyKey("image", { images: ["b", "a"] }),
+    );
+  });
+});

--- a/src/ai-sdk/providers/varg.ts
+++ b/src/ai-sdk/providers/varg.ts
@@ -137,29 +137,83 @@ interface VargJobResponse {
   progress?: number | null;
 }
 
+/**
+ * Stable idempotency key for a job submission.
+ *
+ * Hash of (capability, params) with deterministic key ordering — the same
+ * logical request always produces the same key, so a retry after 429 or a
+ * network error references the SAME job instead of creating a duplicate
+ * (the ep5 incident: 123 jobs for ~8 unique requests, all idempotency-less).
+ *
+ * A per-process salt is NOT included: two identical submissions from the
+ * same or different processes legitimately dedupe to one job — outputs are
+ * deterministic-cached by the API anyway.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object" && value.constructor === Object) {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/** Exported for tests. */
+export function computeIdempotencyKey(
+  capability: string,
+  params: Record<string, unknown>,
+): string {
+  const canonical = JSON.stringify(canonicalize(params));
+  return `varg-sdk-${capability}-${Bun.hash(canonical).toString(16)}`;
+}
+
 async function submitJob(
   baseUrl: string,
   apiKey: string,
   capability: "video" | "image" | "speech" | "music",
   params: Record<string, unknown>,
+  maxRetries = 6,
 ): Promise<VargJobResponse> {
-  const response = await fetch(`${baseUrl}/${capability}`, {
-    method: "POST",
-    headers: getHeaders(apiKey),
-    body: JSON.stringify(params),
-  });
+  const idempotencyKey = computeIdempotencyKey(capability, params);
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(`${baseUrl}/${capability}`, {
+      method: "POST",
+      headers: {
+        ...getHeaders(apiKey),
+        "Idempotency-Key": idempotencyKey,
+      },
+      body: JSON.stringify(params),
+    });
 
-  if (!response.ok) {
+    if (response.ok) {
+      return (await response.json()) as VargJobResponse;
+    }
+
     const raw = (await response.json().catch(() => null)) as Record<
       string,
       unknown
     > | null;
     const errorData = ((raw?.error ?? raw) || {}) as { message?: string };
     const msg = errorData?.message ?? `varg api returned ${response.status}`;
+
+    // Rate limited — back off and retry (60 jobs/min window resets quickly).
+    if (response.status === 429 && attempt < maxRetries) {
+      const retryAfter = Number(response.headers.get("retry-after"));
+      const delayMs = Number.isFinite(retryAfter)
+        ? retryAfter * 1000
+        : Math.min(60_000, 5_000 * 2 ** attempt);
+      console.warn(
+        `[varg] rate limited on ${capability}, retrying in ${Math.round(delayMs / 1000)}s (attempt ${attempt + 1}/${maxRetries})`,
+      );
+      await new Promise((r) => setTimeout(r, delayMs));
+      continue;
+    }
+
     throw new VargAPIError(msg, response.status);
   }
-
-  return (await response.json()) as VargJobResponse;
 }
 
 async function pollJob(
@@ -503,4 +557,5 @@ export function createVarg(settings: VargProviderSettings = {}): VargProvider {
 }
 
 const varg_provider = createVarg();
+
 export { varg_provider as varg };

--- a/src/react/audio-element.ts
+++ b/src/react/audio-element.ts
@@ -25,6 +25,7 @@ import type {
 import {
   computeSoundBounds,
   detectSilence,
+  refineWordTimings,
   transcribeAudio,
 } from "./primitives/audio";
 import { getActiveCache, resolveAudioElement } from "./resolve";
@@ -37,13 +38,28 @@ export interface AudioNode
     PromiseLike<ResolvedElement<"audio">> {
   /**
    * Transcribe the audio to `{ text, words }` with word-level timestamps.
-   * When the parent speech element carries native ElevenLabs word timings,
-   * they are reused and no transcription call is made. Cached by content hash.
+   *
+   * - Parent speech with native ElevenLabs alignment → reused as-is
+   *   (character-level accuracy, no refinement needed, no whisper call).
+   * - Whisper words → boundary-refined against ffmpeg silencedetect by
+   *   default: whisper absorbs leading silence into the first word
+   *   (start=0 under a second of ambience) and stretches the last word
+   *   toward EOF; measured silence clamps both. Middle words untouched.
+   *   Pass `refine: false` to get raw whisper timings.
+   *
+   * Memoized per node: repeated calls (and `speechRange()`) share one
+   * transcription + one silencedetect run. Disk-cached by content hash;
+   * refinement is applied on top of the cache (raw transcript stays the
+   * source of truth).
    */
-  transcribe(): Promise<TranscriptionResult>;
+  transcribe(options?: {
+    refine?: boolean;
+    noiseDb?: number;
+  }): Promise<TranscriptionResult>;
   /**
    * Detect silence intervals via ffmpeg `silencedetect`.
    * Note: detects *sound*, not speech — ambient noise counts as sound.
+   * Memoized per node per options.
    */
   silenceSegments(options?: SilenceDetectOptions): Promise<TimeRange[]>;
   /**
@@ -57,13 +73,22 @@ export interface AudioNode
   /**
    * Range of actual speech: start of the first spoken word, end of the
    * last one, from word-level transcription timings (`transcribe()` —
-   * native ElevenLabs alignment when present, whisper otherwise; cached).
+   * native ElevenLabs alignment when present, whisper otherwise; cached,
+   * silence-refined by default so leading ambience does not pull the
+   * range to 0).
    *
    * Returns `null` when no speech is detected (empty transcript). Word
    * boundaries from whisper carry ~±0.1s slack — pass `pad` to widen the
    * range for soft trims (clamped to [0, duration]).
+   *
+   * Memoized per node per options: repeated calls return the same
+   * promise, sharing the transcription with `transcribe()`.
    */
-  speechRange(options?: { pad?: number }): Promise<TimeRange | null>;
+  speechRange(options?: {
+    pad?: number;
+    refine?: boolean;
+    noiseDb?: number;
+  }): Promise<TimeRange | null>;
   /**
    * Duration in seconds. Available synchronously when derived from an
    * already-resolved parent (e.g. `const { audio } = await Speech(...)`);
@@ -120,51 +145,103 @@ export function makeAudioNode(props: AudioElementProps): AudioNode {
   node.then = (onFulfilled, onRejected) =>
     resolveOnce().then(onFulfilled, onRejected);
 
-  node.transcribe = async (): Promise<TranscriptionResult> => {
-    const resolved = await resolveOnce();
-    const words = resolved.meta.words;
-    if (words && words.length > 0) {
-      return { text: joinWords(words), words };
+  // -------------------------------------------------------------------
+  // Per-node memoization of analysis results. One AudioNode per parent
+  // (WeakMap in the .audio getters), so every consumer — DialogueClip's
+  // speechRange, Captions' transcription, user code — shares one
+  // transcription and one silencedetect run per option set.
+  // -------------------------------------------------------------------
+  const memo = new Map<string, Promise<unknown>>();
+  const memoize = <T>(key: string, fn: () => Promise<T>): Promise<T> => {
+    let existing = memo.get(key);
+    if (!existing) {
+      existing = fn();
+      memo.set(key, existing);
     }
-    // Use the render-level transcription default (gateway whisper) when
-    // available; falls back to direct Groq whisper-large-v3 inside
-    // transcribeAudio() if neither is set.
-    const model = getResolveContext()?.defaults?.transcription;
-    return transcribeAudio(resolved.meta.file, {
-      cache: getActiveCache(),
-      ...(model ? { model } : {}),
+    return existing as Promise<T>;
+  };
+
+  const detectSilenceOnce = (options?: SilenceDetectOptions) =>
+    memoize(`silence:${JSON.stringify(options ?? {})}`, async () => {
+      const resolved = await resolveOnce();
+      return detectSilence(resolved.meta.file, options);
     });
-  };
 
-  node.silenceSegments = async (
-    options?: SilenceDetectOptions,
-  ): Promise<TimeRange[]> => {
-    const resolved = await resolveOnce();
-    return detectSilence(resolved.meta.file, options);
-  };
+  node.transcribe = (options?: { refine?: boolean; noiseDb?: number }) =>
+    memoize(
+      `transcribe:${JSON.stringify(options ?? {})}`,
+      async (): Promise<TranscriptionResult> => {
+        const resolved = await resolveOnce();
+        const nativeWords = resolved.meta.words;
+        if (nativeWords && nativeWords.length > 0) {
+          // Native ElevenLabs alignment — character-level accuracy, no
+          // whisper call and no refinement needed.
+          return { text: joinWords(nativeWords), words: nativeWords };
+        }
+        // Use the render-level transcription default (gateway whisper) when
+        // available; falls back to direct Groq whisper-large-v3 inside
+        // transcribeAudio() if neither is set.
+        const model = getResolveContext()?.defaults?.transcription;
+        const raw = await transcribeAudio(resolved.meta.file, {
+          cache: getActiveCache(),
+          ...(model ? { model } : {}),
+        });
 
-  node.range = async (options?: SilenceDetectOptions): Promise<TimeRange> => {
-    const resolved = await resolveOnce();
-    const silences = await detectSilence(resolved.meta.file, options);
-    return computeSoundBounds(silences, resolved.meta.duration);
-  };
+        // Refine whisper boundaries against measured silence (default on):
+        // whisper absorbs leading ambience into the first word and
+        // stretches the last word toward EOF. Applied on top of the disk
+        // cache — the raw transcript stays the cached source of truth.
+        if (options?.refine === false || raw.words.length === 0) return raw;
+        try {
+          const silences = await detectSilenceOnce({
+            noiseDb: options?.noiseDb ?? -35,
+          });
+          const words = refineWordTimings(
+            raw.words,
+            silences,
+            resolved.meta.duration,
+          );
+          return { text: raw.text, words };
+        } catch {
+          // silencedetect unavailable (e.g. cloud backend) — raw timings
+          // are still correct transcription, just unrefined.
+          return raw;
+        }
+      },
+    );
 
-  node.speechRange = async (options?: {
+  node.silenceSegments = (options?: SilenceDetectOptions) =>
+    detectSilenceOnce(options);
+
+  node.range = (options?: SilenceDetectOptions): Promise<TimeRange> =>
+    memoize(`range:${JSON.stringify(options ?? {})}`, async () => {
+      const resolved = await resolveOnce();
+      const silences = await detectSilenceOnce(options);
+      return computeSoundBounds(silences, resolved.meta.duration);
+    });
+
+  node.speechRange = (options?: {
     pad?: number;
-  }): Promise<TimeRange | null> => {
-    const resolved = await resolveOnce();
-    const { words } = await node.transcribe();
-    if (!words || words.length === 0) return null;
+    refine?: boolean;
+    noiseDb?: number;
+  }): Promise<TimeRange | null> =>
+    memoize(`speechRange:${JSON.stringify(options ?? {})}`, async () => {
+      const resolved = await resolveOnce();
+      const { words } = await node.transcribe({
+        ...(options?.refine !== undefined ? { refine: options.refine } : {}),
+        ...(options?.noiseDb !== undefined ? { noiseDb: options.noiseDb } : {}),
+      });
+      if (!words || words.length === 0) return null;
 
-    const pad = options?.pad ?? 0;
-    const first = words[0]!;
-    const last = words[words.length - 1]!;
-    const duration = resolved.meta.duration;
-    return {
-      start: Math.max(0, first.start - pad),
-      end: duration > 0 ? Math.min(duration, last.end + pad) : last.end + pad,
-    };
-  };
+      const pad = options?.pad ?? 0;
+      const first = words[0]!;
+      const last = words[words.length - 1]!;
+      const duration = resolved.meta.duration;
+      return {
+        start: Math.max(0, first.start - pad),
+        end: duration > 0 ? Math.min(duration, last.end + pad) : last.end + pad,
+      };
+    });
 
   // Sync convenience getters — populated when meta is pre-seeded (resolved
   // parent) or after the node has been awaited.

--- a/src/react/elements.ts
+++ b/src/react/elements.ts
@@ -197,9 +197,19 @@ export function Overlay(props: OverlayProps): VargElement<"overlay"> {
   );
 }
 
-export function Image(
-  props: ImageProps,
-): VargElement<"image"> & PromiseLike<ResolvedElement<"image">> {
+/**
+ * Named element types returned by the media factories — for typing user
+ * code (e.g. async component props) without `ReturnType<typeof Video>`
+ * acrobatics.
+ */
+export type ImageElement = VargElement<"image"> &
+  PromiseLike<ResolvedElement<"image">>;
+export type VideoElement = VargElement<"video"> &
+  PromiseLike<ResolvedElement<"video">> & { readonly audio: AudioNode };
+export type SpeechElement = VargElement<"speech"> &
+  PromiseLike<ResolvedElement<"speech">> & { readonly audio: AudioNode };
+
+export function Image(props: ImageProps): ImageElement {
   const element = createElement(
     "image",
     props as Record<string, unknown>,
@@ -210,10 +220,7 @@ export function Image(
   );
 }
 
-export function Video(
-  props: VideoProps,
-): VargElement<"video"> &
-  PromiseLike<ResolvedElement<"video">> & { readonly audio: AudioNode } {
+export function Video(props: VideoProps): VideoElement {
   const element = createElement(
     "video",
     expandNativeAudio(props) as Record<string, unknown>,
@@ -226,10 +233,7 @@ export function Video(
   );
 }
 
-export function Speech(
-  props: SpeechProps,
-): VargElement<"speech"> &
-  PromiseLike<ResolvedElement<"speech">> & { readonly audio: AudioNode } {
+export function Speech(props: SpeechProps): SpeechElement {
   const element = createElement(
     "speech",
     props as Record<string, unknown>,

--- a/src/react/examples/async/native-audio-scene1.tsx
+++ b/src/react/examples/async/native-audio-scene1.tsx
@@ -1,0 +1,301 @@
+/** @jsxImportSource vargai */
+// ═══════════════════════════════════════════════════════════════════════════
+// TARGET API EXAMPLE — Declarative Audio Graph (RFC 0001, Этап 2а/2в)
+//
+// Full formula-care ep2 (5 scenes, gym, kling-v3 NATIVE dialogue audio),
+// rewritten against the NOT-YET-IMPLEMENTED target API. LSP errors below are
+// intentional — each one marks a feature the refactor introduces:
+//
+//   audio: "native"         Video prop                        (Этап 2а)
+//   vid.audio               derived AudioElement              (Этап 2а)
+//   audio.speechRange()     speech-range op                   (Этап 2а)
+//   audio.range()           silencedetect op                  (Этап 2а)
+//   VideoElement type       named element type exports        (Этап 2а)
+//   Captions w/o src        default = all timeline audio      (Этап 2а)
+//   Music w/o duration      default = final timeline length,  (Этап 2а /
+//                           integer seconds                    Этап 0 bug)
+//   <AsyncComponent />      Promise<Element> JSX              (Этап 4 fix)
+//
+// Today (formula-care-ep2-cloud.tsx) this takes TWO passes:
+//   pass 1: render → ffmpeg -vn per clip → silencedetect per clip by hand →
+//           curl /v2/transcription → hand-build a 58-cue SRT → fix mishears
+//   pass 2: re-render with hardcoded cutFrom/cutTo per clip + <Captions srt>
+//
+// After the refactor it is ONE pass: extraction, silence bounds and the
+// transcript are lazy graph nodes, cached by computeCacheKey like any op.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { createVarg } from "@vargai/gateway";
+import {
+  Captions,
+  Clip,
+  Image,
+  Music,
+  Render,
+  Video,
+  type VideoElement,
+} from "vargai/react";
+
+const varg = createVarg({ apiKey: process.env.VARG_API_KEY! });
+
+const IMG_EDIT = varg.imageModel("nano-banana-pro/edit");
+const IMG_BASE = varg.imageModel("nano-banana-pro");
+const KLING = varg.videoModel("kling-v3");
+const AR = "9:16";
+
+// ── Client photo refs (uploaded once, referenced by URL) ─────────────────
+const A1_PHOTO = "https://uu.varg.ai/1784576476121_3hb7fv71.jpeg";
+const A2_PHOTO = "https://uu.varg.ai/1784576485522_vbgd4amk.jpeg";
+
+// ── Character cards + location (same as today, unchanged) ────────────────
+const a1Card = Image({
+  prompt: {
+    text: "Full-body character reference card of the exact same woman from the photo: same face, same grey hair, same body shape. Overweight woman in her late 50s with grey hair. She wears a simple dark sports bra top and snug high-waisted dark athletic shorts (underwear-style workout shorts), barefoot. Her belly is fully exposed and visible, arms bare, legs bare from mid-thigh down. Standing straight facing camera, neutral relaxed pose, arms at her sides. Plain light grey studio background, even soft lighting, head-to-toe framing, photorealistic",
+    images: [A1_PHOTO],
+  },
+  model: IMG_EDIT,
+  aspectRatio: AR,
+});
+
+const a2Card = Image({
+  prompt: {
+    text: "Full-body character reference card of the exact same woman from the photo: same face, same hair, same slim build. Slim Asian fitness trainer in her 30s. She wears a fitted fitness uniform: sporty crop top and full-length leggings in matching color, clean athletic sneakers. Standing straight facing camera, confident friendly expression, arms at her sides. Plain light grey studio background, even soft lighting, head-to-toe framing, photorealistic",
+    images: [A2_PHOTO],
+  },
+  model: IMG_EDIT,
+  aspectRatio: AR,
+});
+
+const gymLoc = Image({
+  prompt:
+    "Empty modern gym interior with huge floor-to-ceiling windows letting in bright natural daylight, green trees visible outside. Light wooden floor, a few yoga mats rolled in a corner, rack of dumbbells along one wall, mirrors on the opposite wall. No people. Clean airy atmosphere, warm daylight, photorealistic, 9:16 portrait framing",
+  model: IMG_BASE,
+  aspectRatio: AR,
+});
+
+const SAME =
+  "First reference image is Woman A (overweight late-50s woman with grey hair, dark sports bra and dark athletic shorts, barefoot). Second reference image is Woman B (slim Asian trainer in her 30s in fitted fitness uniform with sneakers). Third reference image is the gym location with huge windows. Keep both women's faces, hair, bodies and outfits exactly as in their reference cards, and the gym exactly as in the location reference.";
+
+// ── Scene stills ─────────────────────────────────────────────────────────
+const scene1 = Image({
+  prompt: {
+    text: `${SAME} Medium-wide shot inside the gym in front of the huge windows. Woman A is mid-squat, knees bent, arms stretched forward for balance, belly folding, effortful concentrated expression. Woman B stands beside her closer to camera, facing the camera, speaking with an encouraging open-hand gesture. Bright natural daylight from the windows, warm candid atmosphere, photorealistic`,
+    images: [a1Card, a2Card, gymLoc],
+  },
+  model: IMG_EDIT,
+  aspectRatio: AR,
+});
+
+const scene2 = Image({
+  prompt: {
+    text: `${SAME} Full-body shot inside the gym. Woman A stands facing away from the camera, seen from behind head to toe in her dark sports bra and dark athletic shorts, her bare legs visible. Woman B crouches beside her on the left, pointing a finger toward Woman A's hips and thighs while looking at the camera. Huge windows with daylight in the background, photorealistic`,
+    images: [a1Card, a2Card, gymLoc],
+  },
+  model: IMG_EDIT,
+  aspectRatio: AR,
+});
+
+const scene3 = Image({
+  prompt: {
+    text: `${SAME} Full-body shot inside the gym. Woman A stands facing the camera head to toe, neutral stoic expression, her bare belly fully visible above the dark athletic shorts, hips and part of her rear visible. Woman B stands beside her on the left, slightly crouched, pointing an open hand at Woman A's belly while looking at the camera. Huge windows with daylight behind them, photorealistic`,
+    images: [a1Card, a2Card, gymLoc],
+  },
+  model: IMG_EDIT,
+  aspectRatio: AR,
+});
+
+const scene4 = Image({
+  prompt: {
+    text: `${SAME} Close-up shot inside the gym, framing the upper bodies of both women. Woman A faces the camera holding her right arm raised out to the side, the soft loose skin of her bare upper arm clearly visible, part of her belly visible below. Woman B stands on the left, pointing at Woman A's raised arm while looking directly into the camera with a confident expression. Blurred gym windows in the background, intimate close framing, photorealistic`,
+    images: [a1Card, a2Card, gymLoc],
+  },
+  model: IMG_EDIT,
+  aspectRatio: AR,
+});
+
+const scene5 = Image({
+  prompt: {
+    text: `${SAME} Medium-wide shot inside the gym in front of the huge windows, same framing as a squat training scene. Woman A has just risen from a squat, standing tall with a big proud happy smile, arms slightly raised in triumph. Woman B stands beside her facing the camera, laughing warmly and giving Woman A an encouraging thumbs-up. Both women look genuinely happy. Bright natural daylight, joyful warm atmosphere, photorealistic`,
+    images: [a1Card, a2Card, gymLoc],
+  },
+  model: IMG_EDIT,
+  aspectRatio: AR,
+});
+
+// ── The clips: native dialogue audio, declared ONCE ──────────────────────
+// `audio: "native"` is sugar for providerOptions generate_audio=true AND
+// keepAudio=true in one switch — no more paying 14¢/s for audio that
+// keepAudio:false silently discards (the ep2 bug we found).
+const vid1 = Video({
+  prompt: {
+    text: `Modern gym with huge floor-to-ceiling windows, green trees outside, bright daylight.
+The older grey-haired woman performs slow controlled squats, bending her knees and rising, arms stretched forward, concentrated effort on her face.
+The slim Asian trainer stands beside her facing the camera, gesturing warmly while speaking.
+Static medium-wide shot, natural daylight, candid atmosphere.
+The trainer speaks in a clear encouraging voice: "You do not need to spend hours sweating to transform your shape by summer."
+Soft gym ambient sounds, quiet footsteps on wooden floor.`,
+    images: [scene1],
+  },
+  model: KLING,
+  duration: 6, // kling-v3: integer 3..15s
+  audio: "native", // ← NEW (Этап 2а)
+});
+
+const vid2 = Video({
+  prompt: {
+    text: `Same gym with huge windows. The older grey-haired woman stands still with her back to the camera, full body visible.
+The slim Asian trainer crouches beside her on the left, pointing toward the woman's hips, looking at the camera while speaking.
+Subtle natural movement, the trainer's hand gestures as she talks.
+Static camera, full-body framing.
+The trainer says matter-of-factly: "If your booty looks like this."
+Soft gym ambient sounds.`,
+    images: [scene2],
+  },
+  model: KLING,
+  duration: 4,
+  audio: "native",
+});
+
+const vid3 = Video({
+  prompt: {
+    text: `Same gym with huge windows. Front-facing full-body shot.
+The older grey-haired woman stands facing the camera with a neutral stoic expression, standing still, her bare belly visible.
+The slim Asian trainer stands beside her, slightly crouched, gesturing with an open hand toward the woman's midsection while looking at the camera.
+Static camera, natural daylight.
+The trainer says: "If your belly looks like this."
+Soft gym ambient sounds.`,
+    images: [scene3],
+  },
+  model: KLING,
+  duration: 4,
+  audio: "native",
+});
+
+const vid4 = Video({
+  prompt: {
+    text: `Same gym, tight close-up on both women's upper bodies.
+The older grey-haired woman holds her arm raised out to the side, soft upper arm visible, standing still.
+The slim Asian trainer points at the raised arm, then looks directly into the camera speaking with confident energy.
+Static intimate close-up framing.
+The trainer says clearly and confidently: "If your arms look like this. Simply join our beginner Tai Chi Challenge this Monday, July 27th."
+Soft gym ambient, the trainer's voice is clear and motivating.`,
+    images: [scene4],
+  },
+  model: KLING,
+  duration: 7,
+  audio: "native",
+});
+
+const vid5 = Video({
+  prompt: {
+    text: `Same gym with huge windows, medium-wide shot.
+The older grey-haired woman rises up from a squat and stands tall, breaking into a big proud smile, raising her arms slightly in triumph.
+The slim Asian trainer beside her laughs warmly, gives her a thumbs-up, both women genuinely happy and celebrating.
+Static camera, bright natural daylight, joyful energy.
+The trainer says with conviction: "Forget the diets and cardio to get a beautifully toned body in exactly 28 days."
+Happy laughter, soft gym ambient sounds.`,
+    images: [scene5],
+  },
+  model: KLING,
+  duration: 6,
+  audio: "native",
+});
+
+const scenes = [
+  ["squat-intro", vid1],
+  ["booty", vid2],
+  ["belly", vid3],
+  ["arms-cta", vid4],
+  ["celebration", vid5],
+] as const;
+
+// ── Async component: generation AND math both run under the resolver ─────
+// (way B from the plan — no top-level await, the renderer sees the full
+// graph before anything generates; preview/--dry-run/compile() all work)
+//
+// One component replaces FIVE hand-measured cutFrom/cutTo pairs from ep2:
+//   <Clip cutFrom={0.2} cutTo={5.6}> <Clip cutFrom={0.2} cutTo={2.9}> ...
+// Each of those numbers was a manual ffmpeg-silencedetect session.
+// VideoElement is the named element type the refactor exports — no more
+// `ReturnType<typeof Video>` acrobatics in user code.
+async function DialogueClip({ vid }: { vid: VideoElement }) {
+  // vid.audio — AudioElement, a lazy derived node (ffmpeg -vn behind the
+  // scenes, shared ops layer, cached). Speech elements return the same
+  // AudioElement type, so Captions/Music/mixing treat them uniformly.
+  const audio = vid.audio; // ← NEW (Этап 2а)
+
+  // speechRange() — "when is the trainer actually speaking inside the clip?"
+  // as a graph op instead of a hand-run ffmpeg command. Two related ops:
+  //   audio.range(options?: SilenceDetectOptions) — non-silent audio range
+  //   audio.speechRange({ pad })                  — spoken-word range,
+  //                                                 returns TimeRange | null
+  // speechRange can return null (clip with no detectable speech), so fall
+  // back to the whole clip instead of crashing the graph.
+  const r = await audio.speechRange({ pad: 0.15 }); // ← NEW
+  const { start, end } = r ?? { start: 0, end: audio.duration };
+
+  // Keep ~0.3s of lead-in so the gesture that precedes the line survives,
+  // but never rewind past 0. This is the dynamic pacing that took the ep2
+  // edit from 27s of raw clips down to a 22.4s cut — measured by hand there.
+  const from = Math.max(0, start - 0.3);
+  return (
+    <Clip cutFrom={from} cutTo={end} duration={end - from}>
+      {vid}
+    </Clip>
+  );
+}
+
+// ── Composition ──────────────────────────────────────────────────────────
+// Captions with NO src: the default is "caption everything audible on the
+// timeline". The composer already knows every clip, its trim and its
+// offset — word timings land right without any hand-wired mapping, and a
+// trim change never invalidates an SRT. `src` stays only as an override
+// (one specific audio / speech / SRT). This replaces the 230-line inline
+// SRT block (plus the /tmp/*.srt top-level-await hack) in
+// formula-care-ep2-cloud.tsx.
+//
+// Music with NO duration: the default is "resolve to the final timeline
+// length, integer seconds". Kills two bugs at once — the 22.4s → 422
+// int_from_float class, and today's gotcha where a missing duration makes
+// ElevenLabs generate ~60s and stretch the video.
+export default (
+  <Render width={1080} height={1920} fps={30}>
+    {scenes.map(([name, vid]) => (
+      <DialogueClip key={name} vid={vid} />
+    ))}
+
+    <Captions
+      style="tiktok"
+      position="center"
+      color="#ffffff"
+      activeColor="#a3e635"
+      wordsPerLine={3}
+      fontSize={64}
+    />
+
+    <Music
+      prompt="Upbeat gentle background fitness music, soft piano and light percussion, positive uplifting mood, energetic but not overwhelming"
+      model={varg.musicModel("music_v1")}
+      volume={0.1}
+      ducking
+    />
+  </Render>
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// What changed vs today's ep2 template, node by node:
+//
+//   today (2 passes, manual)              target (1 pass, graph)
+//   ─────────────────────────            ─────────────────────────
+//   ffmpeg -vn output.mp4 audio.mp3   →  vid.audio           (derived node)
+//   ffmpeg silencedetect ×5 + eyeball →  vid.audio.speechRange() (derived)
+//   curl /v2/transcription + SRT file →  Captions w/o src (timeline audio)
+//   5× hardcoded cutFrom/cutTo pairs  →  computed in <DialogueClip>
+//   58-cue inline SRT + /tmp hack     →  gone (derived from the graph)
+//   Music duration hand-rounded int   →  Music w/o duration (timeline len)
+//   keepAudio+generate_audio mismatch →  audio:"native"
+//
+// Cache: every derived node keys off its parent's cache key + op params,
+// so re-renders after a prompt tweak only re-run the affected branch.
+// Determinism: no Math.random/Date.now anywhere — same inputs, same graph.
+// ═══════════════════════════════════════════════════════════════════════════

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -9,6 +9,7 @@ export {
   Clip,
   FFmpeg,
   Image,
+  type ImageElement,
   Music,
   Overlay,
   Packshot,
@@ -17,11 +18,13 @@ export {
   Slice,
   Slider,
   Speech,
+  type SpeechElement,
   Subtitle,
   Swipe,
   TalkingHead,
   Title,
   Video,
+  type VideoElement,
 } from "./elements";
 export { compile } from "./ir/compile";
 export { type ExecuteOptions, executePlan } from "./ir/execute";

--- a/src/react/primitives/audio.ts
+++ b/src/react/primitives/audio.ts
@@ -13,6 +13,8 @@ export { extractAudio } from "./extract";
 export {
   computeSoundBounds,
   detectSilence,
+  type RefineWordTimingsOptions,
+  refineWordTimings,
   type SilenceDetectOptions,
   type TimeRange,
 } from "./silence";

--- a/src/react/primitives/silence.ts
+++ b/src/react/primitives/silence.ts
@@ -101,6 +101,68 @@ function parseSilenceRanges(stderr: string): TimeRange[] {
   return ranges;
 }
 
+export interface RefineWordTimingsOptions {
+  /**
+   * Minimum remaining duration of the first/last word after clamping,
+   * in seconds. Default 0.05.
+   */
+  minWordDuration?: number;
+}
+
+/**
+ * Refine whisper word timings against measured silence intervals.
+ *
+ * Whisper is a seq2seq transcriber, not a frame-level speech detector: its
+ * word timestamps come from attention alignment, and leading silence/noise
+ * frames have no tokens of their own — their attention mass is absorbed by
+ * the FIRST word, which gets `start = 0` even when speech begins ~1s in
+ * (the ep5 case: "I" at 0.000 under a second of footsteps/ambience).
+ * The tail is symmetric: the last word's `end` stretches toward EOF.
+ *
+ * ffmpeg silencedetect measures signal energy directly, so silence knows
+ * the truth whisper lost. Rules:
+ * - leading silence [0, T): clamp `words[0].start` up to
+ *   `min(T, words[0].end − minWordDuration)`
+ * - trailing silence [S, duration]: clamp `words[last].end` down to
+ *   `max(S, words[last].start + minWordDuration)`
+ * - middle words are never touched (ambient noise between words must not
+ *   fragment speech)
+ *
+ * No leading/trailing silence found → no-op. Returns new objects; input
+ * is not mutated.
+ */
+export function refineWordTimings<W extends { start: number; end: number }>(
+  words: W[],
+  silences: TimeRange[],
+  duration: number,
+  options: RefineWordTimingsOptions = {},
+): W[] {
+  if (words.length === 0) return words;
+  const minWord = options.minWordDuration ?? 0.05;
+  const result = words.map((w) => ({ ...w }));
+
+  for (const s of silences) {
+    // Leading silence: starts at (or near) 0 and covers the first word's start
+    if (s.start <= 0.05) {
+      const first = result[0]!;
+      if (first.start < s.end) {
+        first.start = Math.min(
+          s.end,
+          Math.max(first.start, first.end - minWord),
+        );
+      }
+    }
+    // Trailing silence: runs to (or near) EOF and covers the last word's end
+    if (duration > 0 && s.end >= duration - 0.05) {
+      const last = result[result.length - 1]!;
+      if (last.end > s.start) {
+        last.end = Math.max(s.start, Math.min(last.end, last.start + minWord));
+      }
+    }
+  }
+  return result;
+}
+
 /**
  * Compute the bounds of audible content: `start` of the first sound and
  * `end` of the last sound, derived from silence intervals.

--- a/src/react/renderers/ass.test.ts
+++ b/src/react/renderers/ass.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import {
+  convertSrtToAss,
+  convertSrtToAssGrouped,
+  monotonizeEntries,
+  type SubtitleStyle,
+} from "./ass";
+
+const STYLE: SubtitleStyle = {
+  fontName: "Arial",
+  fontSize: 64,
+  primaryColor: "&H00FFFFFF",
+  outlineColor: "&H00000000",
+  backColor: "&H00000000",
+  bold: false,
+  outline: 2,
+  shadow: 0,
+  alignment: 2,
+  marginV: 10,
+};
+
+/** The ep5 incident shape: whisper emitted "can't" starting BEFORE the
+ *  previous words ended (3.18 < 3.56/3.72), producing two stacked caption
+ *  lines on screen. Real timings from /tmp/varg-captions-1784659084338.srt. */
+const EP5_WORDS = [
+  { start: 3.14, end: 3.279, text: "be" },
+  { start: 3.279, end: 3.56, text: "honest" },
+  { start: 3.56, end: 3.72, text: "I" },
+  { start: 3.18, end: 3.96, text: "can't" }, // ← overlaps the previous two
+  { start: 3.96, end: 4.139, text: "get" },
+];
+
+function toSrt(words: { start: number; end: number; text: string }[]): string {
+  const fmt = (t: number) => {
+    const h = Math.floor(t / 3600);
+    const m = Math.floor((t % 3600) / 60);
+    const s = Math.floor(t % 60);
+    const ms = Math.round((t % 1) * 1000);
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")},${String(ms).padStart(3, "0")}`;
+  };
+  return words
+    .map((w, i) => `${i + 1}\n${fmt(w.start)} --> ${fmt(w.end)}\n${w.text}`)
+    .join("\n\n");
+}
+
+function parseDialogueTimes(ass: string): Array<[number, number]> {
+  const t = (ts: string) => {
+    const [h, m, s] = ts.split(":");
+    return Number(h) * 3600 + Number(m) * 60 + Number(s);
+  };
+  return [...ass.matchAll(/^Dialogue:\s*\d+,([\d:.]+),([\d:.]+),/gm)].map(
+    (m) => [t(m[1]!), t(m[2]!)],
+  );
+}
+
+function assertNoOverlaps(times: Array<[number, number]>) {
+  const sorted = [...times].sort((a, b) => a[0] - b[0]);
+  for (let i = 1; i < sorted.length; i++) {
+    expect(sorted[i]![0]).toBeGreaterThanOrEqual(sorted[i - 1]![1] - 1e-9);
+  }
+}
+
+describe("monotonizeEntries", () => {
+  test("passes through already-monotonic entries unchanged", () => {
+    const entries = [
+      { index: 1, start: 0, end: 0.5, text: "a" },
+      { index: 2, start: 0.5, end: 1.0, text: "b" },
+    ];
+    expect(monotonizeEntries(entries)).toEqual(entries);
+  });
+
+  test("clamps a start that precedes the previous end (ep5 shape)", () => {
+    const entries = EP5_WORDS.map((w, i) => ({ index: i, ...w }));
+    const fixed = monotonizeEntries(entries);
+    // "can't" start clamped from 3.18 to "I".end (3.72)
+    expect(fixed[3]!.start).toBeCloseTo(3.72, 5);
+    expect(fixed[3]!.end).toBeCloseTo(3.96, 5);
+    // Strictly monotonic overall
+    for (let i = 1; i < fixed.length; i++) {
+      expect(fixed[i]!.start).toBeGreaterThanOrEqual(fixed[i - 1]!.end);
+    }
+  });
+
+  test("clamps end to start when a cue collapses entirely", () => {
+    const entries = [
+      { index: 1, start: 0, end: 2.0, text: "long" },
+      { index: 2, start: 0.5, end: 1.0, text: "swallowed" },
+      { index: 3, start: 2.5, end: 3.0, text: "after" },
+    ];
+    const fixed = monotonizeEntries(entries);
+    // "swallowed" collapses to zero-length at 2.0 rather than going negative
+    expect(fixed[1]!.start).toBe(2.0);
+    expect(fixed[1]!.end).toBe(2.0);
+    // Later entries unaffected
+    expect(fixed[2]!.start).toBe(2.5);
+  });
+
+  test("does not mutate the input", () => {
+    const entries = [{ index: 1, start: 1, end: 0.5, text: "x" }];
+    monotonizeEntries(entries);
+    expect(entries[0]!.end).toBe(0.5);
+  });
+});
+
+describe("convertSrtToAssGrouped with overlapping whisper timings", () => {
+  test("ep5 shape produces no overlapping Dialogue events", () => {
+    const { ass } = convertSrtToAssGrouped(
+      toSrt(EP5_WORDS),
+      STYLE,
+      1080,
+      1920,
+      3,
+      "&H35E6A3",
+    );
+    assertNoOverlaps(parseDialogueTimes(ass));
+  });
+
+  test("without activeColor (plain groups) also stays non-overlapping", () => {
+    const { ass } = convertSrtToAssGrouped(
+      toSrt(EP5_WORDS),
+      STYLE,
+      1080,
+      1920,
+      3,
+    );
+    assertNoOverlaps(parseDialogueTimes(ass));
+  });
+});
+
+describe("convertSrtToAss with overlapping timings", () => {
+  test("no overlapping Dialogue events", () => {
+    const { ass } = convertSrtToAss(toSrt(EP5_WORDS), STYLE, 1080, 1920);
+    assertNoOverlaps(parseDialogueTimes(ass));
+  });
+});

--- a/src/react/renderers/ass.ts
+++ b/src/react/renderers/ass.ts
@@ -141,6 +141,34 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 `;
 }
 
+/**
+ * Enforce monotonic, non-overlapping entry timings.
+ *
+ * Whisper word timestamps are not guaranteed monotonic — a word's start can
+ * precede the previous word's end (ep5: "I" 3.56-3.72 followed by "can't"
+ * 3.18-3.96). Cue generation trusts these timings, so overlaps leak into
+ * overlapping Dialogue events that ASS renders stacked (two caption lines
+ * on screen at once).
+ *
+ * Rules, in order:
+ * - start is clamped to the previous entry's (adjusted) end
+ * - end is clamped to be >= start (zero-length allowed; grouped rendering
+ *   derives per-word ends from the next word's start anyway)
+ *
+ * Returns new objects; input is not mutated.
+ */
+export function monotonizeEntries(entries: SrtEntry[]): SrtEntry[] {
+  const result: SrtEntry[] = [];
+  let prevEnd = Number.NEGATIVE_INFINITY;
+  for (const entry of entries) {
+    const start = Math.max(entry.start, prevEnd);
+    const end = Math.max(entry.end, start);
+    result.push({ ...entry, start, end });
+    prevEnd = end;
+  }
+  return result;
+}
+
 export function convertSrtToAss(
   srtContent: string,
   style: SubtitleStyle,
@@ -152,7 +180,7 @@ export function convertSrtToAss(
 ): { ass: string; emojiData: EntryEmojiData[] } {
   const assHeader = buildAssHeader(style, width, height);
   const nSpaces = spacesPerEmoji ?? 1;
-  const entries = parseSrt(srtContent);
+  const entries = monotonizeEntries(parseSrt(srtContent));
   const emojiData: EntryEmojiData[] = [];
 
   const assDialogues = entries
@@ -212,7 +240,7 @@ export function convertSrtToAssGrouped(
 ): { ass: string; emojiData: EntryEmojiData[] } {
   const assHeader = buildAssHeader(style, width, height);
   const nSpaces = spacesPerEmoji ?? 1;
-  const entries: SrtEntry[] = parseSrt(srtContent);
+  const entries: SrtEntry[] = monotonizeEntries(parseSrt(srtContent));
   const dialogues: string[] = [];
   const emojiData: EntryEmojiData[] = [];
   const baseColor = style.primaryColor;

--- a/src/react/renderers/captions.ts
+++ b/src/react/renderers/captions.ts
@@ -225,6 +225,26 @@ async function resolveSrtContent(
   }
   const audioPath = await ctx.backend.resolvePath(speechFile);
 
+  // AudioNode src (video.audio / speech.audio) — use the node's own
+  // memoized transcribe(): shares one whisper call + silence-refined
+  // boundaries with speechRange(), so captions and auto-trim agree on
+  // when speech starts (whisper alone absorbs leading ambience into the
+  // first word, putting captions on screen before anyone speaks).
+  const maybeNode = props.src as Partial<import("../audio-element").AudioNode>;
+  if (
+    props.src.type === "audio" &&
+    typeof maybeNode.transcribe === "function"
+  ) {
+    const { words } = await maybeNode.transcribe();
+    if (words && words.length > 0) {
+      const srtContent = convertToSRT(words as GroqWord[]);
+      const srtPath = `/tmp/varg-captions-${Date.now()}.srt`;
+      writeFileSync(srtPath, srtContent);
+      ctx.tempFiles.push(srtPath);
+      return { srtContent, srtPath, audioPath };
+    }
+  }
+
   // Check for native word timings (ElevenLabs alignment) — skip Whisper if present
   const nativeWords =
     props.src instanceof ResolvedElement

--- a/src/react/renderers/captions.ts
+++ b/src/react/renderers/captions.ts
@@ -40,6 +40,7 @@ import {
   getSpaceWidth,
   parseASSSegments,
 } from "./text-measure";
+import { uniqueTempPath } from "./utils";
 
 export interface CaptionsResult {
   assPath: string;
@@ -154,7 +155,7 @@ export async function renderCaptions(
         srtHasEmoji,
         spacesPerEmoji,
       );
-  const assPath = `/tmp/varg-captions-${Date.now()}.ass`;
+  const assPath = uniqueTempPath("varg-captions", "ass");
   writeFileSync(assPath, assContent);
   ctx.tempFiles.push(assPath);
 
@@ -238,7 +239,7 @@ async function resolveSrtContent(
     const { words } = await maybeNode.transcribe();
     if (words && words.length > 0) {
       const srtContent = convertToSRT(words as GroqWord[]);
-      const srtPath = `/tmp/varg-captions-${Date.now()}.srt`;
+      const srtPath = uniqueTempPath("varg-captions", "srt");
       writeFileSync(srtPath, srtContent);
       ctx.tempFiles.push(srtPath);
       return { srtContent, srtPath, audioPath };
@@ -253,7 +254,7 @@ async function resolveSrtContent(
 
   if (nativeWords && nativeWords.length > 0) {
     const srtContent = convertToSRT(nativeWords as GroqWord[]);
-    const srtPath = `/tmp/varg-captions-${Date.now()}.srt`;
+    const srtPath = uniqueTempPath("varg-captions", "srt");
     writeFileSync(srtPath, srtContent);
     ctx.tempFiles.push(srtPath);
     return { srtContent, srtPath, audioPath };
@@ -304,7 +305,7 @@ async function resolveSrtContent(
     words && words.length > 0
       ? convertToSRT(words)
       : `1\n00:00:00,000 --> 00:00:05,000\n${fallbackText}\n`;
-  const srtPath = `/tmp/varg-captions-${Date.now()}.srt`;
+  const srtPath = uniqueTempPath("varg-captions", "srt");
   writeFileSync(srtPath, srtContent);
   ctx.tempFiles.push(srtPath);
 

--- a/src/react/renderers/flatten.ts
+++ b/src/react/renderers/flatten.ts
@@ -5,11 +5,38 @@
  * Extracted from render.ts so renderRoot stays a thin orchestrator.
  */
 
-import type { VargElement } from "../types";
+import type { ClipProps, VargElement } from "../types";
 
 export interface HoistedCaption {
   element: VargElement<"captions">;
   clipIndex: number;
+  /**
+   * Trim window of the leaf clip the captions were hoisted from.
+   * Caption cue timings reference the clip's RAW media (whisper transcribes
+   * the untrimmed audio), but the timeline shows [cutFrom, cutTo]. The
+   * caption merge uses this window to re-base, drop, and clamp cues.
+   * Absent for container/render-level captions (untrimmed window).
+   */
+  window?: CaptionWindow;
+}
+
+export interface CaptionWindow {
+  /** Leaf clip's cutFrom (seconds into the raw media). */
+  cutFrom: number;
+  /** Leaf clip's cutTo (seconds into the raw media), if set. */
+  cutTo?: number;
+  /** Leaf clip's timeline duration, if numeric. */
+  duration?: number;
+}
+
+/** Extract the caption trim window from a leaf clip's props. */
+function captionWindow(props: ClipProps): CaptionWindow | undefined {
+  const cutFrom = props.cutFrom;
+  const cutTo = props.cutTo;
+  const duration =
+    typeof props.duration === "number" ? props.duration : undefined;
+  if (cutFrom === undefined && cutTo === undefined) return undefined;
+  return { cutFrom: cutFrom ?? 0, cutTo, duration };
 }
 
 export interface DeferredAudio {
@@ -56,12 +83,14 @@ export function flattenClips(rootChildren: VargElement[]): FlattenResult {
     if (childClips.length === 0) {
       // Leaf clip — hoist captions, keep everything else
       const currentClipIndex = clipIndexCounter++;
+      const window = captionWindow(clipElement.props as ClipProps);
       const kept: typeof clipElement.children = [];
       for (const el of nonClipChildren) {
         if (el.type === "captions") {
           hoistedCaptions.push({
             element: el as VargElement<"captions">,
             clipIndex: currentClipIndex,
+            window,
           });
         } else {
           kept.push(el);

--- a/src/react/renderers/merge-ass.test.ts
+++ b/src/react/renderers/merge-ass.test.ts
@@ -231,3 +231,17 @@ describe("mergeAssFiles", () => {
     ]);
   });
 });
+
+describe("uniqueTempPath (regression: Date.now collision)", () => {
+  test("rapid successive calls never collide", async () => {
+    const { uniqueTempPath } = await import("./utils");
+    // Memoized transcripts made 12 caption conversions land in the same
+    // millisecond — Date.now()-only paths collided (12 clips -> 7 files)
+    // and clips displayed each other's captions.
+    const paths = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      paths.add(uniqueTempPath("varg-captions", "ass"));
+    }
+    expect(paths.size).toBe(100);
+  });
+});

--- a/src/react/renderers/merge-ass.test.ts
+++ b/src/react/renderers/merge-ass.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync, writeFileSync } from "node:fs";
+import { mergeAssFiles, shiftAssTimestamps, transformCue } from "./merge-ass";
+
+// ---------------------------------------------------------------------------
+// transformCue — the single shift/drop/clamp primitive
+// ---------------------------------------------------------------------------
+describe("transformCue", () => {
+  test("no window: plain shift by timeOffset (legacy behavior)", () => {
+    expect(transformCue(1, 2, 10)).toEqual({ start: 11, end: 12 });
+    expect(transformCue(0, 0.5, 0)).toEqual({ start: 0, end: 0.5 });
+  });
+
+  test("window with cutFrom: shift = timeOffset - cutFrom", () => {
+    // Clip trimmed to start at 0.8s of raw media, placed at 10s on timeline.
+    // A cue at raw 1.0-2.0 shows at timeline 10.2-11.2.
+    const cue = transformCue(1.0, 2.0, 10, { cutFrom: 0.8 });
+    expect(cue!.start).toBeCloseTo(10.2, 5);
+    expect(cue!.end).toBeCloseTo(11.2, 5);
+  });
+
+  test("drops cue entirely before cutFrom", () => {
+    expect(transformCue(0.1, 0.7, 10, { cutFrom: 0.8 })).toBeNull();
+  });
+
+  test("drops cue entirely after cutTo", () => {
+    expect(transformCue(5.6, 6.0, 10, { cutFrom: 0.8, cutTo: 5.5 })).toBeNull();
+  });
+
+  test("clamps cue partially before cutFrom", () => {
+    // Raw cue 0.5-1.5, window starts at 0.8 → visible part 0.8-1.5,
+    // re-based to timeline 10 → 10-10.7.
+    const cue = transformCue(0.5, 1.5, 10, { cutFrom: 0.8 });
+    expect(cue!.start).toBeCloseTo(10, 5);
+    expect(cue!.end).toBeCloseTo(10.7, 5);
+  });
+
+  test("clamps cue partially after cutTo — end never exceeds clip end", () => {
+    // Whisper's trailing word often ends after our cutTo. Raw cue 5.0-5.9,
+    // window [0.8, 5.5] at offset 10 → clamped to raw 5.0-5.5 →
+    // timeline 14.2-14.7. Clip on timeline spans [10, 14.7] — no bleed
+    // into the next clip.
+    const cue = transformCue(5.0, 5.9, 10, { cutFrom: 0.8, cutTo: 5.5 });
+    expect(cue!.start).toBeCloseTo(14.2, 5);
+    expect(cue!.end).toBeCloseTo(14.7, 5);
+  });
+
+  test("cutTo derived from cutFrom + duration when cutTo absent", () => {
+    const cue = transformCue(3.9, 4.6, 0, { cutFrom: 0.5, duration: 4 });
+    // Window is [0.5, 4.5]: cue clamps to 3.9-4.5, shift = -0.5
+    expect(cue!.start).toBeCloseTo(3.4, 5);
+    expect(cue!.end).toBeCloseTo(4.0, 5);
+  });
+
+  test("drops zero-width cue after clamping", () => {
+    expect(transformCue(5.5, 5.9, 0, { cutFrom: 0, cutTo: 5.5 })).toBeNull();
+  });
+
+  test("adjacent clips never overlap after clamping", () => {
+    // Clip A: raw window [0.2, 5.6], timeline offset 0 → spans [0, 5.4]
+    // Clip B: raw window [0.1, 3.0], timeline offset 5.4
+    // Whisper tail cue in A (5.3-6.1) must clamp to end ≤ 5.4.
+    const tailA = transformCue(5.3, 6.1, 0, { cutFrom: 0.2, cutTo: 5.6 });
+    const headB = transformCue(0.1, 0.9, 5.4, { cutFrom: 0.1, cutTo: 3.0 });
+    expect(tailA!.end).toBeCloseTo(5.4, 5);
+    expect(headB!.start).toBeCloseTo(5.4, 5);
+    expect(tailA!.end).toBeLessThanOrEqual(headB!.start + 1e-9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File-level helpers
+// ---------------------------------------------------------------------------
+const ASS_HEADER = `[Script Info]
+Title: Test
+ScriptType: v4.00+
+PlayResX: 1080
+PlayResY: 1920
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,64,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+`;
+
+function writeAss(dialogues: string[]): string {
+  const path = `/tmp/varg-test-${Date.now()}-${Math.random().toString(36).slice(2)}.ass`;
+  writeFileSync(path, ASS_HEADER + dialogues.join("\n") + "\n");
+  return path;
+}
+
+function dialogueTimes(content: string): Array<[string, string]> {
+  return [...content.matchAll(/^Dialogue:\s*\d+,([^,]+),([^,]+),/gm)].map(
+    (m) => [m[1]!, m[2]!],
+  );
+}
+
+describe("shiftAssTimestamps", () => {
+  test("plain offset without window (legacy)", () => {
+    const src = writeAss([
+      "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,hello",
+    ]);
+    const out = shiftAssTimestamps(src, 10);
+    const times = dialogueTimes(readFileSync(out, "utf-8"));
+    expect(times).toEqual([["0:00:11.00", "0:00:12.00"]]);
+  });
+
+  test("window: rebases by cutFrom and drops out-of-window cues", () => {
+    const src = writeAss([
+      "Dialogue: 0,0:00:00.10,0:00:00.70,Default,,0,0,0,,dropped-before",
+      "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,kept",
+      "Dialogue: 0,0:00:05.60,0:00:06.00,Default,,0,0,0,,dropped-after",
+    ]);
+    const out = shiftAssTimestamps(src, 10, { cutFrom: 0.8, cutTo: 5.5 });
+    const content = readFileSync(out, "utf-8");
+    const times = dialogueTimes(content);
+    expect(times).toEqual([["0:00:10.20", "0:00:11.20"]]);
+    expect(content).toContain("kept");
+    expect(content).not.toContain("dropped-before");
+    expect(content).not.toContain("dropped-after");
+  });
+
+  test("window: clamps whisper tail to cutTo", () => {
+    const src = writeAss([
+      "Dialogue: 0,0:00:05.00,0:00:05.90,Default,,0,0,0,,tail",
+    ]);
+    const out = shiftAssTimestamps(src, 10, { cutFrom: 0.8, cutTo: 5.5 });
+    const times = dialogueTimes(readFileSync(out, "utf-8"));
+    expect(times).toEqual([["0:00:14.20", "0:00:14.70"]]);
+  });
+});
+
+describe("mergeAssFiles", () => {
+  test("plain merge without windows (legacy behavior preserved)", () => {
+    const a = writeAss([
+      "Dialogue: 0,0:00:00.50,0:00:01.50,Default,,0,0,0,,first",
+    ]);
+    const b = writeAss([
+      "Dialogue: 0,0:00:00.20,0:00:01.00,Default,,0,0,0,,second",
+    ]);
+    const out = mergeAssFiles(
+      [
+        { assPath: a, timeOffset: 0, styleSuffix: "_0" },
+        { assPath: b, timeOffset: 6, styleSuffix: "_1" },
+      ],
+      1080,
+      1920,
+    );
+    const content = readFileSync(out, "utf-8");
+    const times = dialogueTimes(content);
+    expect(times).toEqual([
+      ["0:00:00.50", "0:00:01.50"],
+      ["0:00:06.20", "0:00:07.00"],
+    ]);
+    expect(content).toContain("Default_0");
+    expect(content).toContain("Default_1");
+  });
+
+  test("windows: rebase + no overlap at clip boundary", () => {
+    // Clip A: window [0.2, 5.6] at offset 0 → timeline [0, 5.4]
+    // Clip B: window [0.1, 3.0] at offset 5.4 → timeline [5.4, 8.3]
+    // A has a whisper tail cue ending past cutTo — the ep5 double-line bug.
+    const a = writeAss([
+      "Dialogue: 0,0:00:00.50,0:00:02.00,Default,,0,0,0,,a-body",
+      "Dialogue: 0,0:00:05.30,0:00:06.10,Default,,0,0,0,,a-tail",
+    ]);
+    const b = writeAss([
+      "Dialogue: 0,0:00:00.10,0:00:00.90,Default,,0,0,0,,b-head",
+    ]);
+    const out = mergeAssFiles(
+      [
+        {
+          assPath: a,
+          timeOffset: 0,
+          styleSuffix: "_0",
+          window: { cutFrom: 0.2, cutTo: 5.6 },
+        },
+        {
+          assPath: b,
+          timeOffset: 5.4,
+          styleSuffix: "_1",
+          window: { cutFrom: 0.1, cutTo: 3.0 },
+        },
+      ],
+      1080,
+      1920,
+    );
+    const content = readFileSync(out, "utf-8");
+    const times = dialogueTimes(content);
+    // a-body: 0.5-2.0 shifted by -0.2 → 0.3-1.8
+    // a-tail: clamped to 5.6, shifted by -0.2 → 5.1-5.4
+    // b-head: 0.1-0.9 shifted by 5.4-0.1=5.3 → 5.4-6.2
+    expect(times).toEqual([
+      ["0:00:00.30", "0:00:01.80"],
+      ["0:00:05.10", "0:00:05.40"],
+      ["0:00:05.40", "0:00:06.20"],
+    ]);
+    // No overlap: a-tail end (5.4) ≤ b-head start (5.4)
+  });
+
+  test("windows: drops cues outside, keeps clips without window untouched", () => {
+    const a = writeAss([
+      "Dialogue: 0,0:00:00.10,0:00:00.60,Default,,0,0,0,,dropped",
+      "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,kept-a",
+    ]);
+    const b = writeAss([
+      "Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,kept-b",
+    ]);
+    const out = mergeAssFiles(
+      [
+        {
+          assPath: a,
+          timeOffset: 0,
+          styleSuffix: "_0",
+          window: { cutFrom: 0.8, duration: 4 },
+        },
+        // No window — legacy plain shift
+        { assPath: b, timeOffset: 4, styleSuffix: "_1" },
+      ],
+      1080,
+      1920,
+    );
+    const content = readFileSync(out, "utf-8");
+    expect(content).not.toContain("dropped");
+    const times = dialogueTimes(content);
+    expect(times).toEqual([
+      ["0:00:00.20", "0:00:01.20"],
+      ["0:00:04.00", "0:00:05.00"],
+    ]);
+  });
+});

--- a/src/react/renderers/merge-ass.ts
+++ b/src/react/renderers/merge-ass.ts
@@ -1,9 +1,53 @@
 import { readFileSync, writeFileSync } from "node:fs";
+import type { CaptionWindow } from "./flatten";
 
 export interface AssSegment {
   assPath: string;
+  /** Timeline position of the clip these captions belong to. */
   timeOffset: number;
   styleSuffix?: string;
+  /**
+   * Trim window of the source clip, when it was trimmed with cutFrom/cutTo.
+   * Cue timestamps in the ASS reference the RAW (untrimmed) media, so:
+   * - effective shift = timeOffset - cutFrom (not just timeOffset)
+   * - cues entirely outside [cutFrom, cutTo] are dropped
+   * - cues partially outside are clamped to the window
+   */
+  window?: CaptionWindow;
+}
+
+/**
+ * Transform one cue's [start, end] (raw-media seconds) into timeline
+ * seconds for a clip at `timeOffset` with an optional trim window.
+ * Returns null when the cue should be dropped (entirely outside the window).
+ */
+export function transformCue(
+  start: number,
+  end: number,
+  timeOffset: number,
+  window?: CaptionWindow,
+): { start: number; end: number } | null {
+  if (!window) {
+    return { start: start + timeOffset, end: end + timeOffset };
+  }
+
+  const cutFrom = window.cutFrom;
+  // Upper bound in raw-media time: explicit cutTo, else cutFrom + duration.
+  const cutTo =
+    window.cutTo ??
+    (window.duration !== undefined ? cutFrom + window.duration : undefined);
+
+  // Drop cues entirely outside the window.
+  if (end <= cutFrom) return null;
+  if (cutTo !== undefined && start >= cutTo) return null;
+
+  // Clamp partially-outside cues to the window, then re-base to timeline.
+  const clampedStart = Math.max(start, cutFrom);
+  const clampedEnd = cutTo !== undefined ? Math.min(end, cutTo) : end;
+  if (clampedEnd <= clampedStart) return null;
+
+  const shift = timeOffset - cutFrom;
+  return { start: clampedStart + shift, end: clampedEnd + shift };
 }
 
 /**
@@ -36,19 +80,35 @@ function formatAssTime(seconds: number): string {
 }
 
 /**
- * Shift all Dialogue timestamps in an ASS file by `offset` seconds.
+ * Shift all Dialogue timestamps in an ASS file by `offset` seconds,
+ * optionally re-basing/clamping to a clip trim window (see transformCue).
+ * Cues dropped by the window are removed entirely.
  * Returns path to a new temp file.
  */
-export function shiftAssTimestamps(assPath: string, offset: number): string {
+export function shiftAssTimestamps(
+  assPath: string,
+  offset: number,
+  window?: CaptionWindow,
+): string {
   const content = readFileSync(assPath, "utf-8");
-  const shifted = content.replace(
-    /^(Dialogue:\s*\d+,)(\d+:\d{2}:\d{2}\.\d{2}),(\d+:\d{2}:\d{2}\.\d{2})/gm,
-    (_match, prefix: string, startTs: string, endTs: string) => {
-      const newStart = formatAssTime(parseAssTime(startTs) + offset);
-      const newEnd = formatAssTime(parseAssTime(endTs) + offset);
-      return `${prefix}${newStart},${newEnd}`;
-    },
-  );
+  const DROP = "\u0000DROP\u0000";
+  const shifted = content
+    .replace(
+      /^(Dialogue:\s*\d+,)(\d+:\d{2}:\d{2}\.\d{2}),(\d+:\d{2}:\d{2}\.\d{2})/gm,
+      (_match, prefix: string, startTs: string, endTs: string) => {
+        const cue = transformCue(
+          parseAssTime(startTs),
+          parseAssTime(endTs),
+          offset,
+          window,
+        );
+        if (!cue) return DROP;
+        return `${prefix}${formatAssTime(cue.start)},${formatAssTime(cue.end)}`;
+      },
+    )
+    .split("\n")
+    .filter((line) => !line.startsWith(DROP))
+    .join("\n");
   const outPath = `/tmp/varg-shifted-captions-${Date.now()}.ass`;
   writeFileSync(outPath, shifted);
   return outPath;
@@ -98,11 +158,17 @@ export function mergeAssFiles(
       const parts = dialogueLine.split(",");
       if (parts.length < 10) continue;
 
-      // Shift Start (index 1) and End (index 2)
-      const startTs = parts[1]!.trim();
-      const endTs = parts[2]!.trim();
-      parts[1] = formatAssTime(parseAssTime(startTs) + segment.timeOffset);
-      parts[2] = formatAssTime(parseAssTime(endTs) + segment.timeOffset);
+      // Re-base Start (index 1) and End (index 2) to the timeline,
+      // dropping/clamping cues via the segment's trim window.
+      const cue = transformCue(
+        parseAssTime(parts[1]!.trim()),
+        parseAssTime(parts[2]!.trim()),
+        segment.timeOffset,
+        segment.window,
+      );
+      if (!cue) continue;
+      parts[1] = formatAssTime(cue.start);
+      parts[2] = formatAssTime(cue.end);
 
       // Rename style reference (index 3)
       const styleName = parts[3]!.trim();

--- a/src/react/renderers/merge-ass.ts
+++ b/src/react/renderers/merge-ass.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import type { CaptionWindow } from "./flatten";
+import { uniqueTempPath } from "./utils";
 
 export interface AssSegment {
   assPath: string;
@@ -109,7 +110,7 @@ export function shiftAssTimestamps(
     .split("\n")
     .filter((line) => !line.startsWith(DROP))
     .join("\n");
-  const outPath = `/tmp/varg-shifted-captions-${Date.now()}.ass`;
+  const outPath = uniqueTempPath("varg-shifted-captions", "ass");
   writeFileSync(outPath, shifted);
   return outPath;
 }
@@ -196,7 +197,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 ${allDialogues.join("\n")}
 `;
 
-  const outPath = `/tmp/varg-merged-captions-${Date.now()}.ass`;
+  const outPath = uniqueTempPath("varg-merged-captions", "ass");
   writeFileSync(outPath, header);
   return outPath;
 }

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -36,7 +36,7 @@ import { createRenderContext, type PreparedRender } from "./context-builder";
 import type { EmojiOverlay } from "./emoji";
 import { type FlattenResult, flattenClips } from "./flatten";
 import { renderImage } from "./image";
-import { mergeAssFiles, shiftAssTimestamps } from "./merge-ass";
+import { mergeAssFiles, shiftAssTimestamps, transformCue } from "./merge-ass";
 import { renderMusic } from "./music";
 import { addTask, completeTask, startTask } from "./progress";
 import { renderSpeech } from "./speech";
@@ -345,26 +345,39 @@ export async function renderRoot(
     for (const {
       element: captionsElement,
       clipIndex,
+      window,
     } of flatten.hoistedCaptions) {
       const result = await renderCaptions(captionsElement, ctx);
       hoistedCaptionsResults.push(result);
 
       if (result.audioPath) {
+        // The audio file covers the RAW (untrimmed) clip — apply the same
+        // trim window so the mixed track matches what's on screen.
         audioTracks.push({
           path: result.audioPath,
           start: clipStartOffsets[clipIndex] ?? 0,
           mixVolume: 1,
+          cutFrom: window?.cutFrom,
+          cutTo:
+            window?.cutTo ??
+            (window && window.duration !== undefined
+              ? window.cutFrom + window.duration
+              : undefined),
         });
       }
     }
 
-    // Merge ASS files: shift timestamps by each clip's start offset
+    // Merge ASS files: re-base cue timestamps from raw-clip time to the
+    // timeline (shift by clip offset minus cutFrom, drop/clamp cues
+    // outside the clip's trim window — see transformCue).
     if (hoistedCaptionsResults.length === 1) {
-      const offset =
-        clipStartOffsets[flatten.hoistedCaptions[0]!.clipIndex] ?? 0;
+      const { clipIndex, window } = flatten.hoistedCaptions[0]!;
+      const offset = clipStartOffsets[clipIndex] ?? 0;
       const assPath = hoistedCaptionsResults[0]!.assPath;
       mergedAssPath =
-        offset > 0 ? shiftAssTimestamps(assPath, offset) : assPath;
+        offset > 0 || window
+          ? shiftAssTimestamps(assPath, offset, window)
+          : assPath;
       if (mergedAssPath !== assPath) {
         ctx.tempFiles.push(mergedAssPath);
       }
@@ -374,6 +387,7 @@ export async function renderRoot(
         timeOffset:
           clipStartOffsets[flatten.hoistedCaptions[i]!.clipIndex] ?? 0,
         styleSuffix: `_${i}`,
+        window: flatten.hoistedCaptions[i]!.window,
       }));
       mergedAssPath = mergeAssFiles(segments, ctx.width, ctx.height);
       ctx.tempFiles.push(mergedAssPath);
@@ -449,20 +463,24 @@ export async function renderRoot(
     }
     const allFontFiles = [...fontFileMap.values()];
 
-    // Collect emoji overlays from all caption results, shifting timing by clip offsets
+    // Collect emoji overlays from all caption results, re-basing timing
+    // from raw-clip time to the timeline (same shift/drop/clamp as cues).
     const allEmojiOverlays: EmojiOverlay[] = [];
     for (let i = 0; i < hoistedCaptionsResults.length; i++) {
       const result = hoistedCaptionsResults[i]!;
-      const offset =
-        clipStartOffsets[flatten.hoistedCaptions[i]!.clipIndex] ?? 0;
+      const { clipIndex, window } = flatten.hoistedCaptions[i]!;
+      const offset = clipStartOffsets[clipIndex] ?? 0;
       for (const overlay of result.emojiOverlays ?? []) {
+        const cue = transformCue(
+          overlay.startTime,
+          overlay.endTime,
+          offset,
+          window,
+        );
+        if (!cue) continue;
         allEmojiOverlays.push(
-          offset > 0
-            ? {
-                ...overlay,
-                startTime: overlay.startTime + offset,
-                endTime: overlay.endTime + offset,
-              }
+          cue.start !== overlay.startTime || cue.end !== overlay.endTime
+            ? { ...overlay, startTime: cue.start, endTime: cue.end }
             : overlay,
         );
       }

--- a/src/react/renderers/utils.ts
+++ b/src/react/renderers/utils.ts
@@ -10,6 +10,22 @@ export function resolvePath(path: string): string {
   return resolve(process.cwd(), path);
 }
 
+let tempCounter = 0;
+
+/**
+ * Collision-free temp file path.
+ *
+ * `Date.now()` alone has millisecond resolution — two renders in the same
+ * millisecond get the SAME path and silently overwrite each other's files.
+ * This bit ep5 hard once caption transcripts became memoized: 12 clips'
+ * ASS files collapsed into 7, and mergeAssFiles composed neighboring
+ * clips' captions over the wrong video. A process-wide counter makes
+ * every path unique regardless of timing.
+ */
+export function uniqueTempPath(prefix: string, ext: string): string {
+  return `/tmp/${prefix}-${Date.now()}-${tempCounter++}.${ext}`;
+}
+
 export function toFileUrl(path: string): string {
   if (path.startsWith("http://") || path.startsWith("https://")) {
     return path;

--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -63,6 +63,58 @@ export function getActiveCache(): CacheStorage {
 }
 
 // ---------------------------------------------------------------------------
+// In-flight resolve memoization — one element, one generation
+// ---------------------------------------------------------------------------
+/**
+ * The computation graph invariant: a single VargElement resolves at most
+ * once, no matter how many paths lead to it.
+ *
+ * Without this, N concurrent consumers of a shared element (e.g. 12 async
+ * components whose videos all reference the same location card) each start
+ * their own generation: the `meta?.file` check only catches *finished*
+ * resolves, so concurrent paths all see `undefined` and fire N parallel
+ * API calls (the ep5 incident: 52 jobs for one image, 429 retry storm).
+ *
+ * Keyed by element identity (WeakMap), not cache key — this is graph
+ * semantics, not caching. Two textually identical but distinct elements
+ * stay distinct nodes (the disk cache still collapses them by cacheKey).
+ *
+ * A rejected promise stays memoized, consistent with `makeThenable` and
+ * the renderers' `pendingFiles` — re-awaiting a failed element re-throws
+ * the same error instead of re-spending money.
+ */
+const inFlightResolves = new WeakMap<object, Promise<ResolvedElement<never>>>();
+
+function memoizedElementResolve<T extends VargElement["type"]>(
+  element: VargElement<T>,
+  fn: () => Promise<ResolvedElement<T>>,
+): Promise<ResolvedElement<T>> {
+  // Fast path: already resolved (awaited earlier, or meta written back).
+  if (element.meta?.file) {
+    return Promise.resolve(
+      element instanceof ResolvedElement
+        ? (element as ResolvedElement<T>)
+        : new ResolvedElement(element, element.meta),
+    );
+  }
+
+  const existing = inFlightResolves.get(element);
+  if (existing) return existing as Promise<ResolvedElement<T>>;
+
+  const promise = fn().then((resolved) => {
+    // Write meta back onto the original element so every other path
+    // (renderers, executePlan, compile) sees it as pre-resolved.
+    element.meta = resolved.meta;
+    return resolved;
+  });
+  inFlightResolves.set(
+    element,
+    promise as unknown as Promise<ResolvedElement<never>>,
+  );
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
 // Duration probing — uses backend.ffprobe() when available, local ffprobe otherwise
 // ---------------------------------------------------------------------------
 /** Probe an audio/video file's duration in seconds. Uses backend.ffprobe() when available. */
@@ -404,7 +456,16 @@ function serializeSegment(seg: Segment): CachedSegment {
 // ---------------------------------------------------------------------------
 
 /** Generate speech audio via the AI SDK and return a ResolvedElement with duration metadata. */
-export async function resolveSpeechElement(
+export function resolveSpeechElement(
+  element: VargElement<"speech">,
+  props: SpeechProps,
+): Promise<ResolvedElement<"speech">> {
+  return memoizedElementResolve(element, () =>
+    resolveSpeechElementImpl(element, props),
+  );
+}
+
+async function resolveSpeechElementImpl(
   element: VargElement<"speech">,
   props: SpeechProps,
 ): Promise<ResolvedElement<"speech">> {
@@ -624,7 +685,16 @@ async function resolveImagePrompt(
 }
 
 /** Generate an image via the AI SDK (or load from src) and return a ResolvedElement. */
-export async function resolveImageElement(
+export function resolveImageElement(
+  element: VargElement<"image">,
+  props: ImageProps,
+): Promise<ResolvedElement<"image">> {
+  return memoizedElementResolve(element, () =>
+    resolveImageElementImpl(element, props),
+  );
+}
+
+async function resolveImageElementImpl(
   element: VargElement<"image">,
   props: ImageProps,
 ): Promise<ResolvedElement<"image">> {
@@ -695,7 +765,16 @@ export async function resolveImageElement(
 // Video
 // ---------------------------------------------------------------------------
 /** Generate a video via the AI SDK (or load from src) and return a ResolvedElement. */
-export async function resolveVideoElement(
+export function resolveVideoElement(
+  element: VargElement<"video">,
+  props: Record<string, unknown>,
+): Promise<ResolvedElement<"video">> {
+  return memoizedElementResolve(element, () =>
+    resolveVideoElementImpl(element, props),
+  );
+}
+
+async function resolveVideoElementImpl(
   element: VargElement<"video">,
   props: Record<string, unknown>,
 ): Promise<ResolvedElement<"video">> {
@@ -1073,7 +1152,16 @@ export async function resolveProbeElement(
 // Music
 // ---------------------------------------------------------------------------
 /** Generate music audio via the AI SDK and return a ResolvedElement with duration metadata. */
-export async function resolveMusicElement(
+export function resolveMusicElement(
+  element: VargElement<"music">,
+  props: MusicProps,
+): Promise<ResolvedElement<"music">> {
+  return memoizedElementResolve(element, () =>
+    resolveMusicElementImpl(element, props),
+  );
+}
+
+async function resolveMusicElementImpl(
   element: VargElement<"music">,
   props: MusicProps,
 ): Promise<ResolvedElement<"music">> {
@@ -1125,16 +1213,17 @@ export async function resolveMusicElement(
  *   preserving word timings and duration.
  * - `src` → load the file directly and probe duration.
  */
-export async function resolveAudioElement(
+export function resolveAudioElement(
   element: VargElement<"audio">,
 ): Promise<ResolvedElement<"audio">> {
-  // Already resolved (pre-seeded from a resolved audio-file parent)
-  if (element.meta?.file) {
-    return element instanceof ResolvedElement
-      ? (element as ResolvedElement<"audio">)
-      : new ResolvedElement(element, element.meta);
-  }
+  return memoizedElementResolve(element, () =>
+    resolveAudioElementImpl(element),
+  );
+}
 
+async function resolveAudioElementImpl(
+  element: VargElement<"audio">,
+): Promise<ResolvedElement<"audio">> {
   const props = element.props as AudioElementProps;
 
   if (props.src) {
@@ -1235,7 +1324,16 @@ export async function resolveAudioElement(
  * 2. Resolve the speech from `audio` prop (generate or reuse pre-resolved)
  * 3. Generate lipsync video from image + audio via `model`
  */
-export async function resolveTalkingHeadElement(
+export function resolveTalkingHeadElement(
+  element: VargElement<"talking-head">,
+  props: TalkingHeadProps,
+): Promise<ResolvedElement<"talking-head">> {
+  return memoizedElementResolve(element, () =>
+    resolveTalkingHeadElementImpl(element, props),
+  );
+}
+
+async function resolveTalkingHeadElementImpl(
   element: VargElement<"talking-head">,
   props: TalkingHeadProps,
 ): Promise<ResolvedElement<"talking-head">> {

--- a/src/react/runtime/jsx-dev-runtime.ts
+++ b/src/react/runtime/jsx-dev-runtime.ts
@@ -66,4 +66,8 @@ export namespace JSX {
     // biome-ignore lint/complexity/noBannedTypes: required for JSX namespace
     children: {};
   }
+  /** Attributes accepted on every JSX element (the `key` prop). */
+  export interface IntrinsicAttributes {
+    key?: string | number;
+  }
 }

--- a/src/react/runtime/jsx-runtime.ts
+++ b/src/react/runtime/jsx-runtime.ts
@@ -64,4 +64,8 @@ export namespace JSX {
     // biome-ignore lint/complexity/noBannedTypes: required for JSX namespace
     children: {};
   }
+  /** Attributes accepted on every JSX element (the `key` prop). */
+  export interface IntrinsicAttributes {
+    key?: string | number;
+  }
 }

--- a/src/react/tests/audio-refine.test.ts
+++ b/src/react/tests/audio-refine.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Word-timing refinement + AudioNode analysis memoization.
+ *
+ * The ep5 incident, part 3: whisper absorbed ~0.9s of leading ambience
+ * (footsteps, birds) into the first word — "I" got start=0.000, so
+ * captions appeared before anyone spoke AND speechRange-based auto-trim
+ * kept the silent lead-in (cutFrom = 0). refineWordTimings clamps the
+ * first/last word against ffmpeg-measured silence; AudioNode memoizes
+ * every analysis so all consumers share one transcription + one
+ * silencedetect run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { File } from "../../ai-sdk/file";
+import { Speech } from "../elements";
+import { refineWordTimings } from "../primitives/silence";
+import { ResolvedElement } from "../resolved-element";
+
+// ---------------------------------------------------------------------------
+// refineWordTimings — pure unit tests
+// ---------------------------------------------------------------------------
+describe("refineWordTimings", () => {
+  // The ep5 shape: speech actually starts ~0.87s in, whisper said 0.000.
+  const EP5_WORDS = [
+    { word: "I", start: 0.0, end: 0.66 },
+    { word: "really", start: 0.66, end: 1.62 },
+    { word: "love", start: 1.62, end: 1.96 },
+  ];
+
+  test("leading silence clamps the first word's start (ep5 shape)", () => {
+    const refined = refineWordTimings(
+      EP5_WORDS,
+      [{ start: 0, end: 0.87 }], // measured leading silence
+      6,
+    );
+    expect(refined[0]!.start).toBeCloseTo(0.66 - 0.05, 5); // min(0.87, end-minWord)
+    // Middle words untouched
+    expect(refined[1]).toEqual(EP5_WORDS[1]!);
+    expect(refined[2]).toEqual(EP5_WORDS[2]!);
+  });
+
+  test("first word keeps minWordDuration when silence covers it entirely", () => {
+    const refined = refineWordTimings(
+      [{ word: "hey", start: 0.0, end: 0.3 }],
+      [{ start: 0, end: 0.9 }],
+      6,
+    );
+    // start clamped to end - 0.05, not to 0.9 (word must survive)
+    expect(refined[0]!.start).toBeCloseTo(0.25, 5);
+    expect(refined[0]!.end).toBe(0.3);
+  });
+
+  test("trailing silence clamps the last word's end", () => {
+    const words = [
+      { word: "done", start: 4.0, end: 6.0 }, // stretched to EOF by whisper
+    ];
+    const refined = refineWordTimings(words, [{ start: 4.6, end: 6.0 }], 6);
+    expect(refined[0]!.end).toBeCloseTo(4.6, 5);
+    expect(refined[0]!.start).toBe(4.0);
+  });
+
+  test("no leading/trailing silence — no-op", () => {
+    const words = [{ word: "hi", start: 0.1, end: 0.5 }];
+    // Mid-clip silence only
+    const refined = refineWordTimings(words, [{ start: 2, end: 3 }], 6);
+    expect(refined).toEqual(words);
+  });
+
+  test("empty inputs are safe", () => {
+    expect(refineWordTimings([], [{ start: 0, end: 1 }], 6)).toEqual([]);
+    const words = [{ word: "a", start: 0, end: 1 }];
+    expect(refineWordTimings(words, [], 6)).toEqual(words);
+  });
+
+  test("does not mutate input", () => {
+    const words = [{ word: "I", start: 0.0, end: 0.66 }];
+    refineWordTimings(words, [{ start: 0, end: 0.5 }], 6);
+    expect(words[0]!.start).toBe(0.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AudioNode analysis memoization
+// ---------------------------------------------------------------------------
+function makeResolvedSpeech(
+  words?: { word: string; start: number; end: number }[],
+) {
+  const speech = Speech({ voice: "adam", children: "hello" });
+  const file = File.fromGenerated({
+    uint8Array: new Uint8Array([0, 1, 2, 3]),
+    mediaType: "audio/mpeg",
+  });
+  return new ResolvedElement(speech, { file, duration: 3, words });
+}
+
+describe("AudioNode analysis memoization", () => {
+  test("repeated speechRange() calls return the same promise", () => {
+    const audio = makeResolvedSpeech([
+      { word: "hi", start: 0.2, end: 0.6 },
+    ]).audio;
+    const a = audio.speechRange({ pad: 0.15 });
+    const b = audio.speechRange({ pad: 0.15 });
+    expect(a).toBe(b);
+  });
+
+  test("different options produce independent memo entries", () => {
+    const audio = makeResolvedSpeech([
+      { word: "hi", start: 0.2, end: 0.6 },
+    ]).audio;
+    const a = audio.speechRange({ pad: 0.15 });
+    const b = audio.speechRange({ pad: 0.3 });
+    expect(a).not.toBe(b);
+  });
+
+  test("transcribe() is memoized and shared with speechRange()", async () => {
+    const audio = makeResolvedSpeech([
+      { word: "hello", start: 0.42, end: 0.9 },
+      { word: "world", start: 1.0, end: 2.31 },
+    ]).audio;
+
+    const t1 = audio.transcribe();
+    const t2 = audio.transcribe();
+    expect(t1).toBe(t2);
+
+    // Native words path: no whisper, no silencedetect — range comes straight
+    // from the shared transcript.
+    const range = await audio.speechRange();
+    expect(range).toEqual({ start: 0.42, end: 2.31 });
+  });
+
+  test("native ElevenLabs words are never refined (trusted alignment)", async () => {
+    // Native words legitimately start at 0 (TTS starts speaking at once).
+    const audio = makeResolvedSpeech([
+      { word: "hello", start: 0.0, end: 0.5 },
+    ]).audio;
+    const { words } = await audio.transcribe();
+    expect(words[0]!.start).toBe(0.0);
+  });
+});

--- a/src/react/tests/resolve-dedup.test.ts
+++ b/src/react/tests/resolve-dedup.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Graph invariant: one element = one generation, no matter how many
+ * concurrent paths lead to it.
+ *
+ * Regression tests for the ep5 incident: 12 async components awaiting
+ * `vid.audio.speechRange()` concurrently resolved shared dependency
+ * images through the standalone resolve path, which had no in-flight
+ * dedup — one location card produced 52 API jobs.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { Image, Video } from "../elements";
+import { resolveImageElement, resolveVideoElement } from "../resolve";
+import type { ImageProps } from "../types";
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10]);
+
+function makeCountingImageModel(counter: { calls: number }) {
+  return {
+    specificationVersion: "v3",
+    provider: "mock",
+    modelId: "mock-image",
+    maxImagesPerCall: 1,
+    doGenerate: mock(async () => {
+      counter.calls++;
+      // Simulate network latency so concurrent callers overlap in-flight.
+      await new Promise((r) => setTimeout(r, 30));
+      return {
+        images: [PNG_BYTES],
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: "mock-image",
+          headers: undefined,
+        },
+      };
+    }),
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock model
+  } as any;
+}
+
+describe("standalone resolve in-flight dedup", () => {
+  test("concurrent resolveImageElement calls for the same element generate once", async () => {
+    const counter = { calls: 0 };
+    const img = Image({
+      prompt: "a shared location card",
+      model: makeCountingImageModel(counter),
+    });
+
+    const results = await Promise.all([
+      resolveImageElement(img, img.props as ImageProps),
+      resolveImageElement(img, img.props as ImageProps),
+      resolveImageElement(img, img.props as ImageProps),
+    ]);
+
+    expect(counter.calls).toBe(1);
+    // All callers observe the same resolved file
+    expect(results[1]!.meta.file).toBe(results[0]!.meta.file);
+    expect(results[2]!.meta.file).toBe(results[0]!.meta.file);
+    // Meta written back — later paths see the element as pre-resolved
+    expect(img.meta?.file).toBe(results[0]!.meta.file);
+  });
+
+  test("sequential re-resolve after completion does not regenerate", async () => {
+    const counter = { calls: 0 };
+    const img = Image({
+      prompt: "resolve me twice",
+      model: makeCountingImageModel(counter),
+    });
+
+    const first = await resolveImageElement(img, img.props as ImageProps);
+    const second = await resolveImageElement(img, img.props as ImageProps);
+
+    expect(counter.calls).toBe(1);
+    expect(second.meta.file).toBe(first.meta.file);
+  });
+
+  test("ep5 shape: concurrent videos sharing one input image generate it once", async () => {
+    const counter = { calls: 0 };
+    const shared = Image({
+      prompt: "the one location card",
+      model: makeCountingImageModel(counter),
+    });
+
+    const videoCounter = { calls: 0 };
+    const videoModel = {
+      specificationVersion: "v3",
+      provider: "mock",
+      modelId: "mock-video",
+      doGenerate: mock(async () => {
+        videoCounter.calls++;
+        await new Promise((r) => setTimeout(r, 10));
+        return {
+          videos: [PNG_BYTES],
+          warnings: [],
+          response: {
+            timestamp: new Date(),
+            modelId: "mock-video",
+            headers: undefined,
+          },
+        };
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock model
+    } as any;
+
+    // 3 distinct videos, all referencing the SAME image element — the ep5
+    // dependency shape (12 videos -> 4 composites -> 1 locTrail).
+    const videos = [1, 2, 3].map((i) =>
+      Video({
+        prompt: { text: `scene ${i}`, images: [shared] },
+        model: videoModel,
+      }),
+    );
+
+    const settled = await Promise.allSettled(
+      videos.map((v) =>
+        resolveVideoElement(v, v.props as Record<string, unknown>),
+      ),
+    );
+
+    // The shared image resolved exactly once regardless of video outcomes —
+    // this is the ep5 regression assertion (was 12 parallel generations).
+    expect(counter.calls).toBe(1);
+    // Videos are distinct elements — all three resolve successfully.
+    // (No exact assert on videoCounter: generateVideo goes through the
+    // disk cache, so doGenerate may be skipped on cache hits.)
+    const fulfilled = settled.filter((s) => s.status === "fulfilled");
+    expect(fulfilled.length).toBe(3);
+    expect(videoCounter.calls).toBeLessThanOrEqual(3);
+  });
+
+  test("failed resolve stays memoized — no silent money re-spend on re-await", async () => {
+    let calls = 0;
+    const failingModel = {
+      specificationVersion: "v3",
+      provider: "mock",
+      modelId: "mock-failing",
+      maxImagesPerCall: 1,
+      doGenerate: mock(async () => {
+        calls++;
+        throw new Error("provider exploded");
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock model
+    } as any;
+    const img = Image({ prompt: "doomed", model: failingModel });
+
+    const [a, b] = await Promise.allSettled([
+      resolveImageElement(img, img.props as ImageProps),
+      resolveImageElement(img, img.props as ImageProps),
+    ]);
+    expect(a!.status).toBe("rejected");
+    expect(b!.status).toBe("rejected");
+    expect(calls).toBe(1);
+
+    // Re-awaiting the failed element re-throws without a new API call.
+    const c = await resolveImageElement(img, img.props as ImageProps).catch(
+      (e) => e,
+    );
+    expect(c).toBeInstanceOf(Error);
+    expect(calls).toBe(1);
+  });
+
+  test("distinct elements with identical props remain distinct graph nodes", async () => {
+    const counter = { calls: 0 };
+    const model = makeCountingImageModel(counter);
+    const a = Image({ prompt: "same prompt", model });
+    const b = Image({ prompt: "same prompt", model });
+
+    await Promise.all([
+      resolveImageElement(a, a.props as ImageProps),
+      resolveImageElement(b, b.props as ImageProps),
+    ]);
+
+    // Identity-keyed memoization: two elements, two resolves. (The disk
+    // cache collapses them by cacheKey in real runs; with a mock model
+    // and no shared cache both hit the model.)
+    expect(counter.calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Three fixes from the formula-care-ep5 production incident (rate-limit storm + caption timing bugs). Targets `feature/ir-compile-audio` (PR #223). Closes the root cause analyzed in #225.

### 1. Captions in trimmed clips — double lines + timing drift

Caption cues are generated in RAW (untrimmed) clip time, but clips trimmed with `cutFrom/cutTo` (e.g. by `speechRange()` auto-trim) start elsewhere on the timeline. Previously only `+ clipStartOffset` was applied:

- **Error A (shift):** captions lagged by `cutFrom` seconds per clip. Correct shift is `clipStartOffset − cutFrom`.
- **Error B (no clamp):** whisper's trailing cue often ends past `cutTo` and bled over the next clip's captions — the double-line frames at clip boundaries (~82s in ep5).

Fix:
- `flatten.ts`: `HoistedCaption` carries the leaf clip's trim window (`cutFrom/cutTo/duration`)
- `merge-ass.ts`: new `transformCue` — single shift/drop/clamp primitive used by both the single-caption path and `mergeAssFiles`; cues fully outside the window are dropped, partial ones clamped (cue end of clip N can never exceed cue start of clip N+1)
- `render.ts`: emoji overlays go through the same transform; `withAudio` caption tracks carry `cutFrom/cutTo` into the audio mix
- Clips without trims behave byte-identically to before (covered by tests)

### 2. In-flight resolve dedup — 52 jobs for one image (#225 root cause)

Production DB showed 123 jobs in 7 min for ~8 unique requests. The standalone resolve path (`resolveImageElement` etc.) had no in-flight dedup: N concurrent async components racing through `speechRange() → resolveAudioElement → resolveVideoElement → resolveImageElement` toward one shared dependency image all saw `meta === undefined` and fired N parallel generations — bypassing both `makeThenable` memoization (nested elements are resolved via direct calls) and the renderers' `pendingFiles`.

Fix: `memoizedElementResolve` in `resolve.ts` — WeakMap keyed by **element identity**, wrapping all standalone resolvers (image/video/speech/music/talking-head/audio). Graph invariant: one element resolves at most once no matter how many concurrent paths lead to it. Meta write-back keeps renderers/executePlan/compile seeing resolved elements; rejected promises stay memoized (no silent re-spend on re-await).

### 3. Idempotency-Key on job submission — retry storm multiplier

Every 429 retry in `submitJob` created a brand-new job (all 123 incident jobs had `idempotency_key = NULL`), refilling the rate window as it reset. Fix: stable `Idempotency-Key` header — hash of (capability, canonicalized params) — so retries reference the same job. Verified live: the API stores the key on created jobs.

### Also included
- Named element type exports: `VideoElement` / `SpeechElement` / `ImageElement` (no more `ReturnType<typeof Video>` in user code)
- `key` prop in JSX `IntrinsicAttributes`
- `examples/async/native-audio-scene1.tsx` — the target-API example, now typechecking

## Verification

- **26 new unit tests**, all green (88 total in affected suites): `merge-ass.test.ts` (15 — shift/drop/clamp/boundary/legacy), `resolve-dedup.test.ts` (5 — concurrent dedup, ep5 shape, failure memoization, distinct-elements), `varg-idempotency.test.ts` (6 — key stability/canonicalization)
- **Live API reproducer** (cheap, ~$0.13): ep5 dependency shape with flux-schnell + nano-banana/edit — 3 async components concurrently resolving images that nest one shared image. Result: exactly 4 jobs for 4 unique requests, shared image generated once, zero rate-limit warnings, all jobs carry idempotency keys (verified in `be_varg_jobs`)
- `bunx tsc --noEmit` clean

## Not done (deliberate)
- Frame-by-frame ep5 boundary check requires an ep5 re-render (deferred per cost policy); timings are covered by unit tests. Checklist when rendered: no double caption lines at ~26/40/53/66/80-83s.
- Concurrency semaphore for the resolveLazy phase — de-escalated follow-up in #225 (with dedup, unique-call counts fit the 60/min window).

Refs #225