### PR TITLE
fix: repair font loading broken by opentype.js 1.3.5 (emoji captions crash in prod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,30 @@ jobs:
 
       - name: Check
         run: bun run check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      # Scoped to suites that are hermetic: no API keys, no paid generation.
+      # `bun run check` (biome + tsc) cannot catch runtime breakage — the
+      # opentype.js 1.3.5 regression, which crashed every emoji caption render
+      # for ~2.5 months, typechecked cleanly because @types still declared the
+      # removed `loadSync()`. Only executing the code catches that class of bug.
+      #
+      # Deliberately excluded: suites needing API keys or a live service
+      # (.../rendi, storage/retry, providers/fal, providers/magnific), heavy
+      # ffmpeg media rendering (providers/editly, react.test.ts,
+      # warnings.test.ts, packshot, talking-head), and pricing.test.ts, which
+      # has 3 failures predating this workflow.
+      # Widen this list as those are fixed.
+      - name: Test (hermetic suites)
+        run: bun run test:ci

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "fluent-ffmpeg": "^2.1.3",
         "groq-sdk": "^0.36.0",
         "ink": "^6.5.1",
-        "opentype.js": "^1.3.4",
+        "opentype.js": "1.3.4",
         "p-limit": "^6.2.0",
         "p-map": "^7.0.4",
         "react": "^19.2.0",
@@ -1064,7 +1064,7 @@
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
-    "opentype.js": ["opentype.js@1.3.5", "", { "bin": { "ot": "bin/ot" } }, "sha512-thKDiELidAApOvXlncrpwDZKJCa9fXLEKM4+FoEWI+qTLDeNb+h7EkN+8a7KQODsB1GZ+Exz9KknkoPrEdXZDw=="],
+    "opentype.js": ["opentype.js@1.3.4", "", { "dependencies": { "string.prototype.codepointat": "^0.2.1", "tiny-inflate": "^1.0.3" }, "bin": { "ot": "bin/ot" } }, "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw=="],
 
     "ow": ["ow@0.28.2", "", { "dependencies": { "@sindresorhus/is": "^4.2.0", "callsites": "^3.1.0", "dot-prop": "^6.0.1", "lodash.isequal": "^4.5.0", "vali-date": "^1.0.0" } }, "sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q=="],
 
@@ -1200,6 +1200,8 @@
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string.prototype.codepointat": ["string.prototype.codepointat@0.2.1", "", {}, "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="],
+
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
@@ -1223,6 +1225,8 @@
     "text-extensions": ["text-extensions@2.4.0", "", {}, "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
+
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "check": "biome check . && tsc --noEmit",
+    "test:ci": "bun test src/react/tests src/react/renderers/ass.test.ts src/react/renderers/cache.test.ts src/react/renderers/emoji.test.ts src/react/renderers/fonts.test.ts src/react/renderers/merge-ass.test.ts src/react/renderers/text-measure.test.ts src/react/renderers/utils.test.ts src/react/layouts src/react/async-elements.test.ts src/react/resolve-context.test.ts src/ai-sdk/cache.test.ts src/ai-sdk/providers/varg-idempotency.test.ts src/speech src/tests/unit.test.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
     "type-check": "tsc --noEmit",
@@ -63,7 +64,7 @@
     "fluent-ffmpeg": "^2.1.3",
     "groq-sdk": "^0.36.0",
     "ink": "^6.5.1",
-    "opentype.js": "^1.3.4",
+    "opentype.js": "1.3.4",
     "p-limit": "^6.2.0",
     "p-map": "^7.0.4",
     "react": "^19.2.0",

--- a/src/ai-sdk/providers/editly/editly.test.ts
+++ b/src/ai-sdk/providers/editly/editly.test.ts
@@ -1,13 +1,42 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, unlinkSync } from "node:fs";
+import {
+  ensureFixtures,
+  ensureLandscapeImage,
+  ensureSilentAudio,
+  fixturePath,
+  LANDSCAPE_IMAGE_PATH,
+  SILENT_AUDIO_PATH,
+} from "../../../tests/fixtures";
 import { localBackend } from "./backends/local";
 import { editly } from "./index";
 
-const VIDEO_1 = "output/sora-landscape.mp4";
-const VIDEO_2 = "output/simpsons-scene.mp4";
-const VIDEO_TALKING = "output/workflow-talking-synced.mp4";
-const IMAGE_SQUARE = "media/replicate-forest.png";
-const IMAGE_PORTRAIT = "media/madi-portrait.png";
+// Media fixtures live in R2, not in gitignored output/ and media/ — these
+// paths are only populated once the beforeAll below has downloaded them.
+const VIDEO_1 = fixturePath("sora-landscape.mp4");
+const VIDEO_2 = fixturePath("simpsons-scene.mp4");
+const VIDEO_TALKING = fixturePath("workflow-talking-synced.mp4");
+const IMAGE_SQUARE = fixturePath("replicate-forest.png");
+const IMAGE_PORTRAIT = fixturePath("madi-portrait.png");
+// Stand-ins for the unavailable media/cyberpunk-street.png and
+// media/kirill-voice.mp3, both generated locally by ffmpeg. These tests
+// assert an output file was produced, never what it looks or sounds like.
+const IMAGE_LANDSCAPE = LANDSCAPE_IMAGE_PATH;
+const AUDIO_TRACK = SILENT_AUDIO_PATH;
+
+beforeAll(async () => {
+  await Promise.all([
+    ensureFixtures(
+      "sora-landscape.mp4",
+      "simpsons-scene.mp4",
+      "workflow-talking-synced.mp4",
+      "replicate-forest.png",
+      "madi-portrait.png",
+    ),
+    ensureSilentAudio(),
+    ensureLandscapeImage(),
+  ]);
+}, 180_000);
 
 const ffprobe = localBackend.ffprobe;
 
@@ -289,7 +318,7 @@ describe("editly", () => {
             layers: [
               {
                 type: "image",
-                path: "media/cyberpunk-street.png",
+                path: IMAGE_LANDSCAPE,
                 zoomDirection: "left",
                 zoomAmount: 0.15,
                 resizeMode: "contain",
@@ -302,7 +331,7 @@ describe("editly", () => {
             layers: [
               {
                 type: "image",
-                path: "media/cyberpunk-street.png",
+                path: IMAGE_LANDSCAPE,
                 zoomDirection: "right",
                 zoomAmount: 0.15,
                 resizeMode: "contain",
@@ -314,7 +343,8 @@ describe("editly", () => {
 
       expect(existsSync(outPath)).toBe(true);
     },
-    { timeout: 10000 },
+    // Two zoompan clips at 1280x720; see the note on the portrait cover test.
+    { timeout: 60000 },
   );
 
   test("title with custom font", async () => {
@@ -658,7 +688,7 @@ describe("editly", () => {
           layers: [
             { type: "fill-color", color: "#1a1a2e" },
             { type: "title", text: "Audio Layer Test" },
-            { type: "audio", path: "media/kirill-voice.mp3" },
+            { type: "audio", path: AUDIO_TRACK },
           ],
         },
       ],
@@ -684,7 +714,7 @@ describe("editly", () => {
             { type: "title", text: "Audio starts at 2s" },
             {
               type: "detached-audio",
-              path: "media/kirill-voice.mp3",
+              path: AUDIO_TRACK,
               start: 2,
             },
           ],
@@ -704,7 +734,7 @@ describe("editly", () => {
       width: 640,
       height: 480,
       fps: 30,
-      audioFilePath: "media/kirill-voice.mp3",
+      audioFilePath: AUDIO_TRACK,
       loopAudio: true,
       clips: [
         {
@@ -854,7 +884,7 @@ describe("editly", () => {
       fps: 30,
       audioTracks: [
         {
-          path: "media/kirill-voice.mp3",
+          path: AUDIO_TRACK,
           cutFrom: 0,
           cutTo: 2,
           start: 1,
@@ -1019,7 +1049,9 @@ describe("editly", () => {
         },
         {
           duration: 4,
-          layers: [{ type: "video", path: "output/duet-mixed.mp4" }],
+          // Was output/duet-mixed.mp4 (gitignored, 404 on R2). VIDEO_2 also
+          // carries an audio stream, which is what keepSourceAudio needs.
+          layers: [{ type: "video", path: VIDEO_2 }],
         },
       ],
     });
@@ -1084,6 +1116,10 @@ describe("editly", () => {
     });
   });
 
+  // Slow by nature: fitting a 16:9 source into 1080x1920 with resizeMode
+  // "cover" makes zoompan operate on a heavily upscaled frame (~20s locally,
+  // regardless of source resolution — measured at 640x360, 960x540, 1280x720).
+  // The square-image sibling test above costs ~2s for the same output size.
   test("portrait 9:16 landscape image with zoompan cover mode", async () => {
     const outPath = "output/editly-test-portrait-landscape-cover.mp4";
     if (existsSync(outPath)) unlinkSync(outPath);
@@ -1099,7 +1135,7 @@ describe("editly", () => {
           layers: [
             {
               type: "image",
-              path: "media/cyberpunk-street.png",
+              path: IMAGE_LANDSCAPE,
               zoomDirection: "in",
               zoomAmount: 0.1,
               resizeMode: "cover",
@@ -1114,7 +1150,7 @@ describe("editly", () => {
     expect(info.width).toBe(1080);
     expect(info.height).toBe(1920);
     expect(info.duration).toBeCloseTo(3, 0);
-  });
+  }, 60_000);
 
   test("video overlay with cropPosition", async () => {
     const outPath = "output/editly-test-crop-position.mp4";
@@ -1214,7 +1250,12 @@ describe("editly", () => {
     expect(info.height).toBe(1080);
   });
 
-  test("issue #62: positioned videos in clip don't bleed into other clips", async () => {
+  // REGRESSED — see the note above `issue #123` below. A clip containing
+  // positioned videos contributes ~0s instead of its declared duration, so
+  // this composition renders 4.4s instead of 5.4s. `test.failing` keeps the
+  // assertion pinned to the CORRECT value and will start failing (loudly) the
+  // moment the underlying bug is fixed, so this cannot be silently forgotten.
+  test.failing("issue #62: positioned videos in clip don't bleed into other clips", async () => {
     // Bug: positioned videos from Grid/Split are treated as continuous overlays
     // spanning entire video instead of being scoped to their clip.
     // Fix: clip-local overlays (no cutFrom/cutTo) vs continuous (has cutFrom/cutTo)
@@ -1267,7 +1308,7 @@ describe("editly", () => {
     expect(existsSync(outPath)).toBe(true);
     const info = await ffprobe(outPath);
     expect(info.duration).toBeCloseTo(5.4, 0);
-  });
+  }, 60_000);
 
   test("issue #62: continuous overlay (with cutFrom/cutTo) spans clips correctly", async () => {
     const outPath = "output/editly-test-continuous-overlay-spans.mp4";
@@ -1337,7 +1378,20 @@ describe("editly", () => {
 
   // Regression test for issue #123
   // https://github.com/vargHQ/sdk/issues/123
-  test("issue #123: clip with only positioned videos (no base layer) generates valid filter", async () => {
+  //
+  // REGRESSED (both #62 and #123). These two tests could never run before —
+  // they died on a missing fixture long before reaching their assertions, so
+  // the regression went unnoticed. Verified with fixtures restored: an
+  // otherwise identical 3-clip composition renders 5s when the middle clip is
+  // fill-color, but 4s when the middle clip holds positioned videos — the
+  // positioned-video clip contributes ~0s of its declared 2s. A clip whose
+  // ONLY layer is a positioned video still throws "Clip N produced no video
+  // output", which is exactly the #123 symptom.
+  //
+  // Marked `test.failing` rather than skipped: the assertion still encodes the
+  // CORRECT expectation and Bun fails the test if it ever starts passing, so
+  // fixing the bug forces this marker to be removed.
+  test.failing("issue #123: clip with only positioned videos (no base layer) generates valid filter", async () => {
     // Bug: when a clip has only positioned videos (from Split/Slot) and no base layer,
     // buildBaseClipFilter returns an empty outputLabel "", causing ffmpeg to crash with
     // "Bad (empty?) label found" error like: "[]concat=n=2:v=1:a=0..."
@@ -1391,7 +1445,7 @@ describe("editly", () => {
     expect(existsSync(outPath)).toBe(true);
     const info = await ffprobe(outPath);
     expect(info.duration).toBeGreaterThan(4);
-  });
+  }, 60_000);
 
   test("issue #123: clip with no layers at all throws clear error", async () => {
     await expect(

--- a/src/react/react.test.ts
+++ b/src/react/react.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, mock, test } from "bun:test";
-import { existsSync, unlinkSync } from "node:fs";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fal } from "../ai-sdk/providers/fal";
+import { ensureFixtures } from "../tests/fixtures";
 import {
   Captions,
   Clip,
@@ -241,9 +243,18 @@ describe("varg-react render", () => {
 });
 
 describe("layout renderers", () => {
-  const testImage1 = "media/cyberpunk-street.png";
-  const testImage2 = "media/fal-coffee-shop.png";
+  // Fixtures come from R2 rather than gitignored media/ — these tests only
+  // assert that a video was produced, so any valid image works.
+  let testImage1 = "";
+  let testImage2 = "";
   const outPath = "output/layout-test.mp4";
+
+  beforeAll(async () => {
+    [testImage1, testImage2] = (await ensureFixtures(
+      "test-red.png",
+      "test-green.png",
+    )) as [string, string];
+  });
 
   test("Split renders side-by-side images", async () => {
     const root = Render({
@@ -369,6 +380,16 @@ describe("layout renderers", () => {
   test(
     "Captions burns subtitles from SRT file",
     async () => {
+      // Generated rather than fixtured: an SRT is plain text, so depending on
+      // a binary asset for it was needless (the old media/dora-test.srt is
+      // gitignored and absent from a fresh checkout).
+      const srtPath = `${tmpdir()}/varg-react-captions-test.srt`;
+      writeFileSync(
+        srtPath,
+        "1\n00:00:00,000 --> 00:00:01,500\nHello world\n\n" +
+          "2\n00:00:01,500 --> 00:00:03,000\nSecond line\n",
+      );
+
       const root = Render({
         width: 1280,
         height: 720,
@@ -378,7 +399,7 @@ describe("layout renderers", () => {
             children: [Image({ src: testImage1 })],
           }),
           Captions({
-            srt: "media/dora-test.srt",
+            srt: srtPath,
             style: "tiktok",
           }),
         ],

--- a/src/react/renderers/text-measure.ts
+++ b/src/react/renderers/text-measure.ts
@@ -12,6 +12,7 @@
  * what libass actually renders.
  */
 
+import { readFileSync } from "node:fs";
 import * as opentype from "opentype.js";
 
 // ---------------------------------------------------------------------------
@@ -22,11 +23,39 @@ const fontCache = new Map<string, opentype.Font>();
 
 /**
  * Load a font from a local file path, caching by path.
+ *
+ * Uses `opentype.parse()` on an explicit buffer rather than `loadSync()`:
+ * opentype.js 1.3.5 (published 2026-04-29 — a v2 codebase republished onto
+ * the 1.x line, which `^1.3.4` silently accepted) replaced `load`/`loadSync`
+ * with stubs that print a deprecation notice and return `undefined`. That
+ * `undefined` was cached here and only surfaced ~300 lines downstream as
+ * `TypeError: undefined is not an object (evaluating 'font.tables')`,
+ * crashing every emoji caption render via captions.ts. `@types/opentype.js`
+ * still declares `loadSync(): Font`, so tsc could not catch it.
+ * `parse()` is present and identical in 1.3.4, 1.3.5 and 2.0.0.
+ *
+ * The buffer is sliced by byteOffset/byteLength because Node allocates small
+ * Buffers as views into a shared pool — passing `.buffer` directly would hand
+ * the parser neighbouring allocations rather than just this file.
  */
 export function loadFont(fontPath: string): opentype.Font {
   let font = fontCache.get(fontPath);
   if (!font) {
-    font = opentype.loadSync(fontPath);
+    const buffer = readFileSync(fontPath);
+    font = opentype.parse(
+      buffer.buffer.slice(
+        buffer.byteOffset,
+        buffer.byteOffset + buffer.byteLength,
+      ),
+    );
+    // Fail loudly at the source. Without this a stubbed/failed loader returns
+    // undefined and every consumer throws an opaque TypeError far from here.
+    if (!font) {
+      throw new Error(
+        `Failed to parse font "${fontPath}" — opentype.parse() returned no font. ` +
+          `Check the file is a valid TTF/OTF and that opentype.js is pinned to 1.3.4.`,
+      );
+    }
     fontCache.set(fontPath, font);
   }
   return font;
@@ -40,10 +69,11 @@ export function loadFont(fontPath: string): opentype.Font {
  * Get glyphs for a text string, falling back to per-character cmap lookup
  * if the font's GSUB processing fails.
  *
- * opentype.js v1.3.4 crashes on Arabic fonts when applying contextual
- * substitution (GSUB lookup type 5 / substFormat 3). The fallback uses
- * `charToGlyph()` which does a direct cmap lookup — no Bidi processing,
- * no GSUB shaping, no crash.
+ * opentype.js throws on Arabic fonts when applying contextual substitution:
+ * 1.3.4 fails on GSUB lookup type 5 / substFormat 3, and 2.0.0 still fails
+ * (lookup type 6 / substFormat 1) — so this fallback is required on every
+ * published version, not a quirk of one. It uses `charToGlyph()`, a direct
+ * cmap lookup — no Bidi processing, no GSUB shaping, no crash.
  *
  * For scripts with complex shaping (Arabic, Hebrew), the nominal advance
  * widths from isolated-form glyphs overestimate the actual rendered width
@@ -107,12 +137,26 @@ Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,${text}`;
 
   try {
     // Render to raw RGB pixels
-    const proc = Bun.spawnSync([
-      "ffmpeg", "-y", "-f", "lavfi",
-      "-i", `color=black:s=${playResX}x${h}:d=1:r=1`,
-      "-vf", `subtitles='${assPath.replace(/'/g, "'\\''")}':fontsdir='${fontDir}'`,
-      "-frames:v", "1", "-f", "rawvideo", "-pix_fmt", "rgb24", "-",
-    ], { stdout: "pipe", stderr: "pipe" });
+    const proc = Bun.spawnSync(
+      [
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        `color=black:s=${playResX}x${h}:d=1:r=1`,
+        "-vf",
+        `subtitles='${assPath.replace(/'/g, "'\\''")}':fontsdir='${fontDir}'`,
+        "-frames:v",
+        "1",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "-",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
 
     if (proc.exitCode !== 0) {
       // Fallback: return a rough estimate
@@ -128,7 +172,11 @@ Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,${text}`;
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
         const off = (y * w + x) * 3;
-        if (pixels[off]! > 20 || pixels[off + 1]! > 20 || pixels[off + 2]! > 20) {
+        if (
+          pixels[off]! > 20 ||
+          pixels[off + 1]! > 20 ||
+          pixels[off + 2]! > 20
+        ) {
           if (x < minX) minX = x;
           if (x > maxX) maxX = x;
         }
@@ -139,7 +187,9 @@ Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,${text}`;
     renderedWidthCache.set(cacheKey, width);
     return width;
   } finally {
-    try { unlinkSync(assPath); } catch {}
+    try {
+      unlinkSync(assPath);
+    } catch {}
   }
 }
 
@@ -196,12 +246,26 @@ Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,${taggedText}`;
   writeFileSync(assPath, assContent);
 
   try {
-    const proc = Bun.spawnSync([
-      "ffmpeg", "-y", "-f", "lavfi",
-      "-i", `color=black:s=${playResX}x${playResY}:d=1:r=1`,
-      "-vf", `subtitles='${assPath.replace(/'/g, "'\\''")}':fontsdir='${fontDir}'`,
-      "-frames:v", "1", "-f", "rawvideo", "-pix_fmt", "rgb24", "-",
-    ], { stdout: "pipe", stderr: "pipe" });
+    const proc = Bun.spawnSync(
+      [
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        `color=black:s=${playResX}x${playResY}:d=1:r=1`,
+        "-vf",
+        `subtitles='${assPath.replace(/'/g, "'\\''")}':fontsdir='${fontDir}'`,
+        "-frames:v",
+        "1",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "-",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
 
     if (proc.exitCode !== 0) return [];
 
@@ -214,7 +278,11 @@ Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,${taggedText}`;
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
         const off = (y * w + x) * 3;
-        if (pixels[off]! > 20 || pixels[off + 1]! > 20 || pixels[off + 2]! > 20) {
+        if (
+          pixels[off]! > 20 ||
+          pixels[off + 1]! > 20 ||
+          pixels[off + 2]! > 20
+        ) {
           colHasText[x] = 1;
         }
       }
@@ -279,13 +347,21 @@ Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,${taggedText}`;
       // Trailing spaces in logical order appear at visual LEFT for RTL
       if (hasLeadingSpaces && missingCount > 0) {
         // Begin emoji: place at the visual RIGHT edge of text
-        const x = Math.round(textRight + 1 + (emojiSize * 0.1));
-        gaps.push({ gapStart: textRight + 1, gapEnd: textRight + emojiSize, x });
+        const x = Math.round(textRight + 1 + emojiSize * 0.1);
+        gaps.push({
+          gapStart: textRight + 1,
+          gapEnd: textRight + emojiSize,
+          x,
+        });
       }
       if (hasTrailingSpaces && gaps.length < numEmoji) {
         // End emoji: place at the visual LEFT edge of text
-        const x = Math.round(textLeft - emojiSize - (emojiSize * 0.1));
-        gaps.unshift({ gapStart: textLeft - emojiSize, gapEnd: textLeft - 1, x });
+        const x = Math.round(textLeft - emojiSize - emojiSize * 0.1);
+        gaps.unshift({
+          gapStart: textLeft - emojiSize,
+          gapEnd: textLeft - 1,
+          x,
+        });
       }
     }
 
@@ -293,7 +369,9 @@ Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,${taggedText}`;
     gaps.sort((a, b) => a.gapStart - b.gapStart);
     return gaps.slice(0, numEmoji);
   } finally {
-    try { unlinkSync(assPath); } catch {}
+    try {
+      unlinkSync(assPath);
+    } catch {}
   }
 }
 
@@ -348,13 +426,11 @@ export function getFontMetrics(
   const winDesc: number = os2?.usWinDescent ?? 0;
   const cellHeight = winAsc + winDesc;
   const ppem =
-    cellHeight > 0
-      ? (assFontSize * font.unitsPerEm) / cellHeight
-      : assFontSize;
+    cellHeight > 0 ? (assFontSize * font.unitsPerEm) / cellHeight : assFontSize;
 
   return {
     ppem,
-    capHeight: (((os2?.sCapHeight ?? 700) * ppem) / font.unitsPerEm),
+    capHeight: ((os2?.sCapHeight ?? 700) * ppem) / font.unitsPerEm,
     winAscent: (winAsc * ppem) / font.unitsPerEm,
     winDescent: (winDesc * ppem) / font.unitsPerEm,
   };
@@ -438,10 +514,7 @@ export type FontPathMap = Map<string, string>;
  * @param fontPath - Local path to the TTF/OTF file
  * @param assFontSize - The ASS fontSize (full cell height, not ppem)
  */
-export function getSpaceWidth(
-  fontPath: string,
-  assFontSize: number,
-): number {
+export function getSpaceWidth(fontPath: string, assFontSize: number): number {
   const ppem = getEffectivePpem(fontPath, assFontSize);
   const font = loadFont(fontPath);
   return font.getAdvanceWidth(" ", ppem);

--- a/src/react/warnings.test.ts
+++ b/src/react/warnings.test.ts
@@ -1,11 +1,56 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { ensureFixtures } from "../tests/fixtures";
 
+/**
+ * These tests render in a child process and assert on its output. The image
+ * fixture is downloaded from R2 rather than read from gitignored media/, so
+ * they are reproducible on a fresh checkout.
+ */
 describe("warnings", () => {
+  let testImage = "";
+
+  beforeAll(async () => {
+    [testImage] = (await ensureFixtures("test-red.png")) as [string];
+  });
+
+  /**
+   * Run a generated script in a child process and return its combined output.
+   *
+   * Asserts a clean exit first: these tests check side effects (a file exists,
+   * a warning was printed), so without this a hard crash in the child shows up
+   * as a confusing assertion diff instead of "the subprocess failed".
+   */
+  async function runScript(tmpFile: string, script: string): Promise<string> {
+    writeFileSync(tmpFile, script);
+    try {
+      const proc = Bun.spawn(["bun", "run", tmpFile], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+      if (exitCode !== 0) {
+        throw new Error(
+          `child process exited with code ${exitCode}:\n${output}`,
+        );
+      }
+      return output;
+    } finally {
+      if (existsSync(tmpFile)) unlinkSync(tmpFile);
+    }
+  }
+
   test(
     "issue #45: Overlay inside Clip renders without warning",
     async () => {
-      const script = `
+      const output = await runScript(
+        ".tmp-test-45.ts",
+        `
 import { Clip, Image, Overlay, Render, render } from "./src/react/index";
 await render(
   Render({
@@ -15,13 +60,13 @@ await render(
       Clip({
         duration: 2,
         children: [
-          Image({ src: "media/cyberpunk-street.png" }),
+          Image({ src: ${JSON.stringify(testImage)} }),
           Overlay({
             left: "10%",
             top: "10%",
             width: "20%",
             height: "20%",
-            children: [Image({ src: "media/cyberpunk-street.png" })],
+            children: [Image({ src: ${JSON.stringify(testImage)} })],
           }),
         ],
       }),
@@ -29,22 +74,9 @@ await render(
   }),
   { output: "output/test-issue-45.mp4", quiet: true }
 );
-`;
-      const tmpFile = ".tmp-test-45.ts";
-      writeFileSync(tmpFile, script);
+`,
+      );
 
-      const proc = Bun.spawn(["bun", "run", tmpFile], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      await proc.exited;
-      unlinkSync(tmpFile);
-
-      const output = stdout + stderr;
       // <Overlay> inside <Clip> is now valid — no warning should be emitted
       expect(output).not.toContain(
         "<Overlay> placed inside <Clip> will be ignored",
@@ -57,7 +89,9 @@ await render(
   test(
     "issue #24: warns when image with zoompan has no resizeMode",
     async () => {
-      const script = `
+      const output = await runScript(
+        ".tmp-test-24.ts",
+        `
 import { Clip, Image, Render, render } from "./src/react/index";
 await render(
   Render({
@@ -66,28 +100,15 @@ await render(
     children: [
       Clip({
         duration: 2,
-        children: [Image({ src: "media/cyberpunk-street.png", zoom: "in" })],
+        children: [Image({ src: ${JSON.stringify(testImage)}, zoom: "in" })],
       }),
     ],
   }),
   { output: "output/test-issue-24.mp4", quiet: true }
 );
-`;
-      const tmpFile = ".tmp-test-24.ts";
-      writeFileSync(tmpFile, script);
+`,
+      );
 
-      const proc = Bun.spawn(["bun", "run", tmpFile], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      await proc.exited;
-      unlinkSync(tmpFile);
-
-      const output = stdout + stderr;
       expect(output).toContain("resizeMode");
       expect(output).toContain("Deprecation");
       expect(existsSync("output/test-issue-24.mp4")).toBe(true);

--- a/src/tests/fixtures.ts
+++ b/src/tests/fixtures.ts
@@ -1,0 +1,168 @@
+/**
+ * Shared test media fixtures.
+ *
+ * `media/` and `output/` are gitignored, so every test that referenced a
+ * local path there could only pass on a machine that had previously run the
+ * (paid) example scripts. On a fresh checkout — and in CI — those tests
+ * failed with ENOENT. Fixtures now live in R2 behind `s3.varg.ai/test-media/`
+ * and are downloaded once per machine into a temp directory.
+ *
+ * Mirrors the pattern already used by `text-measure.test.ts` for fonts.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+
+/** Public R2 mirror for test-only media. */
+export const FIXTURE_BASE_URL = "https://s3.varg.ai/test-media";
+
+/** Local cache directory — survives across runs, downloads once. */
+export const FIXTURE_DIR = "/tmp/varg-test-fixtures";
+
+/**
+ * Fixtures that are present in R2 and safe to depend on.
+ *
+ * Anything NOT listed here is unavailable (see MISSING_FIXTURES) and its
+ * tests are skipped rather than silently failing.
+ */
+export const FIXTURES = {
+  "test-red.png": `${FIXTURE_BASE_URL}/test-red.png`,
+  "test-green.png": `${FIXTURE_BASE_URL}/test-green.png`,
+  "test-blue.png": `${FIXTURE_BASE_URL}/test-blue.png`,
+  "replicate-forest.png": `${FIXTURE_BASE_URL}/replicate-forest.png`,
+  "madi-portrait.png": `${FIXTURE_BASE_URL}/madi-portrait.png`,
+  "sora-landscape.mp4": `${FIXTURE_BASE_URL}/sora-landscape.mp4`,
+  "simpsons-scene.mp4": `${FIXTURE_BASE_URL}/simpsons-scene.mp4`,
+  "workflow-talking-synced.mp4": `${FIXTURE_BASE_URL}/workflow-talking-synced.mp4`,
+} as const;
+
+export type FixtureName = keyof typeof FIXTURES;
+
+/**
+ * Fixtures the old tests referenced that exist NOWHERE — not in the repo
+ * (gitignored) and 404 on R2: `cyberpunk-street.png`, `fal-coffee-shop.png`,
+ * `kirill-voice.mp3`.
+ *
+ * None of the tests using them cared about the *content* — an image test
+ * needs any image, an audio test needs any audio track. So instead of
+ * skipping, they now use an existing R2 image or the locally synthesized
+ * silent audio below. Nothing is left pending on a missing upload.
+ */
+
+/** Absolute local path a fixture will be downloaded to. */
+export function fixturePath(name: FixtureName): string {
+  return `${FIXTURE_DIR}/${name}`;
+}
+
+/** Path of the generated silent audio track. */
+export const SILENT_AUDIO_PATH = `${FIXTURE_DIR}/silence-5s.mp3`;
+
+/**
+ * Synthesize a 5s silent MP3 via ffmpeg, cached on disk.
+ *
+ * Replaces the unavailable `media/kirill-voice.mp3`. Audio-layer tests assert
+ * that a muxed output file is produced, never what it sounds like — so a
+ * generated track is strictly better than a binary fixture: no download, no
+ * upload to maintain, and deterministic.
+ */
+export async function ensureSilentAudio(): Promise<string> {
+  if (!existsSync(FIXTURE_DIR)) {
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+  }
+  if (existsSync(SILENT_AUDIO_PATH)) return SILENT_AUDIO_PATH;
+
+  const proc = Bun.spawn(
+    [
+      "ffmpeg",
+      "-y",
+      "-f",
+      "lavfi",
+      "-i",
+      "anullsrc=r=44100:cl=stereo",
+      "-t",
+      "5",
+      "-c:a",
+      "libmp3lame",
+      "-q:a",
+      "9",
+      SILENT_AUDIO_PATH,
+    ],
+    { stdout: "ignore", stderr: "pipe" },
+  );
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`Failed to generate silent audio fixture:\n${stderr}`);
+  }
+  return SILENT_AUDIO_PATH;
+}
+
+/** Path of the landscape still extracted from sora-landscape.mp4. */
+export const LANDSCAPE_IMAGE_PATH = `${FIXTURE_DIR}/sora-landscape-frame.png`;
+
+/**
+ * Extract a landscape (16:9) still from the landscape video, cached on disk.
+ *
+ * Replaces the unavailable `media/cyberpunk-street.png`. The available R2
+ * images are square (1024x1024) and portrait (1080x1920), so neither can
+ * stand in for tests that specifically exercise landscape-into-portrait
+ * fitting (e.g. "portrait 9:16 landscape image with zoompan cover mode") —
+ * substituting one would quietly stop testing the aspect-ratio path.
+ *
+ * Scaled to 640x360: still 16:9, but zoompan cost scales with source pixels
+ * and a full 1280x720 still pushed those tests past their 10s timeout.
+ */
+export async function ensureLandscapeImage(): Promise<string> {
+  if (existsSync(LANDSCAPE_IMAGE_PATH)) return LANDSCAPE_IMAGE_PATH;
+
+  const [videoPath] = await ensureFixtures("sora-landscape.mp4");
+
+  const proc = Bun.spawn(
+    [
+      "ffmpeg",
+      "-y",
+      "-i",
+      videoPath as string,
+      "-vframes",
+      "1",
+      "-vf",
+      "scale=640:360",
+      LANDSCAPE_IMAGE_PATH,
+    ],
+    { stdout: "ignore", stderr: "pipe" },
+  );
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`Failed to extract landscape image fixture:\n${stderr}`);
+  }
+  return LANDSCAPE_IMAGE_PATH;
+}
+
+/**
+ * Download the named fixtures if not already cached, returning their local
+ * paths in the same order. Call from `beforeAll`.
+ */
+export async function ensureFixtures(
+  ...names: FixtureName[]
+): Promise<string[]> {
+  if (!existsSync(FIXTURE_DIR)) {
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+  }
+
+  return Promise.all(
+    names.map(async (name) => {
+      const localPath = fixturePath(name);
+      if (existsSync(localPath)) return localPath;
+
+      const url = FIXTURES[name];
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(
+          `Failed to download test fixture ${name} from ${url}: ${res.status}`,
+        );
+      }
+      writeFileSync(localPath, new Uint8Array(await res.arrayBuffer()));
+      return localPath;
+    }),
+  );
+}


### PR DESCRIPTION
## The production bug

`opentype.js@1.3.5` was published **2026-04-29** — five years after `1.3.4` (2021) — as a **v2 codebase republished onto the 1.x line**. Its `load`/`loadSync` are stubs that print a deprecation notice and return `undefined`. Our `^1.3.4` range accepted it silently around 2026-05-23.

`loadFont` (`text-measure.ts:29`) cached that `undefined`, and `getFontMetrics` **throws** rather than degrading:

```
TypeError: undefined is not an object (evaluating 'font.tables')
```

That call is at `captions.ts:125`, gated on `srtHasEmoji`. **Every caption render containing an emoji has been crashing for ~2.5 months.**

Why nothing caught it:
- `tsc` can't — `@types/opentype.js@1.3.9` still declares `loadSync(): Font`. The types lie about the runtime.
- CI can't — `.github/workflows/ci.yml` ran only `biome check && tsc --noEmit`. **No test step existed.**

## The fix

`opentype.parse()` on an explicit buffer, sliced by `byteOffset`/`byteLength` (Node pools small Buffers; passing `.buffer` raw hands the parser neighbouring allocations). Plus a null guard so a future stub fails at the source rather than 300 lines downstream.

**Pinned to `1.3.4`, not upgraded to 2.0.0.** I probed v2 in an isolated dir first: it has the *same* `loadSync` stub **and** ships no bundled types (`@types` tops out at the v1 API). Upgrading would keep the bug and lose type coverage.

Verified behaviour-preserving:

| | 1.3.4 `loadSync` | 2.0.0 `parse` |
|---|---|---|
| `unitsPerEm` | 1000 | 1000 |
| `usWinAscent` | 1109 | 1109 |
| `getAdvanceWidth(" ", 72)` | 20.376 | 20.376 |

Also refreshed the `safeGetGlyphs` comment: Arabic GSUB still throws on 2.0.0 (lookup type `6/1` vs 1.3.4's `5/3`), so that fallback is required on every published version.

## Test fixtures

`media/` and `output/` are gitignored, so ~43 tests could only pass on a machine that had already run the paid example scripts.

- **`src/tests/fixtures.ts`** — shared downloader from `s3.varg.ai/test-media/`, mirroring the font pattern already in `text-measure.test.ts`. Uploaded `test-red/green/blue.png` (1.8 KB total) to unblock it.
- **`cyberpunk-street.png` / `kirill-voice.mp3` / `duet-mixed.mp4` exist nowhere** (gitignored *and* 404). Rather than skip, those tests now use equivalents — an ffmpeg-generated silent MP3, a frame extracted from the landscape video, and `VIDEO_2` (which also carries audio, which is what `keepSourceAudio` needs). **None of them asserted on content.**
- The Captions test now writes its own SRT — plain text never needed a binary fixture.
- `warnings.test.ts` asserts child `exitCode === 0` before content assertions, so a subprocess crash reports as a crash.
- Raised timeouts on two landscape→portrait zoompan tests: ~20s is inherent to cover-mode upscaling (measured identical at 640x360, 960x540, 1280x720), not a fixture artifact.

## ⚠️ editly #62 and #123 have regressed

Both issues are **closed**, but their regression tests never actually ran — they died on a missing fixture long before reaching their assertions. With fixtures restored:

- An otherwise identical 3-clip composition renders **5s** when the middle clip is `fill-color` but **4s** when it holds positioned videos — the positioned-video clip contributes ~0s of its declared 2s.
- A clip whose only layer is a positioned video still throws `"Clip N produced no video output"` — exactly the #123 symptom.

Marked `test.failing` rather than skipped: the assertions still encode the **correct** expectation, and Bun fails the test if it ever starts passing, so fixing the bug forces the marker's removal. Filed separately — **not fixed here**, since it's an unrelated filter-graph bug.

## CI

Added a `test` job running `bun run test:ci` — **437 hermetic tests in ~1.7s**, no API keys, no paid generation. Excludes live-service suites, heavy ffmpeg rendering, and `pricing.test.ts` (3 failures predating this change).

Note: `bun run check` **already fails on main** from pre-existing lint errors in files I didn't touch. My changed files are lint-clean (14 warnings, 0 errors).

## Result

**118 failures → 0.** 433 → 562 passing; skips unchanged at 34. Cache untouched (165 entries before and after).

Verified `getFontMetrics` now returns real metrics instead of throwing:
```
{"ppem":46.09,"capHeight":32.27,"winAscent":51.12,"winDescent":20.88}
```