### PR TITLE
fix(react): audio:"native" → unified audio field instead of blind fal.generate_audio injection

### DIFF
--- a/src/ai-sdk/providers/varg.ts
+++ b/src/ai-sdk/providers/varg.ts
@@ -382,9 +382,23 @@ class VargVideoModel implements VideoModelV3 {
     }
 
     if (options.providerOptions?.varg) {
-      params.provider_options = checkVargProviderOptions(
-        options.providerOptions.varg as Record<string, unknown>,
-      );
+      const vargOpts = {
+        ...(options.providerOptions.varg as Record<string, unknown>),
+      };
+      // Unified varg-API fields riding the `varg` namespace are lifted to the
+      // request body top level — they are NOT provider_options. `audio` is the
+      // unified native-audio request (audio: "native" sugar): the API maps it
+      // per model via mapping_rules (rename audio → generate_audio) and models
+      // without the rule silently ignore it. Sending it inside
+      // provider_options.fal instead used to rely on the API silently
+      // stripping unknown keys, which now 422s.
+      if (vargOpts.audio !== undefined) {
+        params.audio = vargOpts.audio;
+        delete vargOpts.audio;
+      }
+      if (Object.keys(vargOpts).length > 0) {
+        params.provider_options = checkVargProviderOptions(vargOpts);
+      }
     }
 
     const result = await executeJob(this.baseUrl, this.apiKey, "video", params);

--- a/src/react/elements.ts
+++ b/src/react/elements.ts
@@ -132,10 +132,15 @@ function attachAudioGetter<
  * IGNORED_PROPS_BY_TYPE) — the expanded providerOptions carry the
  * semantic difference, so pre-existing configurations keep their keys.
  *
- * Provider mapping (verified against the varg API deep-merge behavior):
+ * Provider mapping:
  * - direct fal models → `providerOptions.fal.generate_audio`
- * - varg gateway models → `providerOptions.varg.fal.generate_audio`
- *   (the API forwards `provider_options.fal.*` to the fal payload)
+ * - varg gateway models → `providerOptions.varg.audio` (the UNIFIED field —
+ *   lifted to the request body top level by VargVideoModel and mapped per
+ *   model by the API's mapping_rules; models without native-audio support
+ *   silently ignore it). Do NOT inject provider_options.fal.generate_audio
+ *   here: the API rejects unknown provider_options keys with a 422, so the
+ *   old blind injection broke every fal video model whose schema lacks
+ *   generate_audio.
  */
 function expandNativeAudio(props: VideoProps): VideoProps {
   if (props.audio !== "native") return props;
@@ -155,12 +160,10 @@ function expandNativeAudio(props: VideoProps): VideoProps {
       string,
       unknown
     >;
-    const falOpts = { ...((vargOpts.fal as object) ?? {}) } as Record<
-      string,
-      unknown
-    >;
-    if (falOpts.generate_audio === undefined) falOpts.generate_audio = true;
-    vargOpts.fal = falOpts;
+    // Unified native-audio request — best-effort by design: the varg API
+    // maps it to the provider's own flag on models that support it and
+    // silently drops it elsewhere (mapping_rules, migration 0147).
+    if (vargOpts.audio === undefined) vargOpts.audio = true;
     providerOptions.varg = vargOpts as Record<string, unknown>;
   } else {
     // Default to the fal namespace (fal is the only provider with a

--- a/src/react/tests/audio-element.test.ts
+++ b/src/react/tests/audio-element.test.ts
@@ -200,7 +200,12 @@ describe("audio: native sugar", () => {
     expect(po.fal?.generate_audio).toBe(true);
   });
 
-  test("expands into varg.fal namespace for varg gateway models", () => {
+  test("expands to the unified varg.audio field for varg gateway models", () => {
+    // NOT provider_options.fal.generate_audio: the varg API rejects unknown
+    // provider_options keys with a 422 on models whose fal schema lacks the
+    // flag. The unified `audio` field is mapped per model by the API's
+    // mapping_rules (rename audio → generate_audio) and silently ignored by
+    // models without native-audio support.
     const vid = Video({
       prompt: "sunset",
       audio: "native",
@@ -213,9 +218,8 @@ describe("audio: native sugar", () => {
       string,
       Record<string, unknown>
     >;
-    expect((po.varg?.fal as Record<string, unknown>)?.generate_audio).toBe(
-      true,
-    );
+    expect(po.varg?.audio).toBe(true);
+    expect(po.varg?.fal).toBeUndefined();
     expect(vid.props.keepAudio).toBe(true);
   });
 


### PR DESCRIPTION
Companion to vargHQ/api#111 and api migration 0147.

The `audio: "native"` sugar injected `provider_options.fal.generate_audio` into every varg gateway model, relying on the API silently stripping the flag where unsupported. The API now 422s on unknown provider_options keys, breaking renders on ~26 fal video models without `generate_audio` in their schema.

- `expandNativeAudio`: for varg models sets `providerOptions.varg.audio = true` (unified field) instead of `varg.fal.generate_audio`
- `VargVideoModel.doGenerate`: lifts `audio` from the varg namespace to the request body top level; the API maps it per model (`rename audio → generate_audio`) and silently ignores it elsewhere — same best-effort contract as unified `resolution`
- direct fal/magnific providers untouched (bypass the varg API)

Tests: audio-element suite updated (27 pass); full `bun test` — only pre-existing pricing failures (also fail on main).

Note: render currently vendors vargai/@vargai-gateway — patched separately in the render repo until this ships in a release.