### PR TITLE
fix: bound generation concurrency during the resolveLazy phase

### DIFF
--- a/src/ai-sdk/cache.test.ts
+++ b/src/ai-sdk/cache.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `withCache`'s optional concurrency limiter (sdk#225).
+ *
+ * The limiter guards the expensive underlying call only — cache hits must
+ * never queue for a slot, or a fully cached render would serialize its
+ * cache reads behind a semaphore that exists to protect API traffic.
+ */
+
+import { describe, expect, test } from "bun:test";
+import pLimit from "p-limit";
+import { type CacheStorage, withCache } from "./cache";
+
+function createMemoryCache(): CacheStorage & { store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    async get(key) {
+      return store.get(key);
+    },
+    async set(key, value) {
+      store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+  };
+}
+
+/** Async fn that records peak overlap. */
+function makeTrackedFn(latencyMs = 10) {
+  const state = { active: 0, maxActive: 0, calls: 0 };
+  const fn = async (options: { id: number }) => {
+    state.calls++;
+    state.active++;
+    state.maxActive = Math.max(state.maxActive, state.active);
+    await new Promise((r) => setTimeout(r, latencyMs));
+    state.active--;
+    return { value: options.id };
+  };
+  return { fn, state };
+}
+
+describe("withCache limit option", () => {
+  test("caps concurrent underlying calls on cache miss", async () => {
+    const { fn, state } = makeTrackedFn();
+    const cached = withCache(fn, {
+      storage: createMemoryCache(),
+      limit: pLimit(2),
+    });
+
+    await Promise.all(
+      [1, 2, 3, 4, 5, 6].map((id) => cached({ id, cacheKey: [`k${id}`] })),
+    );
+
+    expect(state.calls).toBe(6);
+    expect(state.maxActive).toBe(2);
+  });
+
+  test("cache hits bypass the limiter entirely", async () => {
+    const { fn, state } = makeTrackedFn();
+    const storage = createMemoryCache();
+    const warm = withCache(fn, { storage, limit: pLimit(4) });
+    await Promise.all(
+      [1, 2, 3, 4].map((id) => warm({ id, cacheKey: [`hit${id}`] })),
+    );
+    expect(state.calls).toBe(4);
+
+    // A limit of 1 would serialize these if hits took slots; the call
+    // count staying flat proves the underlying fn was never invoked.
+    const cold = withCache(fn, { storage, limit: pLimit(1) });
+    const results = await Promise.all(
+      [1, 2, 3, 4].map((id) => cold({ id, cacheKey: [`hit${id}`] })),
+    );
+
+    expect(state.calls).toBe(4);
+    expect(results.map((r) => r.value)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("limits uncached calls too (no cacheKey)", async () => {
+    // Without a cacheKey withCache passes straight through — that path
+    // still hits the API, so it must still respect the limit.
+    const { fn, state } = makeTrackedFn();
+    const cached = withCache(fn, {
+      storage: createMemoryCache(),
+      limit: pLimit(2),
+    });
+
+    await Promise.all([1, 2, 3, 4, 5].map((id) => cached({ id })));
+
+    expect(state.calls).toBe(5);
+    expect(state.maxActive).toBe(2);
+  });
+
+  test("omitting limit preserves unbounded behavior", async () => {
+    const { fn, state } = makeTrackedFn();
+    const cached = withCache(fn, { storage: createMemoryCache() });
+
+    await Promise.all(
+      [1, 2, 3, 4, 5].map((id) => cached({ id, cacheKey: [`u${id}`] })),
+    );
+
+    expect(state.maxActive).toBe(5);
+  });
+
+  test("a rejected call releases its slot", async () => {
+    let calls = 0;
+    const fn = async ({ id }: { id: number }) => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 5));
+      if (id === 1) throw new Error("boom");
+      return { value: id };
+    };
+    const cached = withCache(fn, {
+      storage: createMemoryCache(),
+      limit: pLimit(1),
+    });
+
+    const settled = await Promise.allSettled(
+      [1, 2, 3].map((id) => cached({ id, cacheKey: [`e${id}`] })),
+    );
+
+    // A leaked slot would deadlock the remaining calls instead of settling.
+    expect(settled[0]!.status).toBe("rejected");
+    expect(settled[1]!.status).toBe("fulfilled");
+    expect(settled[2]!.status).toBe("fulfilled");
+    expect(calls).toBe(3);
+  });
+});

