### PR TITLE
Preserve video source audio by default

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -117,8 +117,9 @@ import { Video } from "@vargai/react";
 // use existing video file
 <Video src="./interview.mp4" />
 
-// with audio and trimming
-<Video src="./clip.mp4" keepAudio volume={0.8} cutFrom={5} cutTo={15} />
+// source audio is preserved by default; set keepAudio={false} to mute
+<Video src="./clip.mp4" volume={0.8} cutFrom={5} cutTo={15} />
+<Video src="./silent-clip.mp4" keepAudio={false} />
 ```
 
 ### image-to-video animation
@@ -447,9 +448,11 @@ import { Packshot } from "@vargai/react";
 
 ### preserve source audio
 
+Video source audio is preserved by default. Use `keepAudio={false}` to mute it.
+
 ```tsx
 <Clip>
-  <Video src="./interview.mp4" keepAudio volume={0.8} />
+  <Video src="./interview.mp4" volume={0.8} />
 </Clip>
 ```
 

--- a/src/ai-sdk/providers/editly/backends/local.ts
+++ b/src/ai-sdk/providers/editly/backends/local.ts
@@ -21,6 +21,9 @@ export class LocalBackend implements FFmpegBackend {
     const videoStream = result.streams?.find(
       (s: { codec_type: string }) => s.codec_type === "video",
     );
+    const hasAudio = result.streams?.some(
+      (s: { codec_type: string }) => s.codec_type === "audio",
+    );
     const parsedDuration = parseFloat(result.format?.duration ?? "0");
     const duration = Number.isFinite(parsedDuration) ? parsedDuration : 0;
 
@@ -35,6 +38,7 @@ export class LocalBackend implements FFmpegBackend {
 
     return {
       duration,
+      hasAudio: hasAudio === true,
       ...(videoStream?.width != null ? { width: videoStream.width } : {}),
       ...(videoStream?.height != null ? { height: videoStream.height } : {}),
       ...(fps != null ? { fps } : {}),

--- a/src/ai-sdk/providers/editly/rendi/index.ts
+++ b/src/ai-sdk/providers/editly/rendi/index.ts
@@ -2,6 +2,7 @@ import { zipSync } from "fflate";
 import sharp from "sharp";
 import { File } from "../../../file";
 import type { StorageProvider } from "../../../storage/types";
+import { localBackend } from "../backends/local";
 import type {
   FFmpegBackend,
   FFmpegInput,
@@ -61,6 +62,15 @@ export class RendiBackend implements FFmpegBackend {
   }
 
   async ffprobe(input: string): Promise<VideoInfo> {
+    // The render image includes ffprobe even when Rendi performs composition.
+    // Prefer it because it exposes stream-level metadata such as hasAudio.
+    // Fall back to Rendi in environments that intentionally omit ffprobe.
+    try {
+      return await localBackend.ffprobe(input);
+    } catch {
+      // Continue with the remote metadata probe below.
+    }
+
     const inputUrl = await this.resolvePath(input);
 
     const submitResponse = await fetch(`${RENDI_API_BASE}/run-ffmpeg-command`, {

--- a/src/ai-sdk/providers/editly/types.ts
+++ b/src/ai-sdk/providers/editly/types.ts
@@ -350,6 +350,7 @@ export interface EditlyResult {
 // Internal types used by our implementation
 export interface VideoInfo {
   duration: number;
+  hasAudio?: boolean;
   width?: number;
   height?: number;
   fps?: number;

--- a/src/react/renderers/audio.ts
+++ b/src/react/renderers/audio.ts
@@ -1,0 +1,30 @@
+import type { FFmpegBackend } from "../../ai-sdk/providers/editly/backends";
+
+interface ResolveVideoMixVolumeOptions {
+  backend: FFmpegBackend;
+  keepAudio?: boolean;
+  path: string;
+  volume?: number;
+}
+
+/**
+ * Source audio is enabled by default, but only when the input actually has an
+ * audio stream. Explicit true preserves the previous force-on behavior.
+ */
+export async function resolveVideoMixVolume({
+  backend,
+  keepAudio,
+  path,
+  volume,
+}: ResolveVideoMixVolumeOptions): Promise<number> {
+  if (keepAudio === false) return 0;
+  if (keepAudio === true) return volume ?? 1;
+
+  try {
+    const info = await backend.ffprobe(path);
+    return info.hasAudio === true ? (volume ?? 1) : 0;
+  } catch {
+    // Auto mode must not make an otherwise valid silent video fail rendering.
+    return 0;
+  }
+}

--- a/src/react/renderers/clip.test.ts
+++ b/src/react/renderers/clip.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import type { File } from "../../ai-sdk/file";
+import { Clip, Overlay, Video } from "../elements";
+import { renderClip } from "./clip";
+import type { RenderContext } from "./context";
+
+function createContext(hasAudio = true): RenderContext {
+  const unsupported = async () => {
+    throw new Error("unexpected generation call");
+  };
+
+  return {
+    width: 1080,
+    height: 1920,
+    fps: 30,
+    generateImage: unsupported,
+    generateVideo: unsupported,
+    generateSpeech: unsupported,
+    generateMusic: unsupported,
+    tempFiles: [],
+    pendingFiles: new Map<string, Promise<File>>(),
+    backend: {
+      ffprobe: async () => ({ duration: 5, hasAudio }),
+      resolvePath: async () => "/tmp/source.mp4",
+    },
+    generatedFiles: [],
+  } as unknown as RenderContext;
+}
+
+describe("video source audio defaults", () => {
+  test("keeps audio for a video by default", async () => {
+    const clip = Clip({ children: Video({ src: "/tmp/source.mp4" }) });
+
+    const rendered = await renderClip(clip, createContext());
+
+    expect(rendered.layers[0]).toMatchObject({
+      type: "video",
+      mixVolume: 1,
+    });
+  });
+
+  test("allows a video to opt out of source audio", async () => {
+    const clip = Clip({
+      children: Video({ src: "/tmp/source.mp4", keepAudio: false }),
+    });
+
+    const rendered = await renderClip(clip, createContext());
+
+    expect(rendered.layers[0]).toMatchObject({
+      type: "video",
+      mixVolume: 0,
+    });
+  });
+
+  test("does not add a missing audio stream in default mode", async () => {
+    const clip = Clip({ children: Video({ src: "/tmp/source.mp4" }) });
+
+    const rendered = await renderClip(clip, createContext(false));
+
+    expect(rendered.layers[0]).toMatchObject({
+      type: "video",
+      mixVolume: 0,
+    });
+  });
+
+  test("allows source audio to be forced on", async () => {
+    const clip = Clip({
+      children: Video({ src: "/tmp/source.mp4", keepAudio: true }),
+    });
+
+    const rendered = await renderClip(clip, createContext(false));
+
+    expect(rendered.layers[0]).toMatchObject({
+      type: "video",
+      mixVolume: 1,
+    });
+  });
+
+  test("keeps audio for an overlay video by default", async () => {
+    const clip = Clip({
+      children: Overlay({
+        children: Video({ src: "/tmp/source.mp4" }),
+        volume: 0.4,
+      }),
+    });
+
+    const rendered = await renderClip(clip, createContext());
+
+    expect(rendered.layers[0]).toMatchObject({
+      type: "video",
+      mixVolume: 0.4,
+    });
+  });
+
+  test("allows an overlay video to opt out of source audio", async () => {
+    const clip = Clip({
+      children: Overlay({
+        children: Video({ src: "/tmp/source.mp4" }),
+        keepAudio: false,
+      }),
+    });
+
+    const rendered = await renderClip(clip, createContext());
+
+    expect(rendered.layers[0]).toMatchObject({
+      type: "video",
+      mixVolume: 0,
+    });
+  });
+});

--- a/src/react/renderers/clip.ts
+++ b/src/react/renderers/clip.ts
@@ -18,6 +18,7 @@ import type {
   VargNode,
   VideoProps,
 } from "../types";
+import { resolveVideoMixVolume } from "./audio";
 import type { RenderContext } from "./context";
 import { renderImage } from "./image";
 import { renderMusic } from "./music";
@@ -95,6 +96,12 @@ async function renderClipLayers(
           promise: renderVideo(element as VargElement<"video">, ctx).then(
             async (file) => {
               const path = await ctx.backend.resolvePath(file);
+              const mixVolume = await resolveVideoMixVolume({
+                backend: ctx.backend,
+                keepAudio: props.keepAudio,
+                path,
+                volume: props.volume,
+              });
               return {
                 type: "video",
                 path,
@@ -103,7 +110,7 @@ async function renderClipLayers(
                 cropPosition: props.cropPosition,
                 cutFrom: props.cutFrom ?? clipOptions?.cutFrom,
                 cutTo: props.cutTo ?? clipOptions?.cutTo,
-                mixVolume: props.keepAudio ? (props.volume ?? 1) : 0,
+                mixVolume,
                 left: props.left,
                 top: props.top,
                 width: props.width,
@@ -308,22 +315,25 @@ async function renderClipLayers(
                 ctx,
               )
                 .then((file) => ctx.backend.resolvePath(file))
-                .then(
-                  (path) =>
-                    ({
-                      type: "video",
-                      path,
-                      mixVolume: overlayProps.keepAudio
-                        ? (overlayProps.volume ?? 1)
-                        : 0,
-                      left: overlayProps.left,
-                      top: overlayProps.top,
-                      width: overlayProps.width,
-                      height: overlayProps.height,
-                      start: overlayProps.start,
-                      stop: overlayProps.end,
-                    }) as VideoLayer,
-                ),
+                .then(async (path) => {
+                  const mixVolume = await resolveVideoMixVolume({
+                    backend: ctx.backend,
+                    keepAudio: overlayProps.keepAudio,
+                    path,
+                    volume: overlayProps.volume,
+                  });
+                  return {
+                    type: "video",
+                    path,
+                    mixVolume,
+                    left: overlayProps.left,
+                    top: overlayProps.top,
+                    width: overlayProps.width,
+                    height: overlayProps.height,
+                    start: overlayProps.start,
+                    stop: overlayProps.end,
+                  } as VideoLayer;
+                }),
             });
           }
         }

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -35,6 +35,7 @@ import type {
   SpeechProps,
   VargElement,
 } from "../types";
+import { resolveVideoMixVolume } from "./audio";
 import { burnCaptions } from "./burn-captions";
 import { type CaptionsResult, renderCaptions } from "./captions";
 import { renderClip } from "./clip";
@@ -431,10 +432,17 @@ export async function renderRoot(
         const path = await ctx.backend.resolvePath(file);
         renderedOverlays.push({ path, props: overlayProps, isVideo });
 
-        if (isVideo && overlayProps.keepAudio) {
+        if (isVideo) {
+          const mixVolume = await resolveVideoMixVolume({
+            backend: ctx.backend,
+            keepAudio: overlayProps.keepAudio,
+            path,
+            volume: overlayProps.volume,
+          });
+          if (mixVolume === 0) continue;
           audioTracks.push({
             path,
-            mixVolume: overlayProps.volume ?? 1,
+            mixVolume,
           });
         }
       }

--- a/src/react/renderers/render.ts
+++ b/src/react/renderers/render.ts
@@ -34,6 +34,7 @@ import type {
   RenderResult,
   SpeechProps,
   VargElement,
+  VargNode,
 } from "../types";
 import { resolveVideoMixVolume } from "./audio";
 import { burnCaptions } from "./burn-captions";
@@ -298,6 +299,53 @@ export async function renderRoot(
   // ---------------------------------------------------------------------------
   let clipIndexCounter = 0;
 
+  // Non-visual element types that can live inside <Overlay> but don't need
+  // positioning — they should be promoted to the clip level so they're not
+  // silently dropped by the overlay renderer (which only handles image/video).
+  const OVERLAY_PASSTHROUGH_TYPES = new Set([
+    "speech",
+    "music",
+    "captions",
+    "title",
+    "subtitle",
+  ]);
+
+  /**
+   * Extract non-visual children (speech, music, captions, title, subtitle)
+   * from inside an <Overlay> element, returning them separately from the
+   * visual-only overlay. The overlay is returned with only its visual children
+   * (image, video) so the overlay renderer can position them correctly.
+   *
+   * Without this, placing <Speech> or <Captions> inside <Overlay> would
+   * silently produce a silent video — the overlay case in renderClipLayers
+   * only handles image/video children.
+   */
+  function extractOverlayPassthrough(overlayEl: VargElement<"overlay">): {
+    passthrough: VargElement[];
+    visualOverlay: VargElement<"overlay">;
+  } {
+    const passthrough: VargElement[] = [];
+    const visualChildren: VargNode[] = [];
+
+    for (const child of overlayEl.children) {
+      if (
+        child &&
+        typeof child === "object" &&
+        "type" in child &&
+        OVERLAY_PASSTHROUGH_TYPES.has((child as VargElement).type)
+      ) {
+        passthrough.push(child as VargElement);
+      } else {
+        visualChildren.push(child);
+      }
+    }
+
+    return {
+      passthrough,
+      visualOverlay: { ...overlayEl, children: visualChildren },
+    };
+  }
+
   function flattenClip(clipElement: VargElement<"clip">): void {
     const childClips: VargElement<"clip">[] = [];
     const nonClipChildren: VargElement[] = [];
@@ -313,7 +361,8 @@ export async function renderRoot(
     }
 
     if (childClips.length === 0) {
-      // Leaf clip — hoist captions, keep everything else
+      // Leaf clip — hoist captions, promote non-visual children from overlays,
+      // keep everything else
       const currentClipIndex = clipIndexCounter++;
       const kept: typeof clipElement.children = [];
       for (const el of nonClipChildren) {
@@ -322,6 +371,40 @@ export async function renderRoot(
             element: el as VargElement<"captions">,
             clipIndex: currentClipIndex,
           });
+        } else if (el.type === "overlay") {
+          // Extract non-visual children (speech, music, captions, title,
+          // subtitle) from inside the overlay and promote them to clip level.
+          // The overlay keeps only visual children (image, video) for
+          // positioning.
+          const { passthrough, visualOverlay } = extractOverlayPassthrough(
+            el as VargElement<"overlay">,
+          );
+
+          for (const pt of passthrough) {
+            if (pt.type === "captions") {
+              hoistedCaptions.push({
+                element: pt as VargElement<"captions">,
+                clipIndex: currentClipIndex,
+              });
+            } else {
+              // speech, music, title, subtitle — keep at clip level
+              kept.push(pt);
+            }
+          }
+
+          // Keep the overlay if it still has visual children
+          if (
+            visualOverlay.children.some(
+              (c) =>
+                c &&
+                typeof c === "object" &&
+                "type" in c &&
+                ((c as VargElement).type === "image" ||
+                  (c as VargElement).type === "video"),
+            )
+          ) {
+            kept.push(visualOverlay);
+          }
         } else {
           kept.push(el);
         }
@@ -340,10 +423,44 @@ export async function renderRoot(
 
     // Collect overlays from container level — these get injected into each
     // child clip so the overlay appears across all inner clips.
+    // Non-visual children inside overlays are extracted and handled at the
+    // container level (deferred audio / hoisted captions).
     const containerOverlays: VargElement[] = [];
     for (const el of nonClipChildren) {
       if (el.type === "overlay") {
-        containerOverlays.push(el);
+        const { passthrough, visualOverlay } = extractOverlayPassthrough(
+          el as VargElement<"overlay">,
+        );
+
+        // Handle promoted non-visual children at container level
+        for (const pt of passthrough) {
+          if (pt.type === "captions") {
+            hoistedCaptions.push({
+              element: pt as VargElement<"captions">,
+              clipIndex: firstLeafClipIndex,
+            });
+          } else if (pt.type === "speech" || pt.type === "music") {
+            deferredAudioElements.push({
+              element: pt as VargElement<"speech"> | VargElement<"music">,
+              clipIndex: firstLeafClipIndex,
+            });
+          }
+          // title/subtitle at container level: not yet supported
+        }
+
+        // Keep the overlay with only visual children
+        if (
+          visualOverlay.children.some(
+            (c) =>
+              c &&
+              typeof c === "object" &&
+              "type" in c &&
+              ((c as VargElement).type === "image" ||
+                (c as VargElement).type === "video"),
+          )
+        ) {
+          containerOverlays.push(visualOverlay);
+        }
       }
     }
 
@@ -368,7 +485,7 @@ export async function renderRoot(
           clipIndex: firstLeafClipIndex,
         });
       }
-      // overlay: already handled above (distributed to child clips)
+      // overlay: already handled above (non-visual extracted, visual distributed to child clips)
       // Image/Video at container level: not supported yet (would need
       // background layer spanning all child clips — a future feature)
     }

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -97,6 +97,7 @@ export interface VolumeProps {
 }
 
 export interface AudioProps extends VolumeProps {
+  /** Preserve a video's source audio in the final composition. @default true */
   keepAudio?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- preserve source audio by default for Video and video overlays
- probe inputs before mixing so videos without an audio stream remain renderable
- keep `keepAudio={false}` as the explicit mute option and `keepAudio={true}` as force-on
- prefer local ffprobe metadata in the Rendi backend, with the existing remote fallback
- update React documentation and add coverage for default, mute, force-on, overlay, and silent-video behavior

## Verification
- `bun test src/react/renderers/clip.test.ts src/react/resolve-context.test.ts` (25 passed)
- `bun run type-check`
- FFmpeg smoke test: silent input remains silent; input with audio preserves its audio stream