--- a/src/ai-sdk/cache.ts
+++ b/src/ai-sdk/cache.ts
@@ -1,3 +1,5 @@
+import type { LimitFunction } from "p-limit";
+
 export interface CacheStorage {
   get(key: string): Promise<unknown | undefined>;
   set(key: string, value: unknown, ttl?: number): Promise<void>;
@@ -7,6 +9,16 @@ export interface CacheStorage {
 export interface WithCacheOptions {
   ttl?: number | string;
   storage?: CacheStorage;
+  /**
+   * Optional concurrency limiter applied to the *underlying* call.
+   *
+   * Only cache MISSES consume a slot — a cache hit returns without
+   * queueing, so a fully cached run never serializes on the limiter.
+   * Used by the standalone resolve path (async components running during
+   * `resolveLazy`, before `executePlan` and its `concurrency` cap exist)
+   * to bound real API traffic. See sdk#225.
+   */
+  limit?: LimitFunction;
 }
 
 type CacheKeyDeps = (string | number | boolean | null | undefined)[];
@@ -119,11 +131,15 @@ export function withCache<T extends object, R>(
   const storage = options.storage ?? defaultStorage;
   const ttl = parseTTL(options.ttl ?? DEFAULT_TTL);
   const prefix = fn.name || "anonymous";
+  const limit = options.limit;
+  // Only the real call is limited; cache lookups stay unbounded.
+  const call = (input: T): Promise<R> =>
+    limit ? limit(() => fn(input)) : fn(input);
   return async (opts: WithCacheKey<T>): Promise<R> => {
     const { cacheKey, skipCacheWrite, ...rest } = opts;
 
     if (!cacheKey) {
-      return fn(rest as T);
+      return call(rest as T);
     }
 
     const key = depsToKey(prefix, cacheKey);
@@ -131,7 +147,7 @@ export function withCache<T extends object, R>(
     if (cached !== undefined) {
       return cached as R;
     }
-    const result = await fn(rest as T);
+    const result = await call(rest as T);
     if (!skipCacheWrite) {
       const flattened = flatten(result);
       await storage.set(key, flattened, ttl);

--- a/src/react/primitives/transcribe.ts
+++ b/src/react/primitives/transcribe.ts
@@ -10,7 +10,7 @@ import { experimental_transcribe as transcribe } from "ai";
 import type { CacheStorage } from "../../ai-sdk/cache";
 import type { File } from "../../ai-sdk/file";
 import type { WordTiming } from "../../speech/types";
-import { getResolveContext } from "../resolve-context";
+import { getActiveLimit, getResolveContext } from "../resolve-context";
 
 export interface TranscriptionResult {
   text: string;
@@ -102,18 +102,24 @@ export async function transcribeAudio(
   // varg API and don't accept groq-specific providerOptions. Direct Groq
   // calls need responseFormat + timestampGranularities for word timings.
   const isGatewayModel = options.model !== undefined;
-  const result = await transcribe({
-    model,
-    audio: data,
-    providerOptions: isGatewayModel
-      ? {}
-      : {
-          groq: {
-            responseFormat: "verbose_json",
-            timestampGranularities: ["word"],
+  // Cache miss — this is a real API call, so it takes a limiter slot.
+  // transcribeAudio hand-rolls its cache instead of using withCache, so
+  // the limit is applied here directly. Transcription was the third leg
+  // of the ep5 fan-out: 12 async components => 12 parallel POSTs (sdk#225).
+  const result = await getActiveLimit()(() =>
+    transcribe({
+      model,
+      audio: data,
+      providerOptions: isGatewayModel
+        ? {}
+        : {
+            groq: {
+              responseFormat: "verbose_json",
+              timestampGranularities: ["word"],
+            },
           },
-        },
-  });
+    }),
+  );
 
   const words = extractWordTimings(result);
   const transcription: TranscriptionResult = { text: result.text, words };

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -1,3 +1,4 @@
+import pLimit from "p-limit";
 import { localBackend } from "../ai-sdk/providers/editly";
 import { compile } from "./ir/compile";
 import { executePlan } from "./ir/execute";
@@ -8,6 +9,7 @@ import {
 } from "./renderers/context-builder";
 import { renderRoot } from "./renderers/render";
 import { resolveLazy } from "./renderers/resolve-lazy";
+import { resolveConcurrency } from "./renderers/utils";
 import { type ResolveContext, withResolveContext } from "./resolve-context";
 import type { RenderOptions, RenderResult, VargElement } from "./types";
 
@@ -32,6 +34,11 @@ async function prepare(
     cache,
     storage: options.storage,
     defaults: options.defaults,
+    // Same knob and default as executePlan's `concurrency`: async
+    // components generating during resolveLazy are subject to the same
+    // budget as steps generating during executePlan. Previously this
+    // phase was unbounded — a bypass, not a feature (sdk#225).
+    limit: pLimit(resolveConcurrency(options.concurrency)),
   };
 
   // Resolve lazy elements (from async components) within the resolve context.

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -40,7 +40,7 @@ import { mergeAssFiles, shiftAssTimestamps, transformCue } from "./merge-ass";
 import { renderMusic } from "./music";
 import { addTask, completeTask, startTask } from "./progress";
 import { renderSpeech } from "./speech";
-import { resolvePath } from "./utils";
+import { resolveConcurrency, resolvePath } from "./utils";
 import { renderVideo } from "./video";
 
 interface RenderedOverlay {
@@ -187,14 +187,7 @@ export async function renderRoot(
   audioTracks.push(...overlayAudio);
 
   // 3. Render clips in parallel
-  const concurrency =
-    options.concurrency === undefined ? 3 : options.concurrency;
-  if (
-    concurrency !== Number.POSITIVE_INFINITY &&
-    (!Number.isInteger(concurrency) || concurrency < 1)
-  ) {
-    throw new Error("render option `concurrency` must be a positive integer");
-  }
+  const concurrency = resolveConcurrency(options.concurrency);
 
   const clipResults = await pMap(
     flatten.clipElements,

--- a/src/react/renderers/utils.ts
+++ b/src/react/renderers/utils.ts
@@ -10,6 +10,25 @@ export function resolvePath(path: string): string {
   return resolve(process.cwd(), path);
 }
 
+/**
+ * Normalize the `concurrency` render option into a positive integer (or
+ * Infinity), throwing the SDK's own error message rather than p-limit's
+ * TypeError.
+ *
+ * Shared by the resolveLazy limiter and the clip-render pMap so a bad
+ * value fails identically no matter which phase reaches it first.
+ */
+export function resolveConcurrency(concurrency: number | undefined): number {
+  const value = concurrency === undefined ? 3 : concurrency;
+  if (
+    value !== Number.POSITIVE_INFINITY &&
+    (!Number.isInteger(value) || value < 1)
+  ) {
+    throw new Error("render option `concurrency` must be a positive integer");
+  }
+  return value;
+}
+
 let tempCounter = 0;
 
 /**

--- a/src/react/resolve-context.ts
+++ b/src/react/resolve-context.ts
@@ -10,6 +10,7 @@
  * and resolve functions fall back to local defaults.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import pLimit, { type LimitFunction } from "p-limit";
 import type { CacheStorage } from "../ai-sdk/cache";
 import type { FFmpegBackend } from "../ai-sdk/providers/editly/backends";
 import type { StorageProvider } from "../ai-sdk/storage/types";
@@ -25,6 +26,21 @@ export interface ResolveContext {
   storage?: StorageProvider;
   /** Default models from RenderOptions — used for transcription fallback. */
   defaults?: DefaultModels;
+  /**
+   * Concurrency limiter for the resolveLazy phase — the counterpart of
+   * `executePlan`'s `concurrency` option.
+   *
+   * Async components generate during `resolveLazy`, which runs BEFORE
+   * `executePlan`, so the executor's cap never applies to them. Without
+   * this, N async components fan out N unbounded parallel API calls
+   * (the ep5 incident: ~36-42 simultaneous requests against a 60/min
+   * window, then a self-sustaining 429 retry storm).
+   *
+   * Only leaf network calls are wrapped — never whole resolvers. A
+   * resolver holding a slot while awaiting a nested dependency that is
+   * itself queued behind it would deadlock. See sdk#225.
+   */
+  limit?: LimitFunction;
 }
 
 const resolveContextStorage = new AsyncLocalStorage<ResolveContext>();
@@ -37,4 +53,30 @@ export function getResolveContext(): ResolveContext | undefined {
 /** Run a function with a resolve context available via getResolveContext(). */
 export function withResolveContext<T>(ctx: ResolveContext, fn: () => T): T {
   return resolveContextStorage.run(ctx, fn);
+}
+
+/** Matches executePlan's default `concurrency`. */
+const DEFAULT_RESOLVE_CONCURRENCY = 3;
+
+/**
+ * Fallback limiter for top-level `await Image()` / `await Video()` outside
+ * render(), where no ResolveContext (and therefore no `concurrency` option)
+ * exists. A script doing `Promise.all([...100 images])` at top level has the
+ * same fan-out problem as an async component, just without a render around it.
+ */
+let localLimit: LimitFunction | undefined;
+
+/**
+ * The limiter guarding real generation calls in the standalone resolve path.
+ *
+ * From the ResolveContext when running inside render() (sharing the render's
+ * `concurrency` budget), otherwise a lazily-created module-level fallback.
+ */
+export function getActiveLimit(): LimitFunction {
+  const ctxLimit = getResolveContext()?.limit;
+  if (ctxLimit) return ctxLimit;
+  if (!localLimit) {
+    localLimit = pLimit(DEFAULT_RESOLVE_CONCURRENCY);
+  }
+  return localLimit;
 }

--- a/src/react/resolve.ts
+++ b/src/react/resolve.ts
@@ -11,7 +11,7 @@
  */
 
 import {
-  generateImage,
+  generateImage as generateImageRaw,
   experimental_generateSpeech as generateSpeechAI,
 } from "ai";
 import { $ } from "bun";
@@ -31,7 +31,7 @@ import type {
 } from "../speech/types";
 import { extractAudio } from "./primitives/audio";
 import { computeCacheKey, getTextContent } from "./renderers/utils";
-import { getResolveContext } from "./resolve-context";
+import { getActiveLimit, getResolveContext } from "./resolve-context";
 import { ResolvedElement } from "./resolved-element";
 import type {
   AudioElementProps,
@@ -181,26 +181,32 @@ async function trimVideoLocal(
 }
 
 // ---------------------------------------------------------------------------
-// Cached video generation — uses context cache when available
+// Cached generation — uses the context cache and concurrency limit when
+// available. The limiter is passed to withCache rather than wrapped around
+// it, so cache hits resolve immediately instead of queueing for a slot.
 // ---------------------------------------------------------------------------
 /** Get a cached generateVideo wrapper using the active cache storage. */
 function getCachedGenerateVideo() {
-  const ctx = getResolveContext();
-  const storage = ctx?.cache ?? getLocalCache();
-  return withCache(generateVideoRaw, { storage });
+  return withCache(generateVideoRaw, {
+    storage: getActiveCache(),
+    limit: getActiveLimit(),
+  });
 }
 
 /** Get a cached generateMusic wrapper using the active cache storage. */
 function getCachedGenerateMusic() {
-  const ctx = getResolveContext();
-  const storage = ctx?.cache ?? getLocalCache();
-  return withCache(generateMusicRaw, { storage });
+  return withCache(generateMusicRaw, {
+    storage: getActiveCache(),
+    limit: getActiveLimit(),
+  });
 }
 
 /** Get a cached generateSpeech wrapper using the active cache storage. */
 function getCachedGenerateSpeech() {
-  const storage = getActiveCache();
-  return withCache(generateSpeechAI, { storage });
+  return withCache(generateSpeechAI, {
+    storage: getActiveCache(),
+    limit: getActiveLimit(),
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -724,16 +730,25 @@ async function resolveImageElementImpl(
   }
 
   const cacheKey = computeCacheKey(element);
+  // Nested image inputs are resolved BEFORE taking a limiter slot — a
+  // parent holding a slot while awaiting a child queued behind it would
+  // deadlock. Same ordering in every resolver below.
   const resolvedPrompt = await resolveImagePrompt(prompt);
 
-  const { images } = await generateImage({
-    model,
-    prompt: resolvedPrompt,
-    aspectRatio: props.aspectRatio,
-    providerOptions: props.providerOptions,
-    n: 1,
-    cacheKey,
-  } as Parameters<typeof generateImage>[0]);
+  // NOTE: this path deliberately calls the RAW generateImage — unlike
+  // video/music/speech it is not withCache-wrapped, so `cacheKey` below is
+  // inert here. Wiring up the cache is a separate behavior change (it would
+  // start persisting standalone image generations); out of scope for #225.
+  const { images } = await getActiveLimit()(() =>
+    generateImageRaw({
+      model,
+      prompt: resolvedPrompt,
+      aspectRatio: props.aspectRatio,
+      providerOptions: props.providerOptions,
+      n: 1,
+      cacheKey,
+    } as Parameters<typeof generateImageRaw>[0]),
+  );
 
   const firstImage = images[0];
   if (!firstImage?.uint8Array) {

--- a/src/react/tests/resolve-concurrency.test.ts
+++ b/src/react/tests/resolve-concurrency.test.ts
@@ -1,0 +1,280 @@
+/**
+ * The resolveLazy phase honors the render's `concurrency` budget.
+ *
+ * Async components generate during `resolveLazy`, which runs BEFORE
+ * `executePlan` — so the executor's concurrency cap never applied to
+ * them. ep5 (12 async components each awaiting `vid.audio.speechRange()`)
+ * fanned out ~36-42 simultaneous API calls against a 60/min window and
+ * then sustained a 429 retry storm.
+ *
+ * Dedup (resolve-dedup.test.ts) removed the *duplicate* calls; these
+ * tests cover the *unique* ones, which are still unbounded without a
+ * limiter. See sdk#225.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import pLimit from "p-limit";
+import type { CacheStorage } from "../../ai-sdk/cache";
+import type { FFmpegBackend } from "../../ai-sdk/providers/editly/backends";
+import { Image, Video } from "../elements";
+import { resolveImageElement, resolveVideoElement } from "../resolve";
+import { withResolveContext } from "../resolve-context";
+import type { ImageProps } from "../types";
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10]);
+
+/** Tracks peak simultaneous in-flight calls across a set of mock models. */
+function makeConcurrencyTracker() {
+  return { active: 0, maxActive: 0, calls: 0 };
+}
+
+type Tracker = ReturnType<typeof makeConcurrencyTracker>;
+
+/** Mock image model that records how many generations overlap in time. */
+function makeTrackingImageModel(t: Tracker, latencyMs = 20) {
+  return {
+    specificationVersion: "v3",
+    provider: "mock",
+    modelId: "mock-image",
+    maxImagesPerCall: 1,
+    doGenerate: mock(async () => {
+      t.calls++;
+      t.active++;
+      t.maxActive = Math.max(t.maxActive, t.active);
+      await new Promise((r) => setTimeout(r, latencyMs));
+      t.active--;
+      return {
+        images: [PNG_BYTES],
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: "mock-image",
+          headers: undefined,
+        },
+      };
+    }),
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock model
+  } as any;
+}
+
+/** Mock video model with the same in-flight accounting. */
+function makeTrackingVideoModel(t: Tracker, latencyMs = 20) {
+  return {
+    specificationVersion: "v3",
+    provider: "mock",
+    modelId: "mock-video",
+    doGenerate: mock(async () => {
+      t.calls++;
+      t.active++;
+      t.maxActive = Math.max(t.maxActive, t.active);
+      await new Promise((r) => setTimeout(r, latencyMs));
+      t.active--;
+      return {
+        videos: [PNG_BYTES],
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: "mock-video",
+          headers: undefined,
+        },
+      };
+    }),
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock model
+  } as any;
+}
+
+/**
+ * In-memory cache so tests never touch the user's real `.cache/ai`
+ * (generation cache is production data — see CLAUDE.md cache policy).
+ */
+function createMemoryCache(): CacheStorage & { store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    async get(key) {
+      return store.get(key);
+    },
+    async set(key, value) {
+      store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+  };
+}
+
+const stubBackend = {
+  name: "mock",
+  async ffprobe() {
+    return { duration: 0, width: 0, height: 0 };
+  },
+  async resolvePath() {
+    return "/tmp/mock";
+  },
+  async run() {
+    return { output: { type: "file" as const, path: "/tmp/mock-output.mp4" } };
+  },
+} as unknown as FFmpegBackend;
+
+describe("resolveLazy concurrency limit", () => {
+  test("caps simultaneous generations at the context limit", async () => {
+    const t = makeConcurrencyTracker();
+    const model = makeTrackingImageModel(t);
+    // 10 DISTINCT elements — dedup cannot collapse these; only a
+    // semaphore bounds them.
+    const images = Array.from({ length: 10 }, (_, i) =>
+      Image({ prompt: `distinct scene ${i}`, model }),
+    );
+
+    await withResolveContext(
+      { backend: stubBackend, cache: createMemoryCache(), limit: pLimit(3) },
+      () =>
+        Promise.all(
+          images.map((img) =>
+            resolveImageElement(img, img.props as ImageProps),
+          ),
+        ),
+    );
+
+    expect(t.calls).toBe(10);
+    expect(t.maxActive).toBe(3);
+  });
+
+  test("without a limit the same graph fans out unbounded (the bug)", async () => {
+    const t = makeConcurrencyTracker();
+    const model = makeTrackingImageModel(t);
+    const images = Array.from({ length: 10 }, (_, i) =>
+      Image({ prompt: `unbounded scene ${i}`, model }),
+    );
+
+    // limit: undefined would fall back to the module-level limiter, so to
+    // demonstrate the pre-fix behavior we hand it an explicit Infinity.
+    await withResolveContext(
+      {
+        backend: stubBackend,
+        cache: createMemoryCache(),
+        limit: pLimit(Number.POSITIVE_INFINITY),
+      },
+      () =>
+        Promise.all(
+          images.map((img) =>
+            resolveImageElement(img, img.props as ImageProps),
+          ),
+        ),
+    );
+
+    expect(t.maxActive).toBe(10);
+  });
+
+  test("nested dependencies do not deadlock at concurrency 1", async () => {
+    // The critical safety property: a video resolves its nested image
+    // INSIDE its own resolver. If the limiter wrapped whole resolvers, the
+    // parent would hold the only slot while waiting on a child queued
+    // behind it — permanent deadlock. Limiting only leaf network calls
+    // keeps this graph live even at concurrency 1.
+    const imgT = makeConcurrencyTracker();
+    const vidT = makeConcurrencyTracker();
+    const imageModel = makeTrackingImageModel(imgT, 5);
+    const videoModel = makeTrackingVideoModel(vidT, 5);
+
+    const videos = [1, 2, 3].map((i) =>
+      Video({
+        prompt: {
+          text: `scene ${i}`,
+          images: [Image({ prompt: `nested card ${i}`, model: imageModel })],
+        },
+        model: videoModel,
+      }),
+    );
+
+    const settled = await withResolveContext(
+      { backend: stubBackend, cache: createMemoryCache(), limit: pLimit(1) },
+      () =>
+        Promise.all(
+          videos.map((v) =>
+            resolveVideoElement(v, v.props as Record<string, unknown>),
+          ),
+        ),
+    );
+
+    expect(settled.length).toBe(3);
+    expect(imgT.calls).toBe(3);
+    expect(imgT.maxActive).toBe(1);
+    expect(vidT.maxActive).toBe(1);
+  });
+
+  test("cache hits do not consume a limiter slot", async () => {
+    // A fully cached run must not serialize on the limiter: cache reads
+    // are cheap and are not the resource the semaphore protects.
+    const t = makeConcurrencyTracker();
+    const model = makeTrackingVideoModel(t, 5);
+    const cache = createMemoryCache();
+
+    const makeVideos = () =>
+      [1, 2, 3, 4, 5].map((i) => Video({ prompt: `cached scene ${i}`, model }));
+
+    // Warm pass populates the cache.
+    await withResolveContext(
+      { backend: stubBackend, cache, limit: pLimit(5) },
+      () =>
+        Promise.all(
+          makeVideos().map((v) =>
+            resolveVideoElement(v, v.props as Record<string, unknown>),
+          ),
+        ),
+    );
+    expect(t.calls).toBe(5);
+
+    // Second pass: identical prompts, fresh elements, limit of 1. If cache
+    // hits took slots this would still succeed but only by queueing; the
+    // assertion that matters is that the model is never called again.
+    const before = t.calls;
+    await withResolveContext(
+      { backend: stubBackend, cache, limit: pLimit(1) },
+      () =>
+        Promise.all(
+          makeVideos().map((v) =>
+            resolveVideoElement(v, v.props as Record<string, unknown>),
+          ),
+        ),
+    );
+    expect(t.calls).toBe(before);
+  });
+
+  test("limiter and dedup compose: shared element still generates once", async () => {
+    const t = makeConcurrencyTracker();
+    const model = makeTrackingImageModel(t);
+    const shared = Image({ prompt: "the one location card", model });
+
+    await withResolveContext(
+      { backend: stubBackend, cache: createMemoryCache(), limit: pLimit(2) },
+      () =>
+        Promise.all(
+          Array.from({ length: 5 }, () =>
+            resolveImageElement(shared, shared.props as ImageProps),
+          ),
+        ),
+    );
+
+    // Dedup (WeakMap by element identity) is unaffected by the limiter.
+    expect(t.calls).toBe(1);
+  });
+
+  test("falls back to a bounded limiter with no resolve context", async () => {
+    // Top-level `await Promise.all([...])` outside render() has the same
+    // fan-out problem with no RenderOptions to configure. The module-level
+    // fallback (concurrency 3) bounds it.
+    const t = makeConcurrencyTracker();
+    const model = makeTrackingImageModel(t);
+    const images = Array.from({ length: 8 }, (_, i) =>
+      Image({ prompt: `top-level scene ${i}`, model }),
+    );
+
+    await Promise.all(
+      images.map((img) => resolveImageElement(img, img.props as ImageProps)),
+    );
+
+    expect(t.calls).toBe(8);
+    expect(t.maxActive).toBeLessThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
Closes the last open item on #225 (the semaphore follow-up, de-escalated after the dedup fix landed).

## Problem

Async components generate through the standalone resolve path during `resolveLazy` (`render.ts:41`), which runs **before** `executePlan` (`render.ts:95`). The executor caps at `concurrency ?? 3` (`ir/execute.ts:53`) — that cap never applied to the resolve phase.

ep5's 12 `DialogueClip`s each awaiting `vid.audio.speechRange()` fanned out ~36-42 simultaneous API calls against a 60/min window, then sustained a 429 retry storm.

PR #226's `memoizedElementResolve` removed the **duplicate** calls (52 jobs for one shared location card). The **unique** ones were still unbounded — so any graph with >60 unique generations reproduces the storm. That's what this fixes.

## Approach

`resolveLazy` now honors the same `concurrency` knob and default as `executePlan`. The unbounded phase was a bypass, not a feature.

Two constraints shaped the implementation:

**1. Limit leaf network calls only — never whole resolvers.** `resolveVideoElementImpl` resolves nested images *inside* itself, so a parent holding a slot while awaiting a child queued behind it would deadlock. Every resolver already materializes its deps before generating; a test pins this with a nested image-in-video graph at `concurrency: 1`.

**2. Cache hits must not consume a slot.** All four generators route through `withCache`. Wrapping the cached wrapper would make a fully cached render serialize its cache reads behind a semaphore that exists to protect API traffic. So `limit` is passed *into* `withCache` and applied only after a miss.

## Changes

| File | Change |
|---|---|
| `ai-sdk/cache.ts` | `WithCacheOptions.limit`, applied around the underlying call only. No-op when omitted, so the executor path (`context-builder.ts`) is untouched — double-limiting the same work would halve throughput. |
| `react/resolve-context.ts` | `ResolveContext.limit` + `getActiveLimit()`. Lives here, not `resolve.ts`, so `primitives/` can use it without an import cycle. |
| `react/render.ts` | `prepare()` builds `pLimit(resolveConcurrency(options.concurrency))`. Shared by `render()` and the streaming path. |
| `react/resolve.ts` | Limit threaded through the video/music/speech cached wrappers + the raw `generateImage` call. |
| `react/primitives/transcribe.ts` | `transcribeAudio` hand-rolls its cache instead of using `withCache`, so the limit is applied directly. Third leg of the ep5 fan-out (12 parallel `/v2/transcription`). |
| `react/renderers/utils.ts` | `resolveConcurrency()` extracted so both the limiter and the clip-render `pMap` reject a bad value with the SDK's own error rather than p-limit's `TypeError`. |

No new dependency — `p-limit@6.2.0` was already direct (`storage/retry.ts:8`).

## Behavior changes worth flagging

- **Cold-cache renders get slower.** ep5's 12 kling clips go from ~all-parallel to 4 waves of 3. That's the honest cost of restoring the documented contract; raise `concurrency` to opt out.
- **Top-level `await` is now bounded too.** Outside `render()` there's no `ResolveContext`, so a module-level `pLimit(3)` fallback applies. This closes the same fan-out hole for scripts doing `Promise.all([...100 images])`. Previously unbounded.

## Notes

- `resolveImageElementImpl` calls **raw** `generateImage` — unlike video/music/speech it is not `withCache`-wrapped, so the `cacheKey` it passes is inert. I left that as-is and documented it: wiring the cache up would start persisting standalone image generations, a money-affecting change that deserves its own PR. (I tried it, watched new `generateImage_*.json` entries appear in a real `.cache/ai`, and backed it out.)
- Architectural fix (executor-only generation, standalone resolvers as thin wrappers) remains tracked in #227. This PR restores the invariant within the current architecture.

## Tests

11 new: 6 in `react/tests/resolve-concurrency.test.ts`, 5 in `ai-sdk/cache.test.ts` (`withCache` had no test file). Covers the cap, the no-deadlock nested graph at concurrency 1, cache hits bypassing the limiter, limiter/dedup composition, the top-level fallback, and slot release on rejection.

Full `src/react` + `src/ai-sdk`: **433 → 444 pass**, failures **unchanged at 118** — all pre-existing opentype/font-metrics failures, verified by stashing this branch and re-running baseline.

Not verified: a real ep5 render (paid regeneration). Happy to run it on request